### PR TITLE
fix(hover-area): tooltip not firing on stacked bars with negative values (#2165)

### DIFF
--- a/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
@@ -206,11 +206,24 @@ public class RectangleHoverArea : HoverArea
     public override bool IsPointerOver(LvcPoint pointerLocation, FindingStrategy strategy)
     {
         // at least one pixel to fire the tooltip.
-        var w = Width < 1 ? 1 : Width;
-        var h = Height < 1 ? 1 : Height;
+        var w = Width switch
+        {
+            > 1 => Width,
+            >= 0 => 1,
+            > -1 => -1,
+            _ => Width
+        };
 
-        var isInX = pointerLocation.X > X && pointerLocation.X < X + w;
-        var isInY = pointerLocation.Y > Y && pointerLocation.Y < Y + h;
+        var h = Height switch
+        {
+            > 1 => Height,
+            >= 0 => 1,
+            > -1 => -1,
+            _ => Height
+        };
+
+        var isInX = IsBetween(pointerLocation.X, X, X + w);
+        var isInY = IsBetween(pointerLocation.Y, Y, Y + h);
 
         return strategy switch
         {
@@ -226,6 +239,10 @@ public class RectangleHoverArea : HoverArea
             _ => throw new NotImplementedException()
         };
     }
+
+    private static bool IsBetween(float value, float firstBound, float secondBound) => firstBound > secondBound
+        ? value > secondBound && value < firstBound
+        : value > firstBound && value < secondBound;
 
     /// <inheritdoc cref="HoverArea.SuggestTooltipPlacement(TooltipPlacementContext, LvcSize)"/>
     public override void SuggestTooltipPlacement(TooltipPlacementContext ctx, LvcSize tooltipSize)

--- a/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
+++ b/src/LiveChartsCore/Kernel/Drawing/RectangleHoverArea.cs
@@ -205,25 +205,18 @@ public class RectangleHoverArea : HoverArea
     /// <inheritdoc cref="HoverArea.IsPointerOver(LvcPoint, FindingStrategy)"/>
     public override bool IsPointerOver(LvcPoint pointerLocation, FindingStrategy strategy)
     {
+        // Width/Height may be negative (e.g. stacked bars with negative values), normalize to min/max.
+        var xMin = Math.Min(X, X + Width);
+        var xMax = Math.Max(X, X + Width);
+        var yMin = Math.Min(Y, Y + Height);
+        var yMax = Math.Max(Y, Y + Height);
+
         // at least one pixel to fire the tooltip.
-        var w = Width switch
-        {
-            > 1 => Width,
-            >= 0 => 1,
-            > -1 => -1,
-            _ => Width
-        };
+        if (xMax - xMin < 1) xMax = xMin + 1;
+        if (yMax - yMin < 1) yMax = yMin + 1;
 
-        var h = Height switch
-        {
-            > 1 => Height,
-            >= 0 => 1,
-            > -1 => -1,
-            _ => Height
-        };
-
-        var isInX = IsBetween(pointerLocation.X, X, X + w);
-        var isInY = IsBetween(pointerLocation.Y, Y, Y + h);
+        var isInX = pointerLocation.X > xMin && pointerLocation.X < xMax;
+        var isInY = pointerLocation.Y > yMin && pointerLocation.Y < yMax;
 
         return strategy switch
         {
@@ -239,10 +232,6 @@ public class RectangleHoverArea : HoverArea
             _ => throw new NotImplementedException()
         };
     }
-
-    private static bool IsBetween(float value, float firstBound, float secondBound) => firstBound > secondBound
-        ? value > secondBound && value < firstBound
-        : value > firstBound && value < secondBound;
 
     /// <inheritdoc cref="HoverArea.SuggestTooltipPlacement(TooltipPlacementContext, LvcSize)"/>
     public override void SuggestTooltipPlacement(TooltipPlacementContext ctx, LvcSize tooltipSize)

--- a/tests/CoreTests/CoreObjectsTests/MeasureTesting.cs
+++ b/tests/CoreTests/CoreObjectsTests/MeasureTesting.cs
@@ -465,6 +465,61 @@ public class MeasureTesting
         Assert.IsTrue(isOver);
     }
 
