### PR TITLE
Change MapProjector.ToMap() to avoid unnecessary memory alloc.

### DIFF
--- a/src/LiveChartsCore/Geo/ControlCoordinatesProjector.cs
+++ b/src/LiveChartsCore/Geo/ControlCoordinatesProjector.cs
@@ -60,18 +60,18 @@ public class ControlCoordinatesProjector : MapProjector
     /// </value>
     public static float[] PreferredRatio => new[] { 2f, 1f };
 
-    /// <inheritdoc cref="MapProjector.ToMap(double[])"/>
+    /// <inheritdoc cref="MapProjector.ToMap(LvcPointD)"/>
     public override float[] ToMap(double[] point)
     {
         // simplified formula
-        return new[]
+        return new LvcPoint
         {
-                // x' =
-                (float)(_ox + (point[0] + 180) / 360d * _w),
+            // x' =
+            X = (float)(_ox + (point.X + 180) / 360d * _w),
 
-                // y' =
-                (float)(_oy + (90 - point[1]) / 180d * _h)
-            };
+            // y' =
+            Y = (float)(_oy + (90 - point.Y) / 180d * _h)
+        };
 
         // the following code explains the formula better:
 

--- a/src/LiveChartsCore/Geo/MapProjector.cs
+++ b/src/LiveChartsCore/Geo/MapProjector.cs
@@ -52,5 +52,5 @@ public abstract class MapProjector
     /// </summary>
     /// <param name="point">The point.</param>
     /// <returns></returns>
-    public abstract float[] ToMap(double[] point);
+    public abstract LvcPoint ToMap(LvcPointD point);
 }

--- a/src/LiveChartsCore/Geo/MercatorProjector.cs
+++ b/src/LiveChartsCore/Geo/MercatorProjector.cs
@@ -62,23 +62,23 @@ public class MercatorProjector : MapProjector
     /// </value>
     public static float[] PreferredRatio => new[] { 1f, 1f };
 
-    /// <inheritdoc cref="MapProjector.ToMap(double[])"/>
-    public override float[] ToMap(double[] point)
+    /// <inheritdoc cref="MapProjector.ToMap(LvcPointD)"/>
+    public override LvcPoint ToMap(LvcPointD point)
     {
-        var lat = point[1];
-        var lon = point[0];
+        var lat = point.Y;
+        var lon = point.X;
 
         var latRad = lat * Math.PI / 180d;
         var mercN = Math.Log(Math.Tan(Math.PI / 4d + latRad / 2d), Math.E);
         var y = _h / 2d - _h * mercN / (2 * Math.PI);
 
-        return new[]
+        return new LvcPoint
         {
             // x' =
-            (float)((lon + 180) * (_w / 360d) + _ox),
+            X = (float)((lon + 180) * (_w / 360d) + _ox),
 
             // y' =
-            (float) y + _oy
+            Y = (float) y + _oy
         };
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/MapFactory.cs
@@ -106,10 +106,10 @@ public class MapFactory : IMapFactory<SkiaSharpDrawingContext>
 
                     foreach (var point in landData.Coordinates)
                     {
-                        var p = projector.ToMap(new double[] { point.X, point.Y });
+                        var p = projector.ToMap(point);
 
-                        var x = p[0];
-                        var y = p[1];
+                        var x = p.X;
+                        var y = p.Y;
 
                         if (isFirst)
                         {


### PR DESCRIPTION
Use LvcPoint and LvcPointD to replace float array and double array.