### PR TITLE
ci: merge PR comment sections, group tests by platform

### DIFF
--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -1,0 +1,248 @@
+// Shared helper for the PR Comment workflow.
+//
+// The PR Comment workflow runs two jobs (one per upstream workflow). Both jobs
+// share a single PR comment; each job edits only its own section so partial
+// reruns and out-of-order completions never clobber the other section.
+//
+// Section content lives between marker lines (e.g. `<!-- section:livecharts:start -->`
+// ... `<!-- section:livecharts:end -->`). When a section is missing, upsertSection
+// appends it; when present, it replaces in place.
+
+const TAG = (prNumber) => `<!-- livecharts-bot:pr-${prNumber} -->`;
+const LEGACY_PERF_TAG = (prNumber) => `<!-- livecharts-bot:perf-pr-${prNumber} -->`;
+
+const SECTIONS = {
+  livecharts: {
+    start: '<!-- section:livecharts:start -->',
+    end:   '<!-- section:livecharts:end -->',
+  },
+  benchmarks: {
+    start: '<!-- section:benchmarks:start -->',
+    end:   '<!-- section:benchmarks:end -->',
+  },
+};
+
+// Platform groupings rendered inside the Tests <details>. Each entry must
+// match exactly one matrix variant from the LiveCharts workflow:
+//   - testId / jobName / tf -> the artifact name `test-results-{testId}-{jobName}-{tf}`
+//   - matrix -> values that must prefix-match the parenthesised matrix part of
+//     the corresponding job's display name (declaration order, id-first).
+const PLATFORMS = [
+  { name: 'Avalonia', entries: [
+    { label: 'desktop (windows)', testId: 'avalonia-desktop', jobName: 'test-windows', tf: '',                                 matrix: ['avalonia-desktop'] },
+    { label: 'desktop (linux)',   testId: 'avalonia-desktop', jobName: 'test-linux',   tf: '',                                 matrix: ['avalonia-desktop'] },
+    { label: 'desktop (mac)',     testId: 'avalonia-desktop', jobName: 'test-mac',     tf: '',                                 matrix: ['avalonia-desktop'] },
+    { label: 'android',           testId: 'avalonia-android', jobName: 'test-android', tf: '',                                 matrix: ['avalonia-android'] },
+    { label: 'ios',               testId: 'avalonia-ios',     jobName: 'test-ios',     tf: '',                                 matrix: ['avalonia-ios'] },
+    { label: 'browser',           testId: 'avalonia-browser', jobName: 'test-browser', tf: '',                                 matrix: ['avalonia-browser'] },
+  ]},
+  { name: 'Uno', entries: [
+    { label: 'desktop (windows)',         testId: 'uno', jobName: 'test-windows', tf: 'net10.0-desktop',                matrix: ['uno', 'net10.0-desktop'] },
+    { label: 'win10.0.19041 (windows)',   testId: 'uno', jobName: 'test-windows', tf: 'net10.0-windows10.0.19041.0',     matrix: ['uno', 'net10.0-windows10.0.19041.0'] },
+    { label: 'desktop (linux)',           testId: 'uno', jobName: 'test-linux',   tf: 'net10.0-desktop',                matrix: ['uno', 'net10.0-desktop'] },
+    { label: 'desktop (mac)',             testId: 'uno', jobName: 'test-mac',     tf: 'net10.0-desktop',                matrix: ['uno', 'net10.0-desktop'] },
+  ]},
+  { name: 'MAUI', entries: [
+    { label: 'windows',     testId: 'maui',     jobName: 'test-windows', tf: 'net10.0-windows10.0.19041.0', matrix: ['maui', 'net10.0-windows10.0.19041.0'] },
+    { label: 'maccatalyst', testId: 'maui',     jobName: 'test-mac',     tf: 'net10.0-maccatalyst',         matrix: ['maui', 'net10.0-maccatalyst'] },
+    { label: 'android',     testId: 'maui',     jobName: 'test-android', tf: 'net10.0-android',             matrix: ['maui', 'net10.0-android'] },
+    { label: 'ios',         testId: 'maui-ios', jobName: 'test-ios',     tf: 'net10.0-ios',                 matrix: ['maui-ios', 'net10.0-ios'] },
+  ]},
+  { name: 'WinUI', entries: [
+    { label: 'windows', testId: 'winui', jobName: 'test-windows', tf: '', matrix: ['winui'] },
+  ]},
+  { name: 'WinForms', entries: [
+    { label: 'net10 (windows)',         testId: 'winforms-net10',       jobName: 'test-windows', tf: '', matrix: ['winforms-net10'] },
+    { label: 'net10-19041 (windows)',   testId: 'winforms-net10w19041', jobName: 'test-windows', tf: '', matrix: ['winforms-net10w19041'] },
+    { label: 'net462 (windows)',        testId: 'winforms-net462',      jobName: 'test-windows', tf: '', matrix: ['winforms-net462'] },
+  ]},
+  { name: 'WPF', entries: [
+    { label: 'net10 (windows)',         testId: 'wpf-net10',         jobName: 'test-windows', tf: '', matrix: ['wpf-net10'] },
+    { label: 'net10-19041 (windows)',   testId: 'wpf-net10w19041',   jobName: 'test-windows', tf: '', matrix: ['wpf-net10w19041'] },
+    { label: 'net462 (windows)',        testId: 'wpf-net462',        jobName: 'test-windows', tf: '', matrix: ['wpf-net462'] },
+  ]},
+  { name: 'Eto', entries: [
+    { label: 'windows', testId: 'eto', jobName: 'test-windows', tf: '', matrix: ['eto'] },
+    { label: 'mac',     testId: 'eto', jobName: 'test-mac',     tf: '', matrix: ['eto'] },
+  ]},
+  { name: 'Core', entries: [
+    { label: 'net8.0', testId: 'core-net8.0', jobName: 'test-core', tf: 'net8.0', matrix: ['net8.0'] },
+    { label: 'net462', testId: 'core-net462', jobName: 'test-core', tf: 'net462', matrix: ['net462'] },
+  ]},
+  { name: 'Snapshot', entries: [
+    { label: 'snapshot', testId: 'snapshot', jobName: 'test-snapshot', tf: '', matrix: [] },
+  ]},
+];
+
+const STATUS_EMOJI = {
+  success: '✅', failure: '❌', cancelled: '⚠️',
+  skipped: '⏭️', timed_out: '❌', missing: '❔', unknown: '❔',
+};
+
+function emoji(s) { return STATUS_EMOJI[s] || '❔'; }
+
+function aggregate(statuses) {
+  if (statuses.length === 0) return 'missing';
+  if (statuses.some(s => s === 'failure' || s === 'timed_out')) return 'failure';
+  if (statuses.some(s => s === 'cancelled')) return 'cancelled';
+  if (statuses.every(s => s === 'success')) return 'success';
+  if (statuses.some(s => s === 'skipped')) return 'skipped';
+  return 'unknown';
+}
+
+function statusOf(job) {
+  if (!job) return 'missing';
+  if (job.status !== 'completed') return 'unknown';
+  return job.conclusion || 'unknown';
+}
+
+// Find the matrix variant of `baseJob` whose parenthesised values prefix-match
+// `requiredValues`. Required values must be in YAML declaration order (id, tf).
+// Workloads (when present in the matrix) appears last and is intentionally not
+// part of the required values, but the prefix match still disambiguates because
+// `id` is always first.
+function findMatrixJob(jobs, baseJob, requiredValues) {
+  if (requiredValues.length === 0) {
+    return jobs.find(j => j.name === baseJob);
+  }
+  const prefix = baseJob + ' (';
+  return jobs.find(j => {
+    if (!j.name.startsWith(prefix) || !j.name.endsWith(')')) return false;
+    const inner = j.name.slice(prefix.length, -1);
+    const parts = inner.split(', ');
+    if (parts.length < requiredValues.length) return false;
+    return requiredValues.every((v, i) => parts[i] === v);
+  });
+}
+
+function aggregateBaseJob(jobs, baseJob) {
+  const matching = jobs.filter(j => j.name === baseJob || j.name.startsWith(baseJob + ' ('));
+  return aggregate(matching.map(statusOf));
+}
+
+function artifactUrl(owner, repo, runId, artifact) {
+  return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
+}
+
+function buildTestsBlock({ jobs, artifacts, runId, owner, repo }) {
+  const groups = [];
+  const overall = [];
+  for (const platform of PLATFORMS) {
+    const lines = [];
+    const groupStatuses = [];
+    for (const e of platform.entries) {
+      const job = findMatrixJob(jobs, e.jobName, e.matrix);
+      const status = statusOf(job);
+      if (status === 'missing') continue; // matrix entry was not included in this run
+      groupStatuses.push(status);
+      const artifactName = `test-results-${e.testId}-${e.jobName}-${e.tf}`;
+      const artifact = artifacts.find(a => a.name === artifactName && !a.expired);
+      const link = artifact ? `[trx](${artifactUrl(owner, repo, runId, artifact)})` : '_no trx_';
+      lines.push(`  - ${e.label} ${emoji(status)} — ${link}`);
+    }
+    if (groupStatuses.length === 0) continue;
+    const groupStatus = aggregate(groupStatuses);
+    overall.push(groupStatus);
+    groups.push({ name: platform.name, status: groupStatus, lines });
+  }
+
+  const summary = aggregate(overall);
+  const inner = groups
+    .map(g => `- **${g.name}** ${emoji(g.status)}\n${g.lines.join('\n')}`)
+    .join('\n');
+
+  return [
+    `#### Tests ${emoji(summary)}`,
+    ``,
+    `<details><summary>Show details</summary>`,
+    ``,
+    inner,
+    ``,
+    `</details>`,
+  ].join('\n');
+}
+
+function upsertSection(body, section, content) {
+  const { start, end } = SECTIONS[section];
+  const startIdx = body.indexOf(start);
+  const endIdx = body.indexOf(end);
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    return body.slice(0, startIdx + start.length) + '\n' + content + '\n' + body.slice(endIdx);
+  }
+  return body.replace(/\s*$/, '') + '\n\n' + start + '\n' + content + '\n' + end;
+}
+
+function buildSkeleton(prNumber, section, content) {
+  return [
+    TAG(prNumber),
+    `#### Thanks for your contribution!`,
+    ``,
+    SECTIONS[section].start,
+    content,
+    SECTIONS[section].end,
+  ].join('\n');
+}
+
+async function resolvePr({ github, context, headOwner, headBranch }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const wrPrs = context.payload.workflow_run.pull_requests || [];
+  let prNumber = wrPrs.find(p => p.number)?.number;
+  let baseRef = null;
+  if (!prNumber) {
+    const { data: prs } = await github.rest.pulls.list({
+      owner, repo, state: 'open',
+      head: `${headOwner}:${headBranch}`,
+    });
+    prNumber = prs[0]?.number;
+    baseRef = prs[0]?.base?.ref;
+  }
+  return { prNumber, baseRef };
+}
+
+async function upsertComment({ github, context, prNumber, section, content }) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const tag = TAG(prNumber);
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number: prNumber, per_page: 100,
+  });
+  const existing = comments.find(c => c.body && c.body.includes(tag));
+  if (existing) {
+    const body = upsertSection(existing.body, section, content);
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+  } else {
+    const body = buildSkeleton(prNumber, section, content);
+    await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+  }
+
+  // Best-effort cleanup of the previous standalone benchmark comment, now
+  // folded into the merged comment.
+  const legacy = LEGACY_PERF_TAG(prNumber);
+  for (const c of comments) {
+    if (c.body && c.body.includes(legacy)) {
+      try {
+        await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
+      } catch (e) {
+        // ignore — best-effort
+      }
+    }
+  }
+}
+
+module.exports = {
+  TAG,
+  SECTIONS,
+  PLATFORMS,
+  emoji,
+  aggregate,
+  aggregateBaseJob,
+  statusOf,
+  findMatrixJob,
+  artifactUrl,
+  buildTestsBlock,
+  upsertSection,
+  buildSkeleton,
+  resolvePr,
+  upsertComment,
+};

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,8 +1,12 @@
 name: PR Comment
 