+    // Regression for #2165: stacked column/row series with negative values produce
+    // RectangleHoverArea instances whose Width or Height is negative. IsPointerOver
+    // must treat (X, X+Width) and (Y, Y+Height) as unordered ranges.
+
+    [TestMethod]
+    public void RectangleHoverAreaIsPointerOverNegativeHeight()
+    {
+        // Same rect as a stacked column going downward from baseline:
+        // top edge at y=20, bottom edge at y=70, expressed as Y=70 / Height=-50.
+        var area = new RectangleHoverArea(10, 70, 100, -50);
+
+        // Point that is geometrically inside the rectangle.
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareAll));
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareAllTakeClosest));
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareOnlyY));
+
+        // Outside in Y on either side of the (unordered) range.
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(50, 10), FindingStrategy.CompareAll));
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(50, 80), FindingStrategy.CompareAll));
+    }
+
+    [TestMethod]
+    public void RectangleHoverAreaIsPointerOverNegativeWidth()
+    {
+        // Same shape but for a row series: X=110 / Width=-100 spans x in [10, 110].
+        var area = new RectangleHoverArea(110, 20, -100, 50);
+
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareAll));
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareOnlyX));
+
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(5, 40), FindingStrategy.CompareAll));
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(120, 40), FindingStrategy.CompareAll));
+    }
+
+    [TestMethod]
+    public void RectangleHoverAreaIsPointerOverNegativeWidthAndHeight()
+    {
+        // Both negative — rectangle covers x in [10, 110], y in [20, 70].
+        var area = new RectangleHoverArea(110, 70, -100, -50);
+
+        Assert.IsTrue(area.IsPointerOver(new LvcPoint(50, 40), FindingStrategy.CompareAll));
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(5, 40), FindingStrategy.CompareAll));
+        Assert.IsTrue(!area.IsPointerOver(new LvcPoint(50, 80), FindingStrategy.CompareAll));
+    }
+
+    [TestMethod]
+    public void RectangleHoverAreaDistanceToWithNegativeDimensions()
+    {
+        // Center is at (X + Width/2, Y + Height/2) regardless of sign.
+        var area = new RectangleHoverArea(110, 70, -100, -50); // center: (60, 45)
+        var distance = area.DistanceTo(new LvcPoint(60, 45), FindingStrategy.CompareAll);
+
+        Assert.IsTrue(Math.Abs(distance - 0) < 0.001);
+    }
+
     // ========== SemicircleHoverArea Tests ==========
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- Fixes #2165. `RectangleHoverArea.IsPointerOver` clamped `Width < 1` (and `Height < 1`) down to 1, which collapsed any negative width/height to a 1-pixel range. Stacked column/row series with negative values produce hover areas with negative `Height` (column) or `Width` (row) — see `CoreColumnSeries.cs:246-247` where `b = primaryI - primaryJ` goes negative for the negative side of the stack — so pointer-hit tests rejected every position inside the bar with `CompareAllTakeClosest` (and friends).
- Builds on @mou-haz's fix in #2166 (cherry-picked, authorship preserved). Refactored on top to a min/max range normalization, which keeps the same behavior with the "1 pixel minimum" rule expressed once instead of duplicated per sign.
- Adds regression tests covering negative `Width`, negative `Height`, both negative, and that `DistanceTo`'s center remains sign-agnostic.

Closes #2165. Supersedes #2166 (with credit to @mou-haz on the original fix commit and as Co-Authored-By on the refactor).

## Test plan
- [x] `dotnet test --project tests/CoreTests/CoreTests.csproj --framework net8.0` — all 465 tests pass, including 4 new `RectangleHoverArea*Negative*` cases.
- [ ] Manual: stacked column sample with a `-2, -2, -2` series and `FindingStrategy = CompareAllTakeClosest` shows the tooltip when hovering over the negative bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)