### PR TITLE
ci: collapse coverage in PR comment with per-class diff

### DIFF
--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -162,6 +162,96 @@ function buildTestsBlock({ jobs, artifacts, runId, owner, repo }) {
   ].join('\n');
 }
 
+// Builds the Code Coverage block: an H4 header that announces direction (up /
+// down / unchanged) and the delta, then a collapsed <details> with the
+// before/after table, a link to the full report, and a per-class diff table
+// (when a baseline Summary.json was available on the badges branch).
+function buildCoverageBlock({ summary, oldClasses, newClasses, reportUrl }) {
+  let phrase;
+  if (summary.delta === 'N/A') {
+    phrase = `no baseline (current: ${summary.new})`;
+  } else if (summary.delta === '0%') {
+    phrase = `unchanged at ${summary.new}`;
+  } else if (summary.delta.startsWith('+')) {
+    phrase = `increased ${summary.delta} (${summary.old} → ${summary.new})`;
+  } else {
+    phrase = `decreased ${summary.delta} (${summary.old} → ${summary.new})`;
+  }
+
+  const flatten = (s) => {
+    const out = new Map();
+    const assemblies = s?.coverage?.assemblies || [];
+    for (const a of assemblies) {
+      for (const c of (a.classes || [])) {
+        out.set(`${a.name} / ${c.name}`, c.linecoverage);
+      }
+    }
+    return out;
+  };
+
+  const oldMap = flatten(oldClasses);
+  const newMap = flatten(newClasses);
+
+  let classesTable = '';
+  if (oldMap.size > 0 || newMap.size > 0) {
+    const allKeys = new Set([...oldMap.keys(), ...newMap.keys()]);
+    const changes = [];
+    for (const k of allKeys) {
+      const o = oldMap.get(k);
+      const n = newMap.get(k);
+      if (o === n) continue;
+      const delta = (o !== undefined && n !== undefined) ? (n - o) : null;
+      changes.push({ name: k, old: o, new: n, delta });
+    }
+    // Sort by absolute delta (added/removed classes — null delta — float to top).
+    changes.sort((a, b) => {
+      const av = a.delta === null ? Infinity : Math.abs(a.delta);
+      const bv = b.delta === null ? Infinity : Math.abs(b.delta);
+      return bv - av;
+    });
+
+    const fmt = (v) => v === undefined ? '_n/a_' : `${v.toFixed(1)}%`;
+    const fmtDelta = (d) => {
+      if (d === null) return '—';
+      if (d > 0) return `+${d.toFixed(1)}%`;
+      return `${d.toFixed(1)}%`;
+    };
+
+    if (oldMap.size === 0) {
+      classesTable = '\n\n_No baseline class data on the badges branch yet — per-class diff will populate on the next PR after this lands._';
+    } else if (changes.length === 0) {
+      classesTable = '\n\n_No per-class coverage changes._';
+    } else {
+      const cap = 50;
+      const top = changes.slice(0, cap);
+      classesTable =
+        '\n\n**Class coverage changes**\n\n' +
+        '| Class | Before | After | Delta |\n|---|---|---|---|\n' +
+        top.map(c => `| ${c.name} | ${fmt(c.old)} | ${fmt(c.new)} | ${fmtDelta(c.delta)} |`).join('\n');
+      if (changes.length > cap) {
+        classesTable += `\n\n_…and ${changes.length - cap} more not shown._`;
+      }
+    }
+  }
+
+  return [
+    `#### Code Coverage ${summary.emoji} ${phrase}`,
+    ``,
+    `<details><summary>Show details</summary>`,
+    ``,
+    `| | Line Coverage |`,
+    `|---|---|`,
+    `| **Before** | ${summary.old} |`,
+    `| **After** | ${summary.new} |`,
+    `| **Delta** | ${summary.delta} |`,
+    ``,
+    `Full coverage report: ${reportUrl}`,
+    classesTable,
+    ``,
+    `</details>`,
+  ].join('\n');
+}
+
 function upsertSection(body, section, content) {
   const { start, end } = SECTIONS[section];
   const startIdx = body.indexOf(start);
@@ -241,6 +331,7 @@ module.exports = {
   findMatrixJob,
   artifactUrl,
   buildTestsBlock,
+  buildCoverageBlock,
   upsertSection,
   buildSkeleton,
   resolvePr,

--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -162,7 +162,7 @@ jobs:
         run: dotnet-coverage merge ./artifacts/*.coverage -f xml -o coverage.xml
 
       - name : Generate Badge
-        run: reportgenerator -reports:coverage.xml -targetdir:badge-out -reporttypes:HtmlSummary,Badges  -filters:"-ViewModelsSamples*;-CommunityToolkit*;-Analyzer*;-MSTest*;-SnapshotTests*;-CoreTests*"
+        run: reportgenerator -reports:coverage.xml -targetdir:badge-out -reporttypes:HtmlSummary,Badges,JsonSummary -filters:"-ViewModelsSamples*;-CommunityToolkit*;-Analyzer*;-MSTest*;-SnapshotTests*;-CoreTests*"
 
       - name: Get previous coverage from badges branch
         id: old-coverage
@@ -173,6 +173,8 @@ jobs:
             | grep -oP '>\K[0-9]+\.?[0-9]*%' | head -1 || echo "N/A")
 
           echo "value=${OLD_COVERAGE}" >> $GITHUB_OUTPUT
+
+          git show origin/badges:Summary.json > old-summary.json 2>/dev/null || echo "{}" > old-summary.json
 
       - name: Get new coverage from generated badge
         id: new-coverage
@@ -226,6 +228,8 @@ jobs:
             "emoji": "${{ steps.delta.outputs.emoji }}"
           }
           EOF
+          cp badge-out/Summary.json coverage-summary/classes-new.json 2>/dev/null || echo "{}" > coverage-summary/classes-new.json
+          cp old-summary.json coverage-summary/classes-old.json
 
       - name: Upload coverage summary
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -99,13 +99,17 @@ jobs:
             // ---- Coverage (only when both core & snapshot passed and the artifact landed)
             let coverageBlock = '';
             try {
-              const data = JSON.parse(fs.readFileSync('coverage-summary/coverage-summary.json', 'utf8'));
-              coverageBlock =
-                `\n\n#### Code Coverage ${data.emoji}\n\n` +
-                `| | Line Coverage |\n|---|---|\n` +
-                `| **Before** | ${data.old} |\n` +
-                `| **After** | ${data.new} |\n` +
-                `| **Delta** | ${data.delta} |`;
+              const summary = JSON.parse(fs.readFileSync('coverage-summary/coverage-summary.json', 'utf8'));
+              let oldClasses = {};
+              let newClasses = {};
+              try { oldClasses = JSON.parse(fs.readFileSync('coverage-summary/classes-old.json', 'utf8')); } catch (e) {}
+              try { newClasses = JSON.parse(fs.readFileSync('coverage-summary/classes-new.json', 'utf8')); } catch (e) {}
+              coverageBlock = '\n\n' + lib.buildCoverageBlock({
+                summary,
+                oldClasses,
+                newClasses,
+                reportUrl: 'https://live-charts.github.io/LiveCharts2/',
+              });
             } catch (e) {
               // No coverage data — likely tests failed or didn't run.
             }


### PR DESCRIPTION
## Summary
- Coverage section in the PR comment now follows the same `<details>` pattern as benchmarks/tests: the H4 line states whether coverage **increased / decreased / stayed flat** (with the delta), and the before/after table lives behind a Show details toggle.
- Inside `<details>`: the existing Before/After/Delta table, a link to the full coverage report at https://live-charts.github.io/LiveCharts2/, and a new **Class coverage changes** table that lists only the classes whose line coverage changed since the baseline.
- The coverage job now also emits ReportGenerator's `JsonSummary` and fetches the previous `Summary.json` from the `badges` branch so `pr-comment.js` can compute the per-class diff.

The per-class diff needs a baseline `Summary.json` on the `badges` branch — that gets deployed on the first master push after this lands. Until then, the helper detects the missing baseline and shows a one-line note instead of swamping the table with "everything is new".

## Test plan
- [ ] Verify the next PR run renders the new collapsed coverage block (header line shows direction + delta)
- [ ] After this lands and a master push deploys `Summary.json` to the `badges` branch, verify the next PR shows the **Class coverage changes** table populated
- [ ] Verify the badges and HtmlSummary outputs still deploy correctly (no regression from adding `JsonSummary` to `-reporttypes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)