-# Posts consolidated comments to the PR after upstream workflows finish.
-# This runs in the base repo's context (not the fork's), so the GITHUB_TOKEN has the
-# write permissions that the triggering workflows do not get on fork PRs.
+# Posts a single, consolidated comment to the PR after upstream workflows finish.
+# This runs in the base repo's context (not the fork's), so the GITHUB_TOKEN has
+# the write permissions that the triggering workflows do not get on fork PRs.
+#
+# Each upstream workflow updates its own section of one shared comment via
+# .github/scripts/pr-comment.js — partial reruns and out-of-order completions
+# never clobber the other section.
 
 on:
   workflow_run:
@@ -22,6 +26,9 @@ jobs:
       github.event.workflow_run.name == 'LiveCharts'
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
       - name: Download coverage summary
         id: cov
         continue-on-error: true
@@ -42,73 +49,46 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const lib = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = Number(process.env.RUN_ID);
             const runNumber = process.env.RUN_NUMBER;
-            const headOwner = process.env.HEAD_OWNER;
-            const headBranch = process.env.HEAD_BRANCH;
 
-            // Resolve the PR by head ref. Reliable for both same-repo and fork PRs;
-            // listPullRequestsAssociatedWithCommit is not (it only indexes commits
-            // reachable from the default branch / merge commits).
-            const wrPrs = context.payload.workflow_run.pull_requests || [];
-            let prNumber = wrPrs.find(p => p.number)?.number;
+            const { prNumber } = await lib.resolvePr({
+              github, context,
+              headOwner: process.env.HEAD_OWNER,
+              headBranch: process.env.HEAD_BRANCH,
+            });
             if (!prNumber) {
-              const { data: prs } = await github.rest.pulls.list({
-                owner, repo, state: 'open',
-                head: `${headOwner}:${headBranch}`,
-              });
-              prNumber = prs[0]?.number;
-            }
-            if (!prNumber) {
-              core.warning(`No open PR found for ${headOwner}:${headBranch}; nothing to comment on.`);
+              core.warning(`No open PR found for ${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}; nothing to comment on.`);
               return;
             }
 
