### PR TITLE
fix(zoom): split ZoomAndPanMode into per-gesture flags + honor NoFit in manual Zoom

### DIFF
--- a/docs/cartesianChart/axes.md
+++ b/docs/cartesianChart/axes.md
@@ -22,12 +22,18 @@ Zooming and panning is disabled by default, you can enable it by setting the `Zo
 [ZoomAndPanMode](https://lvcharts.com/api/{{ version }}/LiveChartsCore.Measure.ZoomAndPanMode) and the options are:
 
 - `None`: Disables zooming and panning.
-- `X`: Enables zooming and panning on the X axis.
-- `Y`: Enables zooming and panning on the Y axis.
+- `PanX`: Enables panning on the X axis.
+- `ZoomX`: Enables zooming on the X axis (wheel, pinch and zoom by section).
+- `PanY`: Enables panning on the Y axis.
+- `ZoomY`: Enables zooming on the Y axis (wheel, pinch and zoom by section).
+- `X`: Enables zooming and panning on the X axis. Equivalent to `PanX | ZoomX`.
+- `Y`: Enables zooming and panning on the Y axis. Equivalent to `PanY | ZoomY`.
 - `Both`: Enables zooming and panning on both axes.
 - `NoFit`: Disables the "Fit to Bounds" feature that forces the chart to bounce back to the data bounds when zooming and panning finishes.
 - `NoZoomBySection`: Disables the "Zoom by Section" feature, this feature selects an area and zooms to this area, normally by right clicking or double tapping and then dragging to the end of the section.
 - `InvertPanningPointerTrigger`: Inverts the panning and zoom by section pointer triggers, when the flag is present, panning is triggered by right clicking the chart, and zoom by section by left clicking (or inverts single/double taps on mobile).
+
+Because each gesture has its own flag you can mix and match — for example `ZoomMode = ZoomAndPanMode.ZoomX | ZoomAndPanMode.PanY` enables zoom on the X axis and panning on the Y axis only, and `ZoomMode = ZoomAndPanMode.ZoomX` enables zoom on the X axis with no panning at all (useful on mobile where pan gestures can hide tooltips).
 
 The [ZoomAndPanMode](https://lvcharts.com/api/{{ version }}/LiveChartsCore.Measure.ZoomAndPanMode) type is a flag enum,
 so you can combine the options, for example, if you want to enable zooming on the `X` axis and disable "Fit to Bounds"

--- a/docs/samples/lines/zoom/template.md
+++ b/docs/samples/lines/zoom/template.md
@@ -55,14 +55,14 @@ You can enable zooming and panning by setting the `ZoomMode` property, this prop
 - `X`: Enables zooming and panning on the X axis. Equivalent to `PanX | ZoomX`.
 - `Y`: Enables zooming and panning on the Y axis. Equivalent to `PanY | ZoomY`.
 - `Both`: Enables zooming and panning on both axes.
-- `NoFit`: Disables the "Fit to Bounds" feature that forces the the chart to bounce back to the data bounds when zooming and panning finishes.
+- `NoFit`: Disables the "Fit to Bounds" feature that forces the chart to bounce back to the data bounds when zooming and panning finishes.
 - `NoZoomBySection`: Disables the "Zoom by Section" feature, this feature selects an area and zooms to this area, normally by right clicking or double tapping and then dragging to the end of the section.
 - `InvertPanningPointerTrigger`: Inverts the panning and zoom by section pointer triggers, when the flag is present, panning is triggered by right clicking the chart, and zoom by section by left clicking (or inverts single/double taps on mobile).
 
 Because each gesture has its own flag you can mix and match — for example `ZoomMode = ZoomAndPanMode.ZoomX | ZoomAndPanMode.PanY` enables zoom on the X axis and panning on the Y axis only, and `ZoomMode = ZoomAndPanMode.ZoomX` enables zoom on the X axis with no panning at all (useful on mobile where pan gestures can hide tooltips).
 
 The [ZoomAndPanMode](https://lvcharts.com/api/{{ version }}/LiveChartsCore.Measure.ZoomAndPanMode) type is a flag enum,
-so you can combine the options, for example, if you want to enable zooming on the `Both` axes and disable "Fit top Bounds"
+so you can combine the options, for example, if you want to enable zooming on the `Both` axes and disable "Fit to Bounds"
 you could set the `ZoomMode` property to:
 
 

--- a/docs/samples/lines/zoom/template.md
+++ b/docs/samples/lines/zoom/template.md
@@ -48,12 +48,18 @@ You can enable zooming and panning by setting the `ZoomMode` property, this prop
 [ZoomAndPanMode](https://lvcharts.com/api/{{ version }}/LiveChartsCore.Measure.ZoomAndPanMode) and the options are:
 
 - `None`: Disables zooming and panning.
-- `X`: Enables zooming and panning on the X axis.
-- `Y`: Enables zooming and panning on the Y axis.
+- `PanX`: Enables panning on the X axis.
+- `ZoomX`: Enables zooming on the X axis (wheel, pinch and zoom by section).
+- `PanY`: Enables panning on the Y axis.
+- `ZoomY`: Enables zooming on the Y axis (wheel, pinch and zoom by section).
+- `X`: Enables zooming and panning on the X axis. Equivalent to `PanX | ZoomX`.
+- `Y`: Enables zooming and panning on the Y axis. Equivalent to `PanY | ZoomY`.
 - `Both`: Enables zooming and panning on both axes.
 - `NoFit`: Disables the "Fit to Bounds" feature that forces the the chart to bounce back to the data bounds when zooming and panning finishes.
 - `NoZoomBySection`: Disables the "Zoom by Section" feature, this feature selects an area and zooms to this area, normally by right clicking or double tapping and then dragging to the end of the section.
 - `InvertPanningPointerTrigger`: Inverts the panning and zoom by section pointer triggers, when the flag is present, panning is triggered by right clicking the chart, and zoom by section by left clicking (or inverts single/double taps on mobile).
+
+Because each gesture has its own flag you can mix and match — for example `ZoomMode = ZoomAndPanMode.ZoomX | ZoomAndPanMode.PanY` enables zoom on the X axis and panning on the Y axis only, and `ZoomMode = ZoomAndPanMode.ZoomX` enables zoom on the X axis with no panning at all (useful on mobile where pan gestures can hide tooltips).
 
 The [ZoomAndPanMode](https://lvcharts.com/api/{{ version }}/LiveChartsCore.Measure.ZoomAndPanMode) type is a flag enum,
 so you can combine the options, for example, if you want to enable zooming on the `Both` axes and disable "Fit top Bounds"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -660,6 +660,16 @@ myChart.ZoomMode = ZoomAndPanMode.Both;
 myChart.ZoomMode = ZoomAndPanMode.None;
 ```
 
