### PR TITLE
Use Microsoft.WindowsAppSDK.WinUI metadata package in WinUI library

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.WinUI/LiveChartsCore.SkiaSharpView.WinUI.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="1.7.250606001" />
     <PackageReference Include="SkiaSharp.Views.WinUI" Version="$(LatestSkiaSharpVersion)" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="$(LatestSkiaSharpVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Swap the full `Microsoft.WindowsAppSDK` dependency in the WinUI class library for the targeted `Microsoft.WindowsAppSDK.WinUI` metadata package. This reduces consumer binary size by not pulling in unneeded Windows App SDK components that LiveCharts does not use.

Closes #2138

Generated with [Claude Code](https://claude.ai/code)