### PR TITLE
fix(winforms): forward MouseClick/MouseDoubleClick from inner SKControl

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/SourceGenChart.cs
@@ -70,6 +70,8 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         c.MouseDown += OnMouseDown;
         c.MouseMove += OnMouseMove;
         c.MouseUp += OnMouseUp;
+        c.MouseClick += OnMouseClick;
+        c.MouseDoubleClick += OnMouseDoubleClick;
         c.MouseLeave += OnMouseLeave;
     }
 
@@ -137,6 +139,12 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         base.OnMouseUp(e);
         CoreChart?.InvokePointerUp(new LvcPoint(e.Location.X, e.Location.Y), e.Button == MouseButtons.Right);
     }
+
+    private void OnMouseClick(object? sender, MouseEventArgs e) =>
+        base.OnMouseClick(e);
+
+    private void OnMouseDoubleClick(object? sender, MouseEventArgs e) =>
+        base.OnMouseDoubleClick(e);
 
     private void OnMouseLeave(object? sender, EventArgs e)
     {

--- a/tests/SharedUITests/Events/MouseEventForwardingTests.cs
+++ b/tests/SharedUITests/Events/MouseEventForwardingTests.cs
@@ -1,0 +1,66 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Factos;
+using SharedUITests.Helpers;
+using Xunit;
+
+namespace SharedUITests.Events;
+
+public class MouseEventForwardingTests
+{
+    public AppController App => AppController.Current;
+
+#if WINFORMS_UI_TESTING
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1209
+    // mouse messages reach the inner SKControl, not the outer chart, so the
+    // chart must explicitly re-raise them. before the fix, MouseClick and
+    // MouseDoubleClick subscribers on the outer chart never fired.
+    [AppTestMethod]
+    public async Task Chart_should_re_raise_inner_mouse_events()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var control = (System.Windows.Forms.Control)sut.Chart;
+        var fired = new HashSet<string>();
+
+        control.MouseDown += (_, _) => fired.Add("Down");
+        control.MouseMove += (_, _) => fired.Add("Move");
+        control.MouseUp += (_, _) => fired.Add("Up");
+        control.MouseClick += (_, _) => fired.Add("Click");
+        control.MouseDoubleClick += (_, _) => fired.Add("DoubleClick");
+
+        await sut.Chart.RaiseInput(InputKind.Down, 50, 50);
+        await sut.Chart.RaiseInput(InputKind.Move, 50, 51);
+        await sut.Chart.RaiseInput(InputKind.Up, 50, 51);
+        await sut.Chart.RaiseInput(InputKind.Click, 50, 51);
+        await sut.Chart.RaiseInput(InputKind.DoubleClick, 50, 51);
+
+        Assert.Contains("Down", fired);
+        Assert.Contains("Move", fired);
+        Assert.Contains("Up", fired);
+        Assert.Contains("Click", fired);
+        Assert.Contains("DoubleClick", fired);
+    }
+#endif
+}

--- a/tests/SharedUITests/Helpers/InputTesting.cs
+++ b/tests/SharedUITests/Helpers/InputTesting.cs
@@ -1,0 +1,144 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+#if WINFORMS_UI_TESTING
+using System.Reflection;
+using System.Windows.Forms;
+using LiveChartsGeneratedCode;
+#endif
+
+namespace SharedUITests.Helpers;
+
+// these helpers raise mouse-input events on a chart's actual input source
+// (the inner SKControl on WinForms, the MotionCanvas host on XAML platforms,
+// etc.) so contract tests like "the outer chart re-raises MouseClick" cover
+// the real wiring rather than the outer UserControl alone.
+//
+// Factos cannot drive real OS input, so we reflect into the framework's
+// protected OnXxx raisers — those are stable inheritance APIs.
+
+public enum InputKind
+{
+    Move,
+    Down,
+    Up,
+    Click,
+    DoubleClick,
+    Leave
+}
+
+public enum InputButton
+{
+    Left,
+    Right,
+    Middle
+}
+
+public static class InputTesting
+{
+    extension(IChartView chartView)
+    {
+        public Task RaiseInput(
+            InputKind kind,
+            double x,
+            double y,
+            InputButton button = InputButton.Left)
+        {
+#if WINFORMS_UI_TESTING
+            return WinFormsInputRaiser.Raise(chartView, kind, x, y, button);
+#else
+            throw new PlatformNotSupportedException(
+                "InputTesting.RaiseInput is not implemented for this UI host yet.");
+#endif
+        }
+    }
+}
+
+#if WINFORMS_UI_TESTING
+internal static class WinFormsInputRaiser
+{
+    public static Task Raise(
+        IChartView chartView,
+        InputKind kind,
+        double x,
+        double y,
+        InputButton button)
+    {
+        var outer = (Control)chartView;
+        var inner = ((SourceGenChart)chartView).GetDrawnControl();
+
+        var methodName = kind switch
+        {
+            InputKind.Down => "OnMouseDown",
+            InputKind.Move => "OnMouseMove",
+            InputKind.Up => "OnMouseUp",
+            InputKind.Click => "OnMouseClick",
+            InputKind.DoubleClick => "OnMouseDoubleClick",
+            InputKind.Leave => "OnMouseLeave",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+
+        var method = typeof(Control).GetMethod(
+            methodName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        object[] args;
+        if (kind == InputKind.Leave)
+        {
+            args = [EventArgs.Empty];
+        }
+        else
+        {
+            var clicks = kind == InputKind.DoubleClick ? 2 : 1;
+            args =
+            [
+                new MouseEventArgs(MapButton(button), clicks, (int)x, (int)y, 0)
+            ];
+        }
+
+        // Factos test methods don't run on the chart's UI thread, so marshal.
+        var tcs = new TaskCompletionSource<object?>();
+        _ = outer.BeginInvoke(() =>
+        {
+            try
+            {
+                _ = method.Invoke(inner, args);
+                tcs.SetResult(null);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+        return tcs.Task;
+    }
+
+    private static MouseButtons MapButton(InputButton b) => b switch
+    {
+        InputButton.Left => MouseButtons.Left,
+        InputButton.Right => MouseButtons.Right,
+        InputButton.Middle => MouseButtons.Middle,
+        _ => throw new ArgumentOutOfRangeException(nameof(b))
+    };
+}
+#endif


### PR DESCRIPTION
## Summary
- WinForms mouse messages reach the inner `SKControl`, not the outer `CartesianChart` UserControl. `MouseDown`/`MouseMove`/`MouseUp`/`MouseLeave` are already forwarded via `base.OnMouseXxx(e)`, but `MouseClick` and `MouseDoubleClick` were never wired — so subscribing directly on the chart never fired and users had to fall back to `GetDrawnControl()`.
- This PR subscribes the chart to the inner control's `MouseClick`/`MouseDoubleClick` and re-raises them on the outer chart, so all five mouse events now work uniformly without `GetDrawnControl()`.

Fixes #1209.

## Test plan
- [x] Manual: a local repro sample subscribed `MouseDown`/`MouseMove`/`MouseUp`/`MouseClick`/`MouseDoubleClick` directly on `CartesianChart`. Before: only `MouseClick` (and `MouseDoubleClick`) failed to fire. After: all five tick on click and double-click.
- [x] Automated regression coverage to follow once Factos can drive WinForms input events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)