### PR TITLE
fix: trim orphan segments from path when null gaps are introduced

### DIFF
--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -478,6 +478,12 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             }
 
             if (!isSegmentEmpty) segmentI++;
+
+            // Remove any trailing segments left over from before a new gap was introduced.
+            // Without this, orphan segments from after the gap remain in the path for the
+            // sub-segment before the gap, causing the line to incorrectly cross the gap.
+            fillVector?.TrimTail();
+            strokeVector?.TrimTail();
         }
 
         var maxSegment = fillPathHelperContainer.Count > strokePathHelperContainer.Count

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -454,6 +454,9 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
             }
 
             if (!isSegmentEmpty) segmentI++;
+
+            fillVector?.TrimTail();
+            strokeVector?.TrimTail();
         }
 
         var maxSegment = fillPathHelperContainer.Count > strokePathHelperContainer.Count

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -401,6 +401,9 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
             }
 
             if (!isSegmentEmpty) segmentI++;
+
+            fillVector?.TrimTail();
+            strokeVector?.TrimTail();
         }
 
         var maxSegment = fillPathHelperContainer.Count > strokePathHelperContainer.Count

--- a/src/LiveChartsCore/Measure/VectorManager.cs
+++ b/src/LiveChartsCore/Measure/VectorManager.cs
@@ -102,4 +102,20 @@ internal class VectorManager(LinkedList<Segment> list)
             _currentNode = _currentNode.Next;
         }
     }
+
+    /// <summary>
+    /// Removes all segments that follow the last processed segment.
+    /// Call this after a sub-segment is fully processed to discard segments
+    /// that used to be in this path but now belong to a different sub-segment
+    /// (e.g. when a new null gap is introduced in the data).
+    /// </summary>
+    public void TrimTail()
+    {
+        while (_currentNode is not null)
+        {
+            var next = _currentNode.Next;
+            list.Remove(_currentNode);
+            _currentNode = next;
+        }
+    }
 }

--- a/tests/CoreTests/SeriesTests/LineSeriesTest.cs
+++ b/tests/CoreTests/SeriesTests/LineSeriesTest.cs
@@ -532,4 +532,49 @@ public class LineSeriesTest
         AssertIsStraightLine(points);
         Assert.IsTrue(segments == 5);
     }
+
+    [TestMethod]
+    public void NullGapsShouldNotLeaveOrphanSegments()
+    {
+        // Regression test for https://github.com/Live-Charts/LiveCharts2/issues/2132
+        // When a gap (null value) is introduced, the path for the segment BEFORE the gap
+        // must not retain orphan segments that now belong to the segment AFTER the gap.
+        var values = new List<double?> { 1, 2, 3, 4, 5 };
+
+        var series = new LineSeries<double?> { Values = values };
+        var chart = new SKCartesianChart
+        {
+            Width = 1000,
+            Height = 1000,
+            Series = [series]
+        };
+
+        _ = chart.GetImage();
+
+        // Initially 5 non-null values: expect 1 path segment with 5 bezier commands
+        var pathContainer = series._fillPathHelperDictionary.Values.First();
+        Assert.AreEqual(1, pathContainer.Count, "should have 1 path");
+        Assert.AreEqual(5, pathContainer[0].Commands.Count, "path should have 5 commands");
+
+        // Introduce a gap at index 2: [1, 2, null, 4, 5]
+        // Expect 2 path segments: path[0]=[p0,p1] (2 commands), path[1]=[p3,p4] (2 commands)
+        values[2] = null;
+        _ = chart.GetImage();
+
+        pathContainer = series._fillPathHelperDictionary.Values.First();
+        Assert.AreEqual(2, pathContainer.Count, "should have 2 paths after gap");
+        Assert.AreEqual(2, pathContainer[0].Commands.Count,
+            "path before the gap should only have 2 commands (not orphan segments from after the gap)");
+        Assert.AreEqual(2, pathContainer[1].Commands.Count,
+            "path after the gap should have 2 commands");
+
+        // Remove the gap: [1, 2, 3, 4, 5] → back to 1 segment with 5 commands
+        values[2] = 3;
+        _ = chart.GetImage();
+
+        pathContainer = series._fillPathHelperDictionary.Values.First();
+        Assert.AreEqual(1, pathContainer.Count, "should have 1 path after gap is removed");
+        Assert.AreEqual(5, pathContainer[0].Commands.Count,
+            "path should have all 5 commands after gap is removed");
+    }
 }


### PR DESCRIPTION
Fixes #2132.

## Root Cause

When `SplitByNullGaps` splits a series into sub-segments (e.g. `[1,2,null,4,5]` → `[[1,2],[4,5]]`), `CoreLineSeries.Invalidate` processes each sub-segment using a `VectorManager`. After the inner loop finishes for a sub-segment, `VectorManager._currentNode` pointed at the first segment of the NEXT sub-segment that hadn't been visited yet. Without cleanup, these "orphan trailing segments" remained in the first path's linked list, causing the line to incorrectly connect across the gap.

## Fix

Added `VectorManager.TrimTail()` that removes all nodes from the current position to the end of the list, called after each sub-segment is fully processed in `CoreLineSeries`, `CoreStepLineSeries`, and `CorePolarLineSeries`.

Generated with [Claude Code](https://claude.ai/code)