### PR TITLE
fix(geo-map): preserve shared lands when swapping series (#962)

### DIFF
--- a/src/LiveChartsCore/CoreHeatLandSeries.cs
+++ b/src/LiveChartsCore/CoreHeatLandSeries.cs
@@ -24,6 +24,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+#if NET462
+using System.Linq;
+#endif
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel.Observers;
@@ -168,7 +171,14 @@ public abstract class CoreHeatLandSeries<TModel> : IGeoSeries, INotifyPropertyCh
     /// <inheritdoc cref="IGeoSeries.Delete(MapContext)"/>
     public void Delete(MapContext context)
     {
+        // ClearHeat removes each item from _everUsed during iteration; passing
+        // _everUsed directly throws "Collection was modified" on .NET Framework's
+        // HashSet enumerator, so snapshot it there (matches CollectionDeepObserver).
+#if NET462
+        ClearHeat(_everUsed.ToArray());
+#else
         ClearHeat(_everUsed);
+#endif
         _ = _subscribedTo.Remove(context.CoreMap);
     }
 

--- a/src/LiveChartsCore/GeoMapChart.cs
+++ b/src/LiveChartsCore/GeoMapChart.cs
@@ -353,18 +353,23 @@ public class GeoMapChart
 
         _mapFactory.GenerateLands(context);
 
-        var toDeleteSeries = new HashSet<IGeoSeries>(_everMeasuredSeries);
-        foreach (var series in View.Series?.Cast<IGeoSeries>() ?? [])
+        // Departed series must be deleted BEFORE measuring the new series.
+        // Otherwise CoreHeatLandSeries.Delete -> ClearHeat would null the Shape.Fill
+        // on lands shared with the new series AFTER the new series painted them,
+        // making shared lands appear blank on series swap (issue #962).
+        var currentSeries = View.Series?.Cast<IGeoSeries>().ToArray() ?? [];
+        var currentSet = new HashSet<IGeoSeries>(currentSeries);
+        foreach (var series in _everMeasuredSeries)
+        {
+            if (currentSet.Contains(series)) continue;
+            series.Delete(context);
+        }
+        _everMeasuredSeries.RemoveWhere(s => !currentSet.Contains(s));
+
+        foreach (var series in currentSeries)
         {
             series.Measure(context);
             _ = _everMeasuredSeries.Add(series);
-            _ = toDeleteSeries.Remove(series);
-        }
-
-        foreach (var series in toDeleteSeries)
-        {
-            series.Delete(context);
-            _ = _everMeasuredSeries.Remove(series);
         }
 
         // Refresh tooltip if a land is currently hovered (data may have changed)

--- a/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
+++ b/src/skiasharp/_Shared/SourceGenMapChart.sgp.cs
@@ -123,6 +123,7 @@ public partial class SourceGenMapChart
 #endif
         chart._seriesObserver?.Dispose();
         chart._seriesObserver?.Initialize((IEnumerable<IGeoSeries>)newValue);
+        chart.CoreChart.Update();
     }
 
     static Action<SGChart, object, object> OnPaintPropertyChanged(

--- a/tests/CoreTests/ChartTests/GeoMapTests.cs
+++ b/tests/CoreTests/ChartTests/GeoMapTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+[TestClass]
+public class GeoMapTests
+{
+    // https://github.com/Live-Charts/LiveCharts2/issues/962
+    //
+    // Swapping the Series collection on a GeoMap should preserve the heat fill
+    // on lands that exist in both the old and the new series. Before the fix,
+    // GeoMapChart.Measure() painted the new series first and then called
+    // Delete() on the departed series, which nulled Shape.Fill on every land
+    // the old series had ever painted -- including ones the new series just
+    // painted -- so shared lands appeared blank until the next measure.
+    [TestMethod]
+    public void GeoMap_SwappingSeries_PreservesFillOnSharedLands()
+    {
+        var chart = new SKGeoMap
+        {
+            Width = 400,
+            Height = 400,
+            Series = [
+                new HeatLandSeries
+                {
+                    Lands = [
+                        new() { Name = "fra", Value = 10 },
+                        new() { Name = "usa", Value = 5 },
+                    ]
+                }
+            ]
+        };
+
+        chart.CoreChart.Measure();
+
+        var fra = chart.ActiveMap.FindLand("fra");
+        var usa = chart.ActiveMap.FindLand("usa");
+        Assert.IsNotNull(fra, "fra should exist in the world map");
+        Assert.IsNotNull(usa, "usa should exist in the world map");
+        Assert.IsTrue(
+            fra.Data.All(d => d.Shape?.Fill is not null),
+            "fra should be painted after the first measure");
+
+        // Swap to a series that still contains "fra" but drops "usa".
+        chart.Series = [
+            new HeatLandSeries
+            {
+                Lands = [
+                    new() { Name = "fra", Value = 1 },
+                    new() { Name = "bra", Value = 99 },
+                ]
+            }
+        ];
+
+        chart.CoreChart.Measure();
+
+        Assert.IsTrue(
+            fra.Data.All(d => d.Shape?.Fill is not null),
+            "fra is shared between the old and new series and must stay painted after swap (#962)");
+        Assert.IsTrue(
+            usa.Data.All(d => d.Shape?.Fill is null),
+            "usa is no longer in any series and must be cleared after swap");
+    }
+}


### PR DESCRIPTION
## Summary

Two related bugs caused `GeoMap` to misbehave when its `Series` property was swapped at runtime — symptom from #962: lands shared between the old and new series go blank until the next layout pass (e.g. window resize).

- **Reorder Measure pipeline** (`GeoMapChart.Measure`): delete departed series before measuring the active ones. Previously the new series painted first and the old series's `Delete` then nulled `Shape.Fill` on every land it had ever painted — including ones the new series just painted. The two loops are now swapped so deletion happens first and the new series overpaints shared lands cleanly.
- **Trigger Update on Series reassignment** (`SourceGenMapChart.sgp.cs`): `OnSeriesPropertyChanged` only re-bound the collection observer and never called `CoreChart.Update()`. Reassigning `Series = newArray` therefore didn't queue a measure on its own. The cartesian path already does this; the geo-map path now matches.

The post-#2125 `ClearHeat` fix (#2000) was correct but exposed the ordering issue: previously `ClearHeat` was a no-op so old fills leaked instead of over-clearing. Now the order matters and is correct.

Each fix is a separate commit so they can be reviewed and reverted independently.

Fixes Live-Charts/LiveCharts2#962

## Test plan

- [ ] WPF sample: temporarily bind `Series` to a property that toggles between two `HeatLandSeries[]` with overlapping country sets; clicking the toggle no longer blanks the shared countries.
- [ ] WPF sample: existing `ToggleBrazil` still works (mutating `Lands` inside the same series).
- [ ] Avalonia World map sample (clear/restore controls from #2125): clear no longer leaves residual fill, restore repaints correctly.
- [ ] Existing CoreTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)