### PR TITLE
test(avalonia): Factos regression for #1417 GeoMap tab detach/reattach

### DIFF
--- a/samples/AvaloniaSample/VisualTest/Issue1417Repro/View.axaml
+++ b/samples/AvaloniaSample/VisualTest/Issue1417Repro/View.axaml
@@ -1,0 +1,38 @@
+<UserControl
+    x:Class="AvaloniaSample.VisualTest.Issue1417Repro.View"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+    xmlns:vms="using:ViewModelsSamples.Maps.World"
+    x:DataType="vms:ViewModel">
+
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+
+    <!--
+        Reproducer for https://github.com/Live-Charts/LiveCharts2/issues/1417
+
+        Steps to reproduce:
+        1. Tab 1 hosts a GeoMap, Tab 2 hosts plain content.
+        2. Switching to Tab 2 detaches the GeoMap from the visual tree (Unload).
+        3. Switching back to Tab 1 re-attaches it (must Load); before the fix the
+           chart came back blank, and any further detach NRE'd at
+           _mapFactory.Dispose() because Unload was not idempotent.
+    -->
+
+    <TabControl x:Name="tabs">
+        <TabItem Header="Tab 1 (GeoMap)">
+            <lvc:GeoMap
+                x:Name="geoMap"
+                Series="{Binding Series}"
+                MapProjection="Mercator"/>
+        </TabItem>
+        <TabItem Header="Tab 2 (no chart)">
+            <TextBlock
+                Margin="16"
+                Text="Switching here detaches the GeoMap from the visual tree."/>
+        </TabItem>
+    </TabControl>
+
+</UserControl>

--- a/samples/AvaloniaSample/VisualTest/Issue1417Repro/View.axaml.cs
+++ b/samples/AvaloniaSample/VisualTest/Issue1417Repro/View.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using LiveChartsCore.SkiaSharpView.Avalonia;
+
+namespace AvaloniaSample.VisualTest.Issue1417Repro;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public GeoMap Chart => this.Find<GeoMap>("geoMap")!;
+    public void OpenTab1() => this.Find<TabControl>("tabs")!.SelectedIndex = 0;
+    public void OpenTab2() => this.Find<TabControl>("tabs")!.SelectedIndex = 1;
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/tests/SharedUITests/MapChartTests.cs
+++ b/tests/SharedUITests/MapChartTests.cs
@@ -21,4 +21,32 @@ public class MapChartTests
 
         Assert.ChartIsLoaded(chart);
     }
+
+#if AVALONIA_UI_TESTING
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1417
+    // a GeoMap inside a TabControl crashed on the second tab switch (NRE in
+    // GeoMapChart.Unload at _mapFactory.Dispose) and rendered blank on
+    // re-attach. covers the lifecycle: detach -> attach -> detach -> attach.
+    [AppTestMethod]
+    public async Task GeoMap_should_survive_repeated_tab_switches()
+    {
+        var sut = await App.NavigateTo<Samples.VisualTest.Issue1417Repro.View>();
+        await sut.Chart.WaitUntilChartRenders();
+        Assert.ChartIsLoaded(sut.Chart);
+
+        // away (Unload) -> back (Load): chart must render again, not stay blank.
+        sut.OpenTab2();
+        await Task.Delay(500);
+        sut.OpenTab1();
+        await sut.Chart.WaitUntilChartRenders();
+        Assert.ChartIsLoaded(sut.Chart);
+
+        // second cycle: pre-fix, this Unload NRE'd because it wasn't idempotent.
+        sut.OpenTab2();
+        await Task.Delay(500);
+        sut.OpenTab1();
+        await sut.Chart.WaitUntilChartRenders();
+        Assert.ChartIsLoaded(sut.Chart);
+    }
+#endif
 }


### PR DESCRIPTION
Follow-up to PR #2189 (issue #1417). Replaces the manual smoke-test step in
that PR's plan with an automated Factos regression.

## Summary

- New Avalonia sample `VisualTest/Issue1417Repro` — a `TabControl` whose first
  tab hosts the world `GeoMap` and whose second tab is plain content. Toggling
  `SelectedIndex` drives the same `DetachedFromVisualTree` / `AttachedToVisualTree`
  cycle the original bug report described.
- New shared UI test `MapChartTests.GeoMap_should_survive_repeated_tab_switches`,
  guarded by `AVALONIA_UI_TESTING`, that walks Tab1 → Tab2 → Tab1 → Tab2 → Tab1
  and asserts the chart is loaded after each re-attach. Pre-fix this NRE'd in
  `GeoMapChart.Unload` at `_mapFactory.Dispose` on the second detach.

The sample/test split follows the Issue1986Repro precedent (`88dcc5687` /
`4db90d2f6`).

## Test plan

- [x] `dotnet build samples/AvaloniaSample/AvaloniaSample.csproj -p:UITesting=true` clean
- [x] `dotnet build tests/UITests/UITests.csproj` clean
- [ ] Avalonia desktop UI suite green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)