### PR TITLE
ci: cancel superseded PR runs and gate benchmark regressions on noise

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -80,8 +80,8 @@ jobs:
             delta.md
           retention-days: 30
 
-      - name: Fail job if a benchmark regressed by more than 10%
+      - name: Fail job if a benchmark regressed beyond the noise gate
         if: steps.compare.outputs.has_regression == 'true'
         run: |
-          echo "::error::One or more benchmarks regressed by more than 10%. See the PR comment for details."
+          echo "::error::One or more benchmarks regressed beyond the noise gate (>15% AND >3x combined standard error). See the PR comment for details."
           exit 1

--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -23,6 +23,13 @@ on:
     paths: *code-paths
   workflow_dispatch:
 
+# Group runs by PR (or by branch on push) so a new commit cancels the in-progress
+# run for the same PR. Master pushes are NOT cancelled — every master build must
+# finish so the coverage badge and release-suffix sequence stay continuous.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   prepare:

--- a/tests/Benchmarks/ResultsCompare.cs
+++ b/tests/Benchmarks/ResultsCompare.cs
@@ -9,8 +9,14 @@ namespace Benchmarks;
 // a markdown table.
 internal static class ResultsCompare
 {
-    // Deltas beyond +/- Threshold are flagged. Tuned loose for noisy shared CI runners.
-    private const double Threshold = 0.10;
+    // A row is flagged only when its delta is BOTH:
+    //   * beyond the headline percentage floor (|pct| > PctThreshold), and
+    //   * statistically beyond the combined standard error (|pct| > NoiseFactor * relSE).
+    // The percentage floor catches meaningful real moves; the noise gate filters out
+    // jitter on small benches (Pie ~1 ms, Heat ~2 ms) where one bad sample on a shared
+    // GitHub runner can fake a 10–15% swing.
+    private const double PctThreshold = 0.15;
+    private const double NoiseFactor = 3.0;
 
     public static int Run(ReadOnlySpan<string> args)
     {
@@ -46,8 +52,8 @@ internal static class ResultsCompare
             Console.Write(md);
 
         // Expose flags to the workflow so it can decide whether to post a comment
-        // (any row outside ±Threshold) and whether to fail (any row slower by more
-        // than Threshold).
+        // (any row significantly outside noise) and whether to fail (any row slower
+        // beyond both the percentage floor and the noise gate).
         var githubOutput = Environment.GetEnvironmentVariable("GITHUB_OUTPUT");
         if (!string.IsNullOrEmpty(githubOutput))
         {
@@ -71,18 +77,22 @@ internal static class ResultsCompare
         foreach (var row in rows)
         {
             if (row.Base is null || row.Head is null) continue;
-            var pct = (row.Head.MeanNs - row.Base.MeanNs) / row.Base.MeanNs;
-            if (pct > Threshold)
-            {
-                regression = true;
-                interesting = true;
-            }
-            else if (pct < -Threshold)
-            {
-                interesting = true;
-            }
+            if (!IsSignificant(row.Base, row.Head, out var pct)) continue;
+            interesting = true;
+            if (pct > 0) regression = true;
         }
         return (interesting, regression);
+    }
+
+    // A delta is "significant" when it is both beyond the percentage floor AND
+    // beyond NoiseFactor x the combined relative standard error of base and head.
+    private static bool IsSignificant(BenchmarkStats @base, BenchmarkStats head, out double pct)
+    {
+        pct = (head.MeanNs - @base.MeanNs) / @base.MeanNs;
+        if (Math.Abs(pct) <= PctThreshold) return false;
+        var relSe = Math.Sqrt(@base.StandardErrorNs * @base.StandardErrorNs
+                              + head.StandardErrorNs * head.StandardErrorNs) / @base.MeanNs;
+        return Math.Abs(pct) > NoiseFactor * relSe;
     }
 
     private static Dictionary<string, BenchmarkStats> LoadAll(string dir)
@@ -146,11 +156,10 @@ internal static class ResultsCompare
     private static string DeltaCell(BenchmarkStats? @base, BenchmarkStats? head)
     {
         if (@base is null || head is null) return "—";
-        var pct = (head.MeanNs - @base.MeanNs) / @base.MeanNs;
+        var significant = IsSignificant(@base, head, out var pct);
         var str = (pct * 100).ToString("+0.0;-0.0;0.0", CultureInfo.InvariantCulture) + "%";
-        if (pct > Threshold) return "🔴 " + str;
-        if (pct < -Threshold) return "🟢 " + str;
-        return str;
+        if (!significant) return str;
+        return (pct > 0 ? "🔴 " : "🟢 ") + str;
     }
 
     private static string FormatMs(double ns) => (ns / 1_000_000.0).ToString("N3", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary

- **livecharts.yml**: add a workflow-level `concurrency` group keyed by `github.head_ref || github.ref` so a new commit on a PR cancels the in-progress run for the same PR. Master pushes are exempted (`cancel-in-progress` is gated to `pull_request`) so every master build finishes and the coverage badge / release-suffix sequence stay continuous.
- **benchmarks.yml + ResultsCompare**: replace the flat 10% regression threshold with a two-part gate. A row is flagged only when its delta is BOTH `|pct| > 0.15` AND `|pct| > 3 x combined relative standard error`. The standard error was already being read from BenchmarkDotNet's report, just not used. This silences flaky fails on small benches (Pie ~1 ms, Heat ~2 ms) without letting a real 15% regression on a stable big bench slip through.

## Test plan

- [ ] Trigger this PR's own runs and confirm the cancel-in-progress behavior by pushing a follow-up commit while a run is in flight.
- [ ] Confirm the LiveCharts master push runs still complete (do NOT get cancelled when something else lands).
- [ ] Eyeball the benchmark comment on this PR's run: numbers should not flag rows whose delta is within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)