### PR TITLE
fix: chart not rendered behind ScrollViewer viewport (#1986)

### DIFF
--- a/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/View.axaml
+++ b/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/View.axaml
@@ -1,0 +1,49 @@
+<UserControl
+    x:Class="AvaloniaSample.VisualTest.ScrollViewerVirtualization.View"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+    xmlns:vm="using:AvaloniaSample.VisualTest.ScrollViewerVirtualization"
+    x:DataType="vm:ViewModel">
+
+    <!--
+        Visual test for https://github.com/Live-Charts/LiveCharts2/issues/1986
+        Charts in a TabControl + ScrollViewer where series data is assigned asynchronously.
+        Without the fix, charts remain blank even after data arrives because IsRendering()
+        blocks measurement while the canvas is not actively rendering frames.
+    -->
+
+    <TabControl x:Name="tabs">
+        <TabItem Header="page 1">
+            <ScrollViewer>
+                <StackPanel>
+                    <Border Height="600" Background="#1E88E5" CornerRadius="4">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            Foreground="White"
+                            TextAlignment="Center"
+                            Text="Scroll down — chart data loads after ~1 second.&#10;The chart must render automatically once data arrives." />
+                    </Border>
+                    <lvc:CartesianChart x:Name="chart1" Height="300" Series="{Binding Series1}" />
+                </StackPanel>
+            </ScrollViewer>
+        </TabItem>
+        <TabItem Header="page 2">
+            <ScrollViewer>
+                <StackPanel>
+                    <Border Height="600" Background="#43A047" CornerRadius="4">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            Foreground="White"
+                            TextAlignment="Center"
+                            Text="Scroll down — chart data loads after ~1 second.&#10;The chart must render automatically once data arrives." />
+                    </Border>
+                    <lvc:CartesianChart x:Name="chart2" Height="300" Series="{Binding Series2}" />
+                </StackPanel>
+            </ScrollViewer>
+        </TabItem>
+    </TabControl>
+
+</UserControl>

--- a/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/View.axaml.cs
+++ b/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/View.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using LiveChartsCore.SkiaSharpView.Avalonia;
+
+namespace AvaloniaSample.VisualTest.ScrollViewerVirtualization;
+
+public partial class View : UserControl
+{
+    private readonly ViewModel _vm;
+
+    public View()
+    {
+        _vm = new ViewModel();
+        DataContext = _vm;
+        InitializeComponent();
+        _ = _vm.LoadDataAsync(1000);
+    }
+
+    public CartesianChart Chart1 => this.Find<CartesianChart>("chart1")!;
+    public CartesianChart Chart2 => this.Find<CartesianChart>("chart2")!;
+    public void OpenTab1() => this.Find<TabControl>("tabs")!.SelectedIndex = 0;
+    public void OpenTab2() => this.Find<TabControl>("tabs")!.SelectedIndex = 1;
+    public void ScrollToChart() => ((ScrollViewer)this.Find<TabControl>("tabs")!.SelectedContent!).ScrollToEnd();
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/ViewModel.cs
+++ b/samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/ViewModel.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+
+namespace AvaloniaSample.VisualTest.ScrollViewerVirtualization;
+
+// Simulates a view model that loads series data asynchronously (e.g., from a server).
+// This is a visual test for https://github.com/Live-Charts/LiveCharts2/issues/1986
+public class ViewModel : INotifyPropertyChanged
+{
+    private IEnumerable<ISeries> _series1 = [];
+    private IEnumerable<ISeries> _series2 = [];
+
+    public IEnumerable<ISeries> Series1
+    {
+        get => _series1;
+        private set { _series1 = value; OnPropertyChanged(); }
+    }
+
+    public IEnumerable<ISeries> Series2
+    {
+        get => _series2;
+        private set { _series2 = value; OnPropertyChanged(); }
+    }
+
+    public async Task LoadDataAsync(int delayMs = 1000)
+    {
+        await Task.Delay(delayMs);
+
+        Series1 =
+        [
+            new LineSeries<double> { Values = [5, 10, 8, 4, 9, 6, 11] },
+            new ColumnSeries<double> { Values = [3, 7, 4, 8, 2, 6, 5] }
+        ];
+
+        Series2 =
+        [
+            new LineSeries<double> { Values = [8, 3, 6, 9, 4, 7, 5] },
+            new ColumnSeries<double> { Values = [6, 2, 8, 4, 9, 3, 7] }
+        ];
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -62,6 +62,7 @@ public abstract class Chart
     private LvcSize _previousSize = new();
     private int _nextSeriesId = 0;
     private long _lastMeasureTimeStamp = -1;
+    private volatile bool _renderRetryScheduled;
 
 #if NET5_0_OR_GREATER
     private readonly bool _isMobile;
@@ -323,6 +324,7 @@ public abstract class Chart
     public virtual void Unload()
     {
         _lastMeasureTimeStamp = -1;
+        _renderRetryScheduled = false;
         IsLoaded = false;
         _everMeasuredElements.Clear();
         _toDeleteElements.Clear();
@@ -809,7 +811,24 @@ public abstract class Chart
         var canMeasure = Canvas._lastFrameTimestamp != _lastMeasureTimeStamp;
 
         if (canMeasure)
+        {
             _lastMeasureTimeStamp = Canvas._lastFrameTimestamp;
+            _renderRetryScheduled = false;
+        }
+        else if (!_renderRetryScheduled)
+        {
+            // Fix for https://github.com/Live-Charts/LiveCharts2/issues/1986
+            // When the canvas is not rendering (e.g. chart is in a hidden tab or off-screen in a
+            // ScrollViewer), schedule a retry. If/when the canvas renders a new frame
+            // (_lastFrameTimestamp changes), the retry will find IsRendering() == true and proceed.
+            // This breaks the deadlock: no measure → no draw → no new frame → no measure.
+            _renderRetryScheduled = true;
+            _ = Task.Delay(100).ContinueWith(_ =>
+            {
+                _renderRetryScheduled = false;
+                if (IsLoaded) Update();
+            });
+        }
 
         return canMeasure;
     }

--- a/tests/SharedUITests/CartesianChartTests.cs
+++ b/tests/SharedUITests/CartesianChartTests.cs
@@ -100,6 +100,33 @@ public class CartesianChartTests
         await Task.Delay(1000);
         Assert.ChartIsLoaded(sut.Chart1);
     }
+
+    // based on:
+    // https://github.com/Live-Charts/LiveCharts2/issues/1986
+    // ensure charts render when series data is assigned asynchronously while the chart is
+    // off-screen (in a ScrollViewer below the viewport). This is the scenario @busitech
+    // described: measure is suppressed because the canvas is not rendering when data arrives.
+
+    [AppTestMethod]
+    public async Task ScrollViewerVirtualizationRendersAsyncData()
+    {
+        var sut = await App.NavigateTo<Samples.VisualTest.ScrollViewerVirtualization.View>();
+
+        // wait for the 1 second async data load to complete, then give the chart time to render.
+        await Task.Delay(2500);
+
+        // scroll to reveal chart1 and verify it rendered with the async data.
+        sut.ScrollToChart();
+        await Task.Delay(1000);
+        Assert.ChartIsLoaded(sut.Chart1);
+
+        // switch to tab 2, scroll to chart2, and verify it also loaded.
+        sut.OpenTab2();
+        await Task.Delay(500);
+        sut.ScrollToChart();
+        await Task.Delay(1000);
+        Assert.ChartIsLoaded(sut.Chart2);
+    }
 #endif
 
 #if (WPF_UI_TESTING && TEST_HA_VIEWS) || MAUI_UI_TESTING || WINUI_UI_TESTING || (UNO_UI_TESTING && HAS_OS_LVC)


### PR DESCRIPTION
Fixes #1986

## Root cause

`IsRendering()` in `Chart.cs` compares `_lastFrameTimestamp` (set each time the canvas draws a frame) with `_lastMeasureTimeStamp` (set after measurement). When a chart is off-screen (hidden tab, scrolled out of viewport), the canvas stops drawing frames and the timestamps become equal. `IsRendering()` returns `false`, blocking all further measurements. This creates a deadlock: no measure → no draw → no new frame → timestamps stay equal → no measure. Avalonia 12’s rendering pipeline timing makes this particularly visible.

## Fix

Added a `_renderRetryScheduled` flag and a 100ms retry `Update()` when `IsRendering()` returns `false`. When the chart becomes visible again (tab switch, scroll), Avalonia renders the canvas and updates `_lastFrameTimestamp`. The pending retry then finds `IsRendering() == true` and measurement proceeds.

## Changes

- `src/LiveChartsCore/Chart.cs` — retry mechanism in `IsRendering()`
- `samples/AvaloniaSample/VisualTest/ScrollViewerVirtualization/` — new sample replicating async data + ScrollViewer scenario
- `tests/SharedUITests/CartesianChartTests.cs` — new `ScrollViewerVirtualizationRendersAsyncData` UI test

Generated with [Claude Code](https://claude.ai/code)