### PR TITLE
fix(maui-mac): keep hover alive after a click on Mac Catalyst (#1436)

### DIFF
--- a/src/_Shared.Native/Platforms/Mac/PointerController.cs
+++ b/src/_Shared.Native/Platforms/Mac/PointerController.cs
@@ -82,7 +82,13 @@ internal partial class PointerController : INativePointerController
     public PointerController()
     {
 #if MACCATALYST
-        _hoverGestureRecognizer = new UIHoverGestureRecognizer(OnHover);
+        _hoverGestureRecognizer = new UIHoverGestureRecognizer(OnHover)
+        {
+            // hover must coexist with the long-press recognizer used for clicks;
+            // otherwise a click forces hover into Cancelled/Failed and tooltips
+            // stop appearing afterwards. See issue #1436.
+            ShouldRecognizeSimultaneously = (g1, g2) => true
+        };
 #endif
         _longPressGestureRecognizer = new UILongPressGestureRecognizer(OnLongPress)
         {
@@ -109,6 +115,7 @@ internal partial class PointerController : INativePointerController
         var view = e.View;
         switch (e.State)
         {
+            case UIGestureRecognizerState.Began:
             case UIGestureRecognizerState.Changed:
                 var p = e.LocationInView(view);
                 Moved?.Invoke(view, new(new(p.X, p.Y), e));
@@ -119,7 +126,6 @@ internal partial class PointerController : INativePointerController
                 Exited?.Invoke(view, new(e));
                 break;
             case UIGestureRecognizerState.Possible:
-            case UIGestureRecognizerState.Began:
             default:
                 break;
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
@@ -20,9 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if UI_TESTING
+
 using System.Runtime.CompilerServices;
 
 // SharedUITests sources are linked into MauiSample when UITesting=true (see
 // build/UITestsLinks.Build.props), so Factos UI tests are compiled into
 // MauiSample.dll and need access to internals such as PointerController.
+// Gated to UI-testing builds so shipped packages do not expose internals.
 [assembly: InternalsVisibleTo("MauiSample")]
+
+#endif

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
@@ -1,0 +1,28 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Runtime.CompilerServices;
+
+// SharedUITests sources are linked into MauiSample when UITesting=true (see
+// build/UITestsLinks.Build.props), so Factos UI tests are compiled into
+// MauiSample.dll and need access to internals such as PointerController.
+[assembly: InternalsVisibleTo("MauiSample")]

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/AssemblyInfo.cs
@@ -20,14 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if UI_TESTING
-
 using System.Runtime.CompilerServices;
 
 // SharedUITests sources are linked into MauiSample when UITesting=true (see
 // build/UITestsLinks.Build.props), so Factos UI tests are compiled into
 // MauiSample.dll and need access to internals such as PointerController.
-// Gated to UI-testing builds so shipped packages do not expose internals.
 [assembly: InternalsVisibleTo("MauiSample")]
-
-#endif

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
@@ -47,6 +47,13 @@
     <DefineConstants>$(DefineConstants);MAUI_LVC;XAML_LVC</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(UITesting) == 'true'">
+    <!-- enables InternalsVisibleTo("MauiSample") in AssemblyInfo.cs so UI tests
+         linked into MauiSample.dll can reach internals such as PointerController.
+         only defined under UITesting builds, keeping shipped packages unaffected. -->
+    <DefineConstants>$(DefineConstants);UI_TESTING</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!--
     hack for:

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
@@ -47,13 +47,6 @@
     <DefineConstants>$(DefineConstants);MAUI_LVC;XAML_LVC</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(UITesting) == 'true'">
-    <!-- enables InternalsVisibleTo("MauiSample") in AssemblyInfo.cs so UI tests
-         linked into MauiSample.dll can reach internals such as PointerController.
-         only defined under UITesting builds, keeping shipped packages unaffected. -->
-    <DefineConstants>$(DefineConstants);UI_TESTING</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup>
     <!--
     hack for:

--- a/tests/SharedUITests/Events/HoverGestureRecognizerTests.cs
+++ b/tests/SharedUITests/Events/HoverGestureRecognizerTests.cs
@@ -43,9 +43,10 @@ public class HoverGestureRecognizerTests
     {
         var controller = new PointerController();
         var hover = GetHoverRecognizer(controller);
+        var longPress = GetLongPressRecognizer(controller);
 
         Assert.NotNull(hover.ShouldRecognizeSimultaneously);
-        Assert.True(hover.ShouldRecognizeSimultaneously(hover, hover));
+        Assert.True(hover.ShouldRecognizeSimultaneously(hover, longPress));
 
         return Task.CompletedTask;
     }
@@ -79,6 +80,14 @@ public class HoverGestureRecognizerTests
             "_hoverGestureRecognizer", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(field);
         return (UIHoverGestureRecognizer)field!.GetValue(controller)!;
+    }
+
+    private static UILongPressGestureRecognizer GetLongPressRecognizer(PointerController controller)
+    {
+        var field = typeof(PointerController).GetField(
+            "_longPressGestureRecognizer", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        return (UILongPressGestureRecognizer)field!.GetValue(controller)!;
     }
 
     private sealed class FakeHoverGestureRecognizer : UIHoverGestureRecognizer

--- a/tests/SharedUITests/Events/HoverGestureRecognizerTests.cs
+++ b/tests/SharedUITests/Events/HoverGestureRecognizerTests.cs
@@ -1,0 +1,92 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if MAUI_UI_TESTING && MACCATALYST
+
+using System.Reflection;
+using Factos;
+using LiveChartsCore.Native;
+using UIKit;
+using Xunit;
+
+namespace SharedUITests.Events;
+
+public class HoverGestureRecognizerTests
+{
+    public AppController App => AppController.Current;
+
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1436
+    // on Mac Catalyst the hover recognizer must coexist with the long-press
+    // recognizer used for clicks. Without simultaneous recognition, a click
+    // forces hover into Cancelled/Failed and tooltips stop showing afterwards.
+    [AppTestMethod]
+    public Task HoverRecognizer_AllowsSimultaneousRecognitionWithLongPress()
+    {
+        var controller = new PointerController();
+        var hover = GetHoverRecognizer(controller);
+
+        Assert.NotNull(hover.ShouldRecognizeSimultaneously);
+        Assert.True(hover.ShouldRecognizeSimultaneously(hover, hover));
+
+        return Task.CompletedTask;
+    }
+
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1436
+    // when the hover gesture restarts (e.g. after a click), the first sample
+    // arrives in Began state. OnHover must treat Began like Changed and raise
+    // Moved, otherwise the tooltip won't reappear until the cursor leaves and
+    // re-enters the chart.
+    [AppTestMethod]
+    public Task OnHover_RaisesMovedOnBeganState()
+    {
+        var controller = new PointerController();
+        var onHover = typeof(PointerController).GetMethod(
+            "OnHover", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(onHover);
+
+        var movedFired = false;
+        controller.Moved += (_, _) => movedFired = true;
+
+        var fake = new FakeHoverGestureRecognizer { FakeState = UIGestureRecognizerState.Began };
+        onHover!.Invoke(controller, [fake]);
+
+        Assert.True(movedFired);
+        return Task.CompletedTask;
+    }
+
+    private static UIHoverGestureRecognizer GetHoverRecognizer(PointerController controller)
+    {
+        var field = typeof(PointerController).GetField(
+            "_hoverGestureRecognizer", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+        return (UIHoverGestureRecognizer)field!.GetValue(controller)!;
+    }
+
+    private sealed class FakeHoverGestureRecognizer : UIHoverGestureRecognizer
+    {
+        public FakeHoverGestureRecognizer() : base(_ => { }) { }
+        public UIGestureRecognizerState FakeState { get; set; }
+        public override UIGestureRecognizerState State => FakeState;
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Fixes [#1436](https://github.com/Live-Charts/LiveCharts2/issues/1436): on Mac Catalyst, after the first click on a chart surface, tooltips stop appearing.

Two small changes in `src/_Shared.Native/Platforms/Mac/PointerController.cs`:

- **Allow simultaneous recognition** between the hover and long-press gesture recognizers. Without it, the long-press (used for clicks) wins exclusively and forces hover into `Cancelled`/`Failed`, after which UIKit silently stops delivering hover updates.
- **Treat `Began` like `Changed`** in `OnHover`. When hover restarts (e.g. after a click), the first sample arrives in `Began` state — previously dropped on the floor, so the tooltip wouldn't reappear until the cursor left and re-entered the chart.

## Test plan

Two Mac-only Factos tests in `tests/SharedUITests/Events/HoverGestureRecognizerTests.cs`, gated by `MAUI_UI_TESTING && MACCATALYST`:

- [x] `HoverRecognizer_AllowsSimultaneousRecognitionWithLongPress` — asserts `ShouldRecognizeSimultaneously` is wired and returns `true`.
- [x] `OnHover_RaisesMovedOnBeganState` — invokes the private `OnHover` with a fake `Began`-state recognizer and asserts `Moved` fires.
- [x] Both tests verified to **fail** when their respective fix is reverted, and **pass** with the fix applied (12/12 green on macOS 26.1, .NET 10.0.203, Xcode 26.1.1).
- [x] Windows MAUI build still clean (no regressions on non-Mac targets — fix and tests are guarded by `#if MACCATALYST`).

`InternalsVisibleTo("MauiSample")` is added on `LiveChartsCore.SkiaSharpView.Maui` because `SharedUITests` sources are linked into `MauiSample` at build time (see `build/UITestsLinks.Build.props`), so the test code lives in `MauiSample.dll` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)