### PR TITLE
ci: restore code-coverage block in PR comments

### DIFF
--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -182,8 +182,8 @@ function buildCoverageBlock({ summary, oldClasses, newClasses, reportUrl }) {
     const out = new Map();
     const assemblies = s?.coverage?.assemblies || [];
     for (const a of assemblies) {
-      for (const c of (a.classes || [])) {
-        out.set(`${a.name} / ${c.name}`, c.linecoverage);
+      for (const c of (a.classesinassembly || [])) {
+        out.set(`${a.name} / ${c.name}`, c.coverage);
       }
     }
     return out;


### PR DESCRIPTION
## Summary

- `buildCoverageBlock` was iterating `a.classes` (a number — count of classes, e.g. `191`) instead of `a.classesinassembly` (the actual array), throwing `TypeError: number is not iterable` on every PR.
- The outer `try/catch` in `pr-comment.yml` swallowed the throw, so the entire **#### Code Coverage** block silently disappeared from PR comments — no visible failure in the workflow logs, no PR-level signal.
- Per-class line coverage was also reading `c.linecoverage` (does not exist); should be `c.coverage`.

Regression from 70350b8a3 (PR #2176, "ci: collapse coverage in PR comment with per-class diff" — April 26). Coverage was visible on PRs #2170/#2172/#2173 and silent on every PR thereafter.

Verified end-to-end by running the script locally against the real `coverage-summary` artifact from PR #2193's run — the **#### Code Coverage** header, the before/after table, and the per-class diff all render as designed.

## Test plan

- [ ] PR comment on this PR shows a `#### Code Coverage` block (this is the live test — the script runs once this PR's LiveCharts run finishes).
- [ ] Block contains the before/after table.
- [ ] If the badges branch has a baseline `Summary.json`, the per-class diff table appears too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)