-            // Pull all jobs of the upstream run and aggregate by base name. Matrix
-            // jobs render as "name (matrix, values)" so we match the literal name
-            // OR the name followed by a space.
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner, repo, run_id: runId, per_page: 100,
             });
-            const matching = (name) =>
-              jobs.filter(j => j.name === name || j.name.startsWith(name + ' '));
-            const aggregate = (list) => {
-              if (list.length === 0) return 'missing';
-              if (list.some(j => j.conclusion === 'failure' || j.conclusion === 'timed_out')) return 'failure';
-              if (list.some(j => j.conclusion === 'cancelled')) return 'cancelled';
-              if (list.every(j => j.conclusion === 'success')) return 'success';
-              if (list.some(j => j.conclusion === 'skipped')) return 'skipped';
-              return 'unknown';
-            };
-            const emoji = (s) => ({
-              success: '✅', failure: '❌', cancelled: '⚠️',
-              skipped: '⏭️', missing: '❔', unknown: '❔',
-            }[s] || '❔');
-
-            const sec = {
-              pack: aggregate(matching('pack')),
-              testCore: aggregate(matching('test-core')),
-              testSnapshot: aggregate(matching('test-snapshot')),
-              testWindows: aggregate(matching('test-windows')),
-              testLinux: aggregate(matching('test-linux')),
-              testMac: aggregate(matching('test-mac')),
-              testBrowser: aggregate(matching('test-browser')),
-              testAndroid: aggregate(matching('test-android')),
-              testIos: aggregate(matching('test-ios')),
-            };
-
-            // Resolve the merged nuget-packages artifact URL, if present.
-            const arts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
               owner, repo, run_id: runId, per_page: 100,
             });