+Each gesture also has its own flag (`PanX`, `ZoomX`, `PanY`, `ZoomY`) so zoom and pan can be enabled independently. The composites `X = PanX | ZoomX`, `Y = PanY | ZoomY` and `Both = X | Y` keep their original pan+zoom semantics.
+
+```csharp
+// Allow zooming on the X axis but disable panning (e.g. so pan gestures don't hide tooltips on mobile):
+myChart.ZoomMode = ZoomAndPanMode.ZoomX;
+
+// Zoom on X, pan on Y:
+myChart.ZoomMode = ZoomAndPanMode.ZoomX | ZoomAndPanMode.PanY;
+```
+
 `ZoomAndPanMode` is a flags enum — combine values:
 ```csharp
 myChart.ZoomMode = ZoomAndPanMode.X | ZoomAndPanMode.NoFit | ZoomAndPanMode.NoZoomBySection;

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -144,7 +144,7 @@ public class CartesianChartEngine(
     /// Zooms at the specified pivot.
     /// </summary>
     /// <param name="flags">
-    /// The flags, for example ZoomAndPanMode.X | ZoomAndPanMode.NoFit, will zoom only in the x axis
+    /// The flags, for example ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, will zoom only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
     /// <param name="pivot">The pivot, is the reference point, the center where the zoom operation is calculated.</param>
@@ -164,11 +164,11 @@ public class CartesianChartEngine(
                 $"When the scale factor is defined, the zoom direction must be {nameof(ZoomDirection.DefinedByScaleFactor)}... " +
                 $"it just makes sense.");
 
-        if (flags.HasFlag(ZoomAndPanMode.X))
+        if (flags.HasFlag(ZoomAndPanMode.ZoomX))
             foreach (var axis in XAxes)
                 ZoomAxis(axis, flags, pivot.X, direction, scaleFactor);
 
-        if (flags.HasFlag(ZoomAndPanMode.Y))
+        if (flags.HasFlag(ZoomAndPanMode.ZoomY))
             foreach (var axis in YAxes)
                 ZoomAxis(axis, flags, pivot.Y, direction, scaleFactor);
 
@@ -179,17 +179,17 @@ public class CartesianChartEngine(
     /// Pans with the specified delta.
     /// </summary>
     /// <param name="flags">
-    /// The flags, for example ZoomAndPanMode.X | ZoomAndPanMode.NoFit, will pan only in the x axis
+    /// The flags, for example ZoomAndPanMode.PanX | ZoomAndPanMode.NoFit, will pan only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
     /// <param name="delta">The delta.</param>
     public void Pan(ZoomAndPanMode flags, LvcPoint delta)
     {
-        if (flags.HasFlag(ZoomAndPanMode.X))
+        if (flags.HasFlag(ZoomAndPanMode.PanX))
             foreach (var axis in XAxes)
                 PanAxis(axis, flags, delta.X, true);
 
-        if (flags.HasFlag(ZoomAndPanMode.Y))
+        if (flags.HasFlag(ZoomAndPanMode.PanY))
             foreach (var axis in YAxes)
                 PanAxis(axis, flags, delta.Y, true);
     }
@@ -198,14 +198,14 @@ public class CartesianChartEngine(
     /// Starts a zooming section operation at the specified point.
     /// </summary>
     /// <param name="flags">
-    /// The flags, for example ZoomAndPanMode.X | ZoomAndPanMode.NoFit, will zoom only in the x axis
+    /// The flags, for example ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, will zoom only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
     /// <param name="point">The point to start the panning operation.</param>
     public void StartZoomingSection(ZoomAndPanMode flags, LvcPoint point)
     {
-        var xMode = (flags & ZoomAndPanMode.X) == ZoomAndPanMode.X;
-        var yMode = (flags & ZoomAndPanMode.Y) == ZoomAndPanMode.Y;
+        var xMode = flags.HasFlag(ZoomAndPanMode.ZoomX);
+        var yMode = flags.HasFlag(ZoomAndPanMode.ZoomY);
 
         if (flags.HasFlag(ZoomAndPanMode.NoZoomBySection) || (!xMode && !yMode))
             return;
@@ -249,7 +249,7 @@ public class CartesianChartEngine(
     /// in the UI, it does not apply the zoom yet.
     /// </summary>
     /// <param name="flags">
-    /// The flags, for example ZoomAndPanMode.X | ZoomAndPanMode.NoFit, will zoom only in the x axis
+    /// The flags, for example ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, will zoom only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
     /// <param name="point">The point.</param>
@@ -257,8 +257,8 @@ public class CartesianChartEngine(
     {
         if (_zoomingSection is null || _sectionZoomingStart is null) return;
 
-        var xMode = (flags & ZoomAndPanMode.X) == ZoomAndPanMode.X;
-        var yMode = (flags & ZoomAndPanMode.Y) == ZoomAndPanMode.Y;
+        var xMode = flags.HasFlag(ZoomAndPanMode.ZoomX);
+        var yMode = flags.HasFlag(ZoomAndPanMode.ZoomY);
 
         var x = point.X;
         var y = point.Y;
@@ -279,7 +279,7 @@ public class CartesianChartEngine(
     /// End the zooming section operation at the specified point, and applies the zoom.
     /// </summary>
     /// <param name="flags">
-    /// The flags, for example ZoomAndPanMode.X | ZoomAndPanMode.NoFit, will zoom only in the x axis
+    /// The flags, for example ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, will zoom only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
     /// <param name="point">The point.</param>
@@ -301,11 +301,11 @@ public class CartesianChartEngine(
             return;
         }
 
-        if ((flags & ZoomAndPanMode.X) == ZoomAndPanMode.X)
+        if (flags.HasFlag(ZoomAndPanMode.ZoomX))
             foreach (var axis in XAxes)
                 ZoomAxisBySection(axis, point.X);
 
-        if ((flags & ZoomAndPanMode.Y) == ZoomAndPanMode.Y)
+        if (flags.HasFlag(ZoomAndPanMode.ZoomY))
             foreach (var axis in YAxes)
                 ZoomAxisBySection(axis, point.Y);
 
@@ -944,10 +944,10 @@ public class CartesianChartEngine(
         var fits = !flags.HasFlag(ZoomAndPanMode.NoFit);
         if (fits)
         {
-            if (flags.HasFlag(ZoomAndPanMode.X))
+            if (flags.HasFlag(ZoomAndPanMode.PanX))
                 foreach (var axis in XAxes)
                     PanAxis(axis, flags, 0, false);
-            if (flags.HasFlag(ZoomAndPanMode.Y))
+            if (flags.HasFlag(ZoomAndPanMode.PanY))
                 foreach (var axis in YAxes)
                     PanAxis(axis, flags, 0, false);
         }
@@ -1009,11 +1009,11 @@ public class CartesianChartEngine(
             axis.SetLimits(min, max);
         }
 
-        if (flags.HasFlag(ZoomAndPanMode.X))
+        if (flags.HasFlag(ZoomAndPanMode.ZoomX))
             foreach (var axis in XAxes)
                 Fit(axis);
 
-        if (flags.HasFlag(ZoomAndPanMode.Y))
+        if (flags.HasFlag(ZoomAndPanMode.ZoomY))
             foreach (var axis in YAxes)
                 Fit(axis);
     }

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -986,7 +986,10 @@ public class CartesianChartEngine(
 
     private void FitAllOnZoom(ZoomAndPanMode flags)
     {
-        if (_chartView.ZoomMode.HasFlag(ZoomAndPanMode.NoFit))
+        // Honor the flags passed to the public Zoom(...) call rather than the view's
+        // ZoomMode. Manual callers (e.g. a button-driven zoom) need NoFit to take
+        // effect even when the view's ZoomMode does not include it.
+        if (flags.HasFlag(ZoomAndPanMode.NoFit))
             return;
 
         void Fit(ICartesianAxis axis)

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -201,7 +201,7 @@ public class CartesianChartEngine(
     /// The flags, for example ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, will zoom only in the x axis
     /// and will ignore the fit to bounds feature.
     /// </param>
-    /// <param name="point">The point to start the panning operation.</param>
+    /// <param name="point">The point where the zooming section operation starts.</param>
     public void StartZoomingSection(ZoomAndPanMode flags, LvcPoint point)
     {
         var xMode = flags.HasFlag(ZoomAndPanMode.ZoomX);

--- a/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
+++ b/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -36,33 +36,59 @@ public enum ZoomAndPanMode
     None = 0,
 
     /// <summary>
-    /// Enables zooming and panning on the X axis and enables fitting to bounds.
+    /// Enables panning on the X axis.
     /// </summary>
-    X = 1 << 0,
+    PanX = 1 << 0,
 
     /// <summary>
-    /// Enables zooming and panning on the Y axis and enables fitting to bounds.
+    /// Enables zooming on the X axis (wheel, pinch and zoom by section).
     /// </summary>
-    Y = 1 << 1,
+    ZoomX = 1 << 1,
+
+    /// <summary>
+    /// Enables panning on the Y axis.
+    /// </summary>
+    PanY = 1 << 2,
+
+    /// <summary>
+    /// Enables zooming on the Y axis (wheel, pinch and zoom by section).
+    /// </summary>
+    ZoomY = 1 << 3,
 
     /// <summary>
     /// Disables data bounds fitting when zooming or panning, this flag must be used in conjunction with
-    /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/> to have an effect.
+    /// any of the pan/zoom flags (<see cref="PanX"/>, <see cref="ZoomX"/>, <see cref="PanY"/>, <see cref="ZoomY"/>,
+    /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/>) to have an effect.
     /// </summary>
-    NoFit = 1 << 2,
+    NoFit = 1 << 4,
 
     /// <summary>
     /// Disables the "Zoom by section" feature, which allows zooming in on a specific section of the chart.
     /// </summary>
-    NoZoomBySection = 1 << 3,
+    NoZoomBySection = 1 << 5,
 
     /// <summary>
     /// When this flag is present the panning will be triggered using the right click on desktop devices and the touch-and-hold gesture on touch devices.
     /// The "Zoom by section" feature will be triggered to the left click on desktop devices and the touch-and-hold gesture on touch devices,
-    /// this flag must be used in conjunction with
-    /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/> to have an effect.
+    /// this flag must be used in conjunction with any of the pan/zoom flags
+    /// (<see cref="PanX"/>, <see cref="ZoomX"/>, <see cref="PanY"/>, <see cref="ZoomY"/>,
+    /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/>) to have an effect.
     /// </summary>
-    InvertPanningPointerTrigger = 1 << 4,
+    InvertPanningPointerTrigger = 1 << 6,
+
+    /// <summary>
+    /// Enables zooming and panning on the X axis and enables fitting to bounds.
+    /// Equivalent to <see cref="PanX"/> | <see cref="ZoomX"/>. To enable only one
+    /// gesture on the X axis use <see cref="PanX"/> or <see cref="ZoomX"/> directly.
+    /// </summary>
+    X = PanX | ZoomX,
+
+    /// <summary>
+    /// Enables zooming and panning on the Y axis and enables fitting to bounds.
+    /// Equivalent to <see cref="PanY"/> | <see cref="ZoomY"/>. To enable only one
+    /// gesture on the Y axis use <see cref="PanY"/> or <see cref="ZoomY"/> directly.
+    /// </summary>
+    Y = PanY | ZoomY,
 
     /// <summary>
     /// Enables zooming and panning on both axes and enables fitting to bounds.

--- a/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
+++ b/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
@@ -68,8 +68,8 @@ public enum ZoomAndPanMode
     NoZoomBySection = 1 << 5,
 
     /// <summary>
-    /// When this flag is present the panning will be triggered using the right click on desktop devices and the touch-and-hold gesture on touch devices.
-    /// The "Zoom by section" feature will be triggered by the left click on desktop devices and the touch-and-hold gesture on touch devices,
+    /// When this flag is present the panning will be triggered using the right click on desktop devices and a double tap on touch devices.
+    /// The "Zoom by section" feature will be triggered by the left click on desktop devices and a single tap on touch devices,
     /// this flag must be used in conjunction with any of the pan/zoom flags
     /// (<see cref="PanX"/>, <see cref="ZoomX"/>, <see cref="PanY"/>, <see cref="ZoomY"/>,
     /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/>) to have an effect.

--- a/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
+++ b/src/LiveChartsCore/Measure/ZoomAndPanMode.cs
@@ -69,7 +69,7 @@ public enum ZoomAndPanMode
 
     /// <summary>
     /// When this flag is present the panning will be triggered using the right click on desktop devices and the touch-and-hold gesture on touch devices.
-    /// The "Zoom by section" feature will be triggered to the left click on desktop devices and the touch-and-hold gesture on touch devices,
+    /// The "Zoom by section" feature will be triggered by the left click on desktop devices and the touch-and-hold gesture on touch devices,
     /// this flag must be used in conjunction with any of the pan/zoom flags
     /// (<see cref="PanX"/>, <see cref="ZoomX"/>, <see cref="PanY"/>, <see cref="ZoomY"/>,
     /// <see cref="X"/>, <see cref="Y"/>, or <see cref="Both"/>) to have an effect.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenCartesianChart.avalonia.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenCartesianChart.avalonia.cs
@@ -56,8 +56,10 @@ public partial class SourceGenCartesianChart : SourceGenChart, ICartesianChartVi
         // Only mark the event as handled when zoom is enabled; otherwise let it bubble
         // so parent ScrollViewers still scroll and external subscribers still fire
         // (Avalonia routed events skip subsequent handlers once Handled = true).
+        // Pan-only modes (PanX/PanY) must not swallow wheel either since the Zoom
+        // call below is a no-op for them.
         // See https://github.com/Live-Charts/LiveCharts2/issues/1864.
-        if (ZoomMode == ZoomAndPanMode.None) return;
+        if ((ZoomMode & (ZoomAndPanMode.ZoomX | ZoomAndPanMode.ZoomY)) == 0) return;
         e.Handled = true;
 
         var c = (CartesianChartEngine)CoreChart;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenCartesianChart.eto.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/SourceGenCartesianChart.eto.cs
@@ -45,6 +45,10 @@ public partial class SourceGenCartesianChart : SourceGenChart, ICartesianChartVi
 
     private void OnMouseWheel(object? sender, MouseEventArgs e)
     {
+        // Don't swallow the wheel when zoom is not enabled — pan-only modes
+        // (PanX/PanY) and None must let the event bubble so containers can scroll.
+        if ((ZoomMode & (ZoomAndPanMode.ZoomX | ZoomAndPanMode.ZoomY)) == 0) return;
+
         var c = (CartesianChartEngine)CoreChart;
         var p = e.Location;
         c.Zoom(ZoomMode, new LvcPoint(p.X, p.Y), e.Delta.Height > 0 ? ZoomDirection.ZoomIn : ZoomDirection.ZoomOut);

--- a/tests/CoreTests/OtherTests/ChartInteractiveApiTests.cs
+++ b/tests/CoreTests/OtherTests/ChartInteractiveApiTests.cs
@@ -131,6 +131,134 @@ public class ChartInteractiveApiTests
             new LvcPoint(100, 100));
     }
 
+    private static (SKCartesianChart chart, Axis xAxis, Axis yAxis, CartesianChartEngine core) CreatePinnedChart()
+    {
+        // MinLimit/MaxLimit are pinned so Zoom/Pan operations leave a measurable change
+        // on the axis limits without the auto-fit logic snapping things back.
+        var xAxis = new Axis { MinLimit = 0, MaxLimit = 10 };
+        var yAxis = new Axis { MinLimit = 0, MaxLimit = 10 };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            XAxes = [xAxis],
+            YAxes = [yAxis],
+            Series = [ new LineSeries<double> { Values = [1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d, 10d] } ]
+        };
+
+        _ = chart.GetImage();
+        var core = (CartesianChartEngine)chart.CoreChart;
+        return (chart, xAxis, yAxis, core);
+    }
+
+    [TestMethod]
+    public void Zoom_WithZoomXOnly_AffectsOnlyXAxis()
+    {
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xRangeBefore = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        var yRangeBefore = yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value;
+
+        core.Zoom(ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, new LvcPoint(200, 200), ZoomDirection.ZoomIn);
+
+        var xRangeAfter = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        var yRangeAfter = yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value;
+
+        Assert.IsTrue(xRangeAfter < xRangeBefore, "ZoomX should shrink the X axis range.");
+        Assert.AreEqual(yRangeBefore, yRangeAfter, 1e-9, "ZoomX must leave the Y axis untouched.");
+    }
+
+    [TestMethod]
+    public void Zoom_WithPanXOnly_DoesNotZoomXAxis()
+    {
+        // PanX alone enables panning but NOT zooming; a Zoom call should be a no-op.
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xRangeBefore = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        var yRangeBefore = yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value;
+
+        core.Zoom(ZoomAndPanMode.PanX | ZoomAndPanMode.NoFit, new LvcPoint(200, 200), ZoomDirection.ZoomIn);
+
+        Assert.AreEqual(xRangeBefore, xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value, 1e-9);
+        Assert.AreEqual(yRangeBefore, yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value, 1e-9);
+    }
+
+    [TestMethod]
+    public void Pan_WithPanXOnly_AffectsOnlyXAxis()
+    {
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xMinBefore = xAxis.MinLimit!.Value;
+        var yMinBefore = yAxis.MinLimit!.Value;
+
+        core.Pan(ZoomAndPanMode.PanX | ZoomAndPanMode.NoFit, new LvcPoint(20, 20));
+
+        Assert.AreNotEqual(xMinBefore, xAxis.MinLimit!.Value, "PanX should shift the X axis.");
+        Assert.AreEqual(yMinBefore, yAxis.MinLimit!.Value, 1e-9, "PanX must leave the Y axis untouched.");
+    }
+
+    [TestMethod]
+    public void Pan_WithZoomXOnly_DoesNotPanXAxis()
+    {
+        // ZoomX alone enables zoom but NOT pan; a Pan call should be a no-op.
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xMinBefore = xAxis.MinLimit!.Value;
+        var yMinBefore = yAxis.MinLimit!.Value;
+
+        core.Pan(ZoomAndPanMode.ZoomX | ZoomAndPanMode.NoFit, new LvcPoint(20, 20));
+
+        Assert.AreEqual(xMinBefore, xAxis.MinLimit!.Value, 1e-9);
+        Assert.AreEqual(yMinBefore, yAxis.MinLimit!.Value, 1e-9);
+    }
+
+    [TestMethod]
+    public void Zoom_WithZoomYOnly_AffectsOnlyYAxis()
+    {
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xRangeBefore = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        var yRangeBefore = yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value;
+
+        core.Zoom(ZoomAndPanMode.ZoomY | ZoomAndPanMode.NoFit, new LvcPoint(200, 200), ZoomDirection.ZoomIn);
+
+        Assert.AreEqual(xRangeBefore, xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value, 1e-9);
+        Assert.IsTrue(yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value < yRangeBefore);
+    }
+
+    [TestMethod]
+    public void Pan_WithPanYOnly_AffectsOnlyYAxis()
+    {
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xMinBefore = xAxis.MinLimit!.Value;
+        var yMinBefore = yAxis.MinLimit!.Value;
+
+        core.Pan(ZoomAndPanMode.PanY | ZoomAndPanMode.NoFit, new LvcPoint(20, 20));
+
+        Assert.AreEqual(xMinBefore, xAxis.MinLimit!.Value, 1e-9);
+        Assert.AreNotEqual(yMinBefore, yAxis.MinLimit!.Value);
+    }
+
+    [TestMethod]
+    public void CompositeXFlag_StillEnablesBothPanAndZoomOnX()
+    {
+        // Backward-compat guarantee: ZoomAndPanMode.X must keep pan+zoom semantics.
+        var (_, xAxis, yAxis, core) = CreatePinnedChart();
+
+        var xRangeBefore = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        var yRangeBefore = yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value;
+        var xMinBefore = xAxis.MinLimit!.Value;
+
+        core.Zoom(ZoomAndPanMode.X | ZoomAndPanMode.NoFit, new LvcPoint(200, 200), ZoomDirection.ZoomIn);
+        core.Pan(ZoomAndPanMode.X | ZoomAndPanMode.NoFit, new LvcPoint(20, 0));
+
+        Assert.IsTrue(xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value < xRangeBefore);
+        Assert.AreNotEqual(xMinBefore, xAxis.MinLimit!.Value);
+        Assert.AreEqual(yRangeBefore, yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value, 1e-9);
+    }
+
     private static SKGeoMap CreateGeoMap(MapProjection projection = MapProjection.Mercator) =>
         new()
         {

--- a/tests/CoreTests/OtherTests/ChartInteractiveApiTests.cs
+++ b/tests/CoreTests/OtherTests/ChartInteractiveApiTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using LiveChartsCore;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
@@ -257,6 +258,40 @@ public class ChartInteractiveApiTests
         Assert.IsTrue(xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value < xRangeBefore);
         Assert.AreNotEqual(xMinBefore, xAxis.MinLimit!.Value);
         Assert.AreEqual(yRangeBefore, yAxis.MaxLimit!.Value - yAxis.MinLimit!.Value, 1e-9);
+    }
+
+    [TestMethod]
+    public async Task Zoom_NoFitArgumentIsHonored_EvenWhenViewZoomModeOmitsIt()
+    {
+        // Reproduces issue #2119: a manual core.Zoom(... | NoFit, ...) call must keep
+        // the zoomed range. Previously the post-zoom debounced fit checked the view's
+        // ZoomMode (None here) instead of the flags argument, snapping limits back.
+        var xAxis = new Axis { MinLimit = 50, MaxLimit = 60 };
+        var yAxis = new Axis { MinLimit = 50, MaxLimit = 60 };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.None,
+            XAxes = [xAxis],
+            YAxes = [yAxis],
+            Series = [ new LineSeries<double> { Values = [1d, 2d, 3d, 4d, 5d, 6d, 7d, 8d, 9d, 10d] } ]
+        };
+        _ = chart.GetImage();
+
+        var core = (CartesianChartEngine)chart.CoreChart;
+
+        // Pinned MaxLimit (60) sits above the data bounds (1..10). Without NoFit, the
+        // post-zoom Fit would clamp MaxLimit down toward the data max (~10).
+        core.Zoom(ZoomAndPanMode.Both | ZoomAndPanMode.NoFit, new LvcPoint(200, 200), ZoomDirection.ZoomIn);
+
+        // Wait past the 300 ms debounce so FitAllOnZoom has had a chance to fire.
+        await Task.Delay(450);
+        _ = chart.GetImage();
+
+        Assert.IsTrue(xAxis.MaxLimit!.Value > 50, $"NoFit must prevent X MaxLimit snap-to-data; X MaxLimit={xAxis.MaxLimit}.");
+        Assert.IsTrue(yAxis.MaxLimit!.Value > 50, $"NoFit must prevent Y MaxLimit snap-to-data; Y MaxLimit={yAxis.MaxLimit}.");
     }
 
     private static SKGeoMap CreateGeoMap(MapProjection projection = MapProjection.Mercator) =>


### PR DESCRIPTION
## Summary
- Adds `PanX`, `ZoomX`, `PanY`, `ZoomY` to `ZoomAndPanMode` so each gesture can be enabled independently (e.g. `ZoomMode = ZoomAndPanMode.ZoomX` to allow wheel/pinch zoom on the X axis with no panning).
- Keeps `X`, `Y`, `Both` as composites (`X = PanX | ZoomX`, `Y = PanY | ZoomY`, `Both = X | Y`) — code or XAML that references them by name keeps the existing pan+zoom behavior.
- Updates `CartesianChartEngine` so each gesture consults the right flag: `Zoom` and zoom-by-section check `ZoomX`/`ZoomY`, `Pan` and the pointer-up bounce-back check `PanX`/`PanY`, and the post-zoom fit checks `ZoomX`/`ZoomY`.
- Fixes `FitAllOnZoom` to honor the `NoFit` flag passed to the public `Zoom(...)` call. It used to read the chart view's `ZoomMode` for `NoFit`, which silently ignored the argument when callers had set `ZoomMode = None` and were driving zoom manually.
- Updates the axes guide, the lines/zoom sample doc, and `llms-full.txt` to list the new per-gesture flags and show the "zoom on X, no pan" combination.

Closes #2175 (originally reported in discussion #2167 — "How to disable pan, but keep the zoom on axis?").
Closes #2119 — the "decouple Zoom and Pan" and "manual `Zoom` must honor `NoFit`" parts. The third ask in #2119 (custom input mapping for keys/pointer events) is intentionally out of scope; the existing API surface is enough to build that on the consumer side.

## Notes
- The integer bit positions of the flags shifted (`NoFit` is now `16`, etc.). Code that references the enum by name is unaffected; anyone hardcoding integer values for the enum would see a shift.
- The composite `X` (now `PanX | ZoomX = 3`) still preserves the old pan+zoom-on-X behavior.

## Test plan
- [x] `dotnet test --project tests/CoreTests/CoreTests.csproj --framework net8.0` — 461/461 passing (453 prior + 8 new).
- [x] Granular flag tests: `ZoomX`/`PanX` isolation, `ZoomY`/`PanY` isolation, `Pan` no-op under `ZoomX`-only, `Zoom` no-op under `PanX`-only, composite `X` still pans+zooms.
- [x] `NoFit`-honoring regression test verified to fail without the engine fix (`MaxLimit` snapped from 60 → ~9 with the bug, stays ~59 with the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)