### PR TITLE
ci: post PR comments as LiveCharts bot

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -26,6 +26,13 @@ jobs:
       github.event.workflow_run.name == 'LiveCharts'
     runs-on: ubuntu-24.04
     steps:
+      - name: Mint LiveCharts bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
@@ -37,7 +44,7 @@ jobs:
           name: coverage-summary
           path: coverage-summary
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Build and post comment
         uses: actions/github-script@v8
@@ -47,6 +54,7 @@ jobs:
           HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const lib = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);
@@ -119,6 +127,13 @@ jobs:
       github.event.workflow_run.name == 'Benchmarks'
     runs-on: ubuntu-24.04
     steps:
+      - name: Mint LiveCharts bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
@@ -130,7 +145,7 @@ jobs:
           name: benchmark-delta
           path: benchmark-delta
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Build and post comment
         uses: actions/github-script@v8
@@ -142,6 +157,7 @@ jobs:
           BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
           WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const lib = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-comment.js`);


### PR DESCRIPTION
## Summary
- Mint an installation token from the LiveCharts GitHub App at the start of each `pr-comment.yml` job and use it for the cross-run artifact downloads and the `github-script` step that upserts the comment.
- PR build summaries and benchmark deltas now post as `livecharts[bot]` instead of `github-actions[bot]`.
- Uses the existing `APP_ID` and `APP_PRIVATE_KEY` repo secrets — no new secrets required.

## Notes
- The App needs Repository permissions: **Contents: Read**, **Actions: Read**, **Pull requests: Read & write**, plus the auto-granted **Metadata: Read**. Confirm this on the App settings page before merging — anything missing and the comment step will 403.
- `auto-rerun.yml` is unchanged; it still uses the default `GITHUB_TOKEN` since reruns are not user-facing identity.
- This workflow runs in the base repo's context (not the fork's), so the App token is safe from fork PRs.

## Test plan
- [ ] Merge, then open a throwaway PR (or push to an existing one) and confirm the consolidated comment is authored by `livecharts[bot]`.
- [ ] Confirm both sections (LiveCharts build summary + Benchmarks delta) update in place across reruns.
- [ ] Confirm a fork PR still gets a comment (the workflow runs in base context, so it should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)