-            const nuget = arts.find(a => a.name === 'nuget-packages' && !a.expired);
-            const nugetUrl = nuget
-              ? `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${nuget.id}`
-              : null;
 
-            // Coverage summary, written by livecharts.yml when both core & snapshot pass.
+            // ---- Packing
+            const packStatus = lib.aggregateBaseJob(jobs, 'pack');
+            const nuget = artifacts.find(a => a.name === 'nuget-packages' && !a.expired);
+            const nugetUrl = nuget ? lib.artifactUrl(owner, repo, runId, nuget) : null;
+            const packBlock = nugetUrl
+              ? `#### Packing ${lib.emoji(packStatus)}\n\n` +
+                `Download the NuGet packages for this build [here (dev-${runNumber})](${nugetUrl}). ` +
+                `Available for 30 days — you can either ` +
+                `[use them directly](https://stackoverflow.com/questions/43400069/add-a-package-with-a-local-package-file-in-dotnet) ` +
+                `or wait for this PR to be merged to have them published to NuGet.org.`
+              : `#### Packing ${lib.emoji(packStatus)}\n\nNuGet packages were not produced.`;
+
+            // ---- Tests (collapsed details, grouped by platform)
+            const testsBlock = lib.buildTestsBlock({ jobs, artifacts, runId, owner, repo });
+
+            // ---- Coverage (only when both core & snapshot passed and the artifact landed)
             let coverageBlock = '';
             try {
               const data = JSON.parse(fs.readFileSync('coverage-summary/coverage-summary.json', 'utf8'));
@@ -122,47 +102,16 @@ jobs:
               // No coverage data — likely tests failed or didn't run.
             }
 
