### PR TITLE
fix(avalonia): only mark wheel event as handled when zoom is enabled (#1864)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenCartesianChart.avalonia.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenCartesianChart.avalonia.cs
@@ -53,6 +53,11 @@ public partial class SourceGenCartesianChart : SourceGenChart, ICartesianChartVi
 
     private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
     {
+        // Only mark the event as handled when zoom is enabled; otherwise let it bubble
+        // so parent ScrollViewers still scroll and external subscribers still fire
+        // (Avalonia routed events skip subsequent handlers once Handled = true).
+        // See https://github.com/Live-Charts/LiveCharts2/issues/1864.
+        if (ZoomMode == ZoomAndPanMode.None) return;
         e.Handled = true;
 
         var c = (CartesianChartEngine)CoreChart;


### PR DESCRIPTION
## Summary
- Closes #1864.
- In Avalonia's `SourceGenCartesianChart`, the wheel handler unconditionally set `e.Handled = true`. Because Avalonia routed events skip later handlers once `Handled` is true, this swallowed wheel events intended for parent `ScrollViewer`s and prevented external `PointerWheelChanged` subscribers from firing — even when `ZoomMode = None` disabled the chart's own zoom.
- Now the handler returns early when `ZoomMode == ZoomAndPanMode.None`, leaving the event unhandled so it bubbles normally. With zoom enabled, behavior is unchanged.
- This brings the Avalonia view in line with the WPF view, which never sets `Handled` on its wheel handler.
- Map chart wheel handling will be addressed in a follow-up PR.

## Test plan
- [ ] Run `dotnet build src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/LiveChartsCore.SkiaSharpView.Avalonia.csproj` (verified locally, 0 errors).
- [ ] Manually verify in an Avalonia sample: place a `CartesianChart` inside a `ScrollViewer`, set `ZoomMode="None"`, and confirm wheel events scroll the parent.
- [ ] With `ZoomMode="Both"` (or X/Y), confirm wheel still zooms the chart and does not also scroll the parent.
- [ ] With an external `PointerWheelChanged` handler attached to the chart, confirm it now fires when `ZoomMode="None"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)