-            const sec1Ok = sec.testCore === 'success' && sec.testSnapshot === 'success';
-            const uiKeys = ['testWindows', 'testLinux', 'testMac', 'testBrowser', 'testAndroid', 'testIos'];
-            const sec2Ok = uiKeys.every(k => sec[k] === 'success');
-
-            const packBlock = nugetUrl
-              ? `#### Packing ${emoji(sec.pack)}\n\n` +
-                `Download the NuGet packages for this build [here (dev-${runNumber})](${nugetUrl}). ` +
-                `Available for 30 days — you can either ` +
-                `[use them directly](https://stackoverflow.com/questions/43400069/add-a-package-with-a-local-package-file-in-dotnet) ` +
-                `or wait for this PR to be merged to have them published to NuGet.org.`
-              : `#### Packing ${emoji(sec.pack)}\n\nNuGet packages were not produced.`;
-
-            const tag = `<!-- livecharts-bot:pr-${prNumber} -->`;
-            const body = [
-              tag,
-              `#### Thanks for your contribution!`,
-              ``,
+            const content = [
               `Build summary for [run #${runNumber}](https://github.com/${owner}/${repo}/actions/runs/${runId}).`,
               ``,
               packBlock,
               ``,
-              `#### Core & Snapshot Tests ${emoji(sec1Ok ? 'success' : 'failure')}`,
-              ``,
-              `Core ${emoji(sec.testCore)} | Snapshot ${emoji(sec.testSnapshot)}`,
-              ``,
-              `#### UI Tests ${emoji(sec2Ok ? 'success' : 'failure')}`,
-              ``,
-              `Windows ${emoji(sec.testWindows)} | Linux ${emoji(sec.testLinux)} | Mac ${emoji(sec.testMac)} | Browser ${emoji(sec.testBrowser)} | Android ${emoji(sec.testAndroid)} | iOS ${emoji(sec.testIos)}`,
+              testsBlock,
               coverageBlock,
             ].join('\n');
 
-            // Find existing comment by marker; create or update.
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number: prNumber, per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(tag));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
-            }
+            await lib.upsertComment({ github, context, prNumber, section: 'livecharts', content });
 
   benchmarks:
     if: >-
@@ -170,6 +119,9 @@ jobs:
       github.event.workflow_run.name == 'Benchmarks'
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.1
+
       - name: Download benchmark delta
         id: delta
         continue-on-error: true
@@ -181,7 +133,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and post comment
-        if: steps.delta.outcome == 'success'
         uses: actions/github-script@v8
         env:
           RUN_ID: ${{ github.event.workflow_run.id }}
@@ -189,64 +140,70 @@ jobs:
           HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+          WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
           script: |
             const fs = require('fs');
+            const lib = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = Number(process.env.RUN_ID);
             const headSha = process.env.HEAD_SHA;
-            const headOwner = process.env.HEAD_OWNER;
-            const headBranch = process.env.HEAD_BRANCH;
+            const wfConclusion = process.env.WF_CONCLUSION;
 
-            const wrPrs = context.payload.workflow_run.pull_requests || [];
-            let prNumber = wrPrs.find(p => p.number)?.number;
-            let baseRef = process.env.BASE_REF;
+            const { prNumber, baseRef: resolvedBase } = await lib.resolvePr({
+              github, context,
+              headOwner: process.env.HEAD_OWNER,
+              headBranch: process.env.HEAD_BRANCH,
+            });
             if (!prNumber) {
-              const { data: prs } = await github.rest.pulls.list({
-                owner, repo, state: 'open',
-                head: `${headOwner}:${headBranch}`,
-              });
-              prNumber = prs[0]?.number;
-              baseRef = baseRef || prs[0]?.base?.ref;
-            }
-            if (!prNumber) {
-              core.warning(`No open PR found for ${headOwner}:${headBranch}; nothing to comment on.`);
+              core.warning(`No open PR found for ${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}; nothing to comment on.`);
               return;
             }
+            const baseRef = process.env.BASE_REF || resolvedBase || 'master';
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
 
-            const delta = fs.readFileSync('benchmark-delta/delta.md', 'utf8');
-            // Each table row in delta.md carries a 🔴 / 🟢 prefix in the Δ column when
-            // the benchmark moved past the ±10% threshold. Count them for the summary.
-            const regressions = (delta.match(/🔴/g) || []).length;
-            const improvements = (delta.match(/🟢/g) || []).length;
-            const summary = regressions > 0
-              ? `❌ ${regressions} regression${regressions === 1 ? '' : 's'}, ${improvements} improvement${improvements === 1 ? '' : 's'}`
-              : improvements > 0
-                ? `✅ ${improvements} improvement${improvements === 1 ? '' : 's'}, no regressions`
-                : `➖ No significant changes`;
-
-            const tag = `<!-- livecharts-bot:perf-pr-${prNumber} -->`;
-            const body = [
-              tag,
-              `#### Benchmark delta — ${summary}`,
-              ``,
-              `<details><summary>Show details</summary>`,
-              ``,
-              `Base: **${baseRef || 'master'}** — Head: **${headSha}**`,
-              `Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.`,
-              ``,
-              delta,
-              ``,
-              `</details>`,
-            ].join('\n');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number: prNumber, per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(tag));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            let content;
+            let delta = null;
+            try {
+              delta = fs.readFileSync('benchmark-delta/delta.md', 'utf8');
+            } catch (e) {
+              // No delta artifact — either nothing significant changed or the run failed.
             }
+
+            if (delta) {
+              const regressions = (delta.match(/🔴/g) || []).length;
+              const improvements = (delta.match(/🟢/g) || []).length;
+              const summary = regressions > 0
+                ? `❌ ${regressions} regression${regressions === 1 ? '' : 's'}, ${improvements} improvement${improvements === 1 ? '' : 's'}`
+                : improvements > 0
+                  ? `✅ ${improvements} improvement${improvements === 1 ? '' : 's'}, no regressions`
+                  : `➖ No significant changes`;
+              content = [
+                `#### Benchmark delta — ${summary}`,
+                ``,
+                `<details><summary>Show details</summary>`,
+                ``,
+                `Base: **${baseRef}** — Head: **${headSha}** ([run](${runUrl}))`,
+                `Thresholds: 🔴 > +10% slower, 🟢 > -10% faster. Numbers on GitHub-hosted runners are noisy — treat double-digit deltas on non-trivial benchmarks as signal, single-digit as noise.`,
+                ``,
+                delta,
+                ``,
+                `</details>`,
+              ].join('\n');
+            } else if (wfConclusion === 'success') {
+              content = [
+                `#### Benchmark delta — ➖ No significant changes`,
+                ``,
+                `Base: **${baseRef}** — Head: **${headSha}** ([run](${runUrl}))`,
+              ].join('\n');
+            } else {
+              content = [
+                `#### Benchmark delta ${lib.emoji(wfConclusion === 'failure' ? 'failure' : 'unknown')}`,
+                ``,
+                `Workflow ${wfConclusion || 'did not produce a delta'} — see the [run](${runUrl}) for details.`,
+              ].join('\n');
+            }
+
+            await lib.upsertComment({ github, context, prNumber, section: 'benchmarks', content });


### PR DESCRIPTION
## Summary

- Merge the LiveCharts and Benchmarks PR comments into a single comment. Both upstream workflows now write distinct sections of the same comment via a shared helper at `.github/scripts/pr-comment.js`, with marker-delimited sections so partial reruns / out-of-order completions don't clobber each other. Legacy `livecharts-bot:perf-pr-*` comments are cleaned up on first run.
- Replace the separate **Core & Snapshot Tests** + **UI Tests** sections with a single `#### Tests ✅` summary backed by a `<details>` tag. Inside the details, runs are grouped by platform (Avalonia, Uno, MAUI, WinUI, WinForms, WPF, Eto, Core, Snapshot) with a TRX artifact link per matrix variant.

Matrix variants are correlated by parsing the parenthesised job names from `listJobsForWorkflowRun` (e.g. `test-windows (uno, net10.0-desktop, maui)`). Matching uses the YAML declaration order with `id` first, so it cleanly disambiguates `(uno, …, maui)` from `(maui, …, maui)`.

## Test plan

- [ ] Open this PR and confirm the LiveCharts run posts a single comment with the new layout
- [ ] Confirm the Benchmarks run appends/updates the benchmarks section in the same comment (no duplicate top-level comment)
- [ ] Click into a few TRX links in the Tests `<details>` and confirm they resolve to the right artifact
- [ ] Push a follow-up commit and confirm both sections update in place (rather than appended again)
- [ ] On a PR that does *not* trigger Benchmarks (path filter miss), confirm the comment renders correctly with only the LiveCharts section

🤖 Generated with [Claude Code](https://claude.com/claude-code)