### PR TITLE
fix(maui): derive pixel density per-paint to track active display (#1523)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/RenderScale.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/RenderScale.cs
@@ -1,0 +1,33 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.SkiaSharpView.Drawing;
+
+internal static class RenderScale
+{
+    // Pixels-per-DIP for a paint, derived from the surface size SkiaSharp gives us
+    // and the view's logical width. Used by backends that, unlike WPF/WinUI, do not
+    // expose a per-visual scale and would otherwise fall back to a global "main
+    // display" density that is wrong on extended monitors (issue #1523).
+    public static float PixelDensityFromSurface(int surfacePixelWidth, double viewDipWidth) =>
+        viewDipWidth > 0 ? (float)(surfacePixelWidth / viewDipWidth) : 1f;
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/CPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/CPURenderMode.cs
@@ -20,11 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using Microsoft.Maui.Devices;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
@@ -34,7 +32,6 @@ namespace LiveChartsCore.SkiaSharpView.Maui.Rendering;
 internal class CPURenderMode : SKCanvasView, IRenderMode
 {
     private CoreMotionCanvas _canvas = null!;
-    private float _pixelDensity = 1;
 
     public event CoreMotionCanvas.FrameRequestHandler? FrameRequest;
 
@@ -43,9 +40,6 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
         _canvas = canvas;
         PaintSurface += OnPaintSurface;
 
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
-        DeviceDisplay.MainDisplayInfoChanged += MainDisplayInfoChanged;
-
         CoreMotionCanvas.s_rendererName = $"{nameof(CPURenderMode)} and {nameof(SKCanvasView)}";
     }
 
@@ -53,7 +47,6 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
     {
         _canvas = null!;
         PaintSurface -= OnPaintSurface;
-        DeviceDisplay.MainDisplayInfoChanged -= MainDisplayInfoChanged;
     }
 
     public void InvalidateRenderer() =>
@@ -61,15 +54,16 @@ internal class CPURenderMode : SKCanvasView, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
     {
-        if (_pixelDensity != 1)
-            args.Surface.Canvas.Scale(_pixelDensity, _pixelDensity);
+        // Derive scale from the actual surface every paint: this tracks the
+        // display the window is currently on, including extended monitors with
+        // a different scale than the main display (issue #1523).
+        var density = RenderScale.PixelDensityFromSurface(args.Info.Width, Width);
+        if (density != 1)
+            args.Surface.Canvas.Scale(density, density);
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, args.Surface.Canvas, GetBackground()));
     }
-
-    private void MainDisplayInfoChanged(object? sender, EventArgs e) =>
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
 
     private SKColor GetBackground() =>
         (Parent?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/GPURenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/Rendering/GPURenderMode.cs
@@ -20,11 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView.Drawing;
-using Microsoft.Maui.Devices;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
@@ -34,7 +32,6 @@ namespace LiveChartsCore.SkiaSharpView.Maui.Rendering;
 internal class GPURenderMode : SKGLView, IRenderMode
 {
     private CoreMotionCanvas _canvas = null!;
-    private float _pixelDensity = 1;
 
     public event CoreMotionCanvas.FrameRequestHandler? FrameRequest;
 
@@ -43,9 +40,6 @@ internal class GPURenderMode : SKGLView, IRenderMode
         _canvas = canvas;
         PaintSurface += OnPaintSurface;
 
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
-        DeviceDisplay.MainDisplayInfoChanged += MainDisplayInfoChanged;
-
         CoreMotionCanvas.s_rendererName = $"{nameof(GPURenderMode)} and {nameof(SKGLView)}";
     }
 
@@ -53,7 +47,6 @@ internal class GPURenderMode : SKGLView, IRenderMode
     {
         _canvas = null!;
         PaintSurface -= OnPaintSurface;
-        DeviceDisplay.MainDisplayInfoChanged -= MainDisplayInfoChanged;
     }
 
     public void InvalidateRenderer() =>
@@ -61,15 +54,16 @@ internal class GPURenderMode : SKGLView, IRenderMode
 
     private void OnPaintSurface(object? sender, SKPaintGLSurfaceEventArgs e)
     {
-        if (_pixelDensity != 1)
-            e.Surface.Canvas.Scale(_pixelDensity, _pixelDensity);
+        // Derive scale from the actual surface every paint: this tracks the
+        // display the window is currently on, including extended monitors with
+        // a different scale than the main display (issue #1523).
+        var density = RenderScale.PixelDensityFromSurface(e.Info.Width, Width);
+        if (density != 1)
+            e.Surface.Canvas.Scale(density, density);
 
         FrameRequest?.Invoke(
             new SkiaSharpDrawingContext(_canvas, e.Surface.Canvas, GetBackground()));
     }
-
-    private void MainDisplayInfoChanged(object? sender, EventArgs e) =>
-        _pixelDensity = (float)DeviceDisplay.MainDisplayInfo.Density;
 
     private SKColor GetBackground() =>
         (Parent?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/tests/CoreTests/OtherTests/RenderScaleTests.cs
+++ b/tests/CoreTests/OtherTests/RenderScaleTests.cs
@@ -1,0 +1,36 @@
+using LiveChartsCore.SkiaSharpView.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+// Regression coverage for issue #1523: Maui CPU/GPU render modes used to cache
+// DeviceDisplay.MainDisplayInfo.Density at init and only refresh it when the
+// MAIN display info changed. Moving the window to an extended display with a
+// different scale produced misscaled output. The fix derives the per-paint
+// scale from the surface SkiaSharp gives us, via this helper.
+[TestClass]
+public class RenderScaleTests
+{
+    [TestMethod]
+    public void PixelDensityFromSurface_returns_one_when_view_not_yet_sized()
+    {
+        // Before first layout the view's DIP width can be 0 or -1 (Maui default).
+        // We must not produce 0 or a negative scale — the canvas would collapse.
+        Assert.AreEqual(1f, RenderScale.PixelDensityFromSurface(800, 0));
+        Assert.AreEqual(1f, RenderScale.PixelDensityFromSurface(800, -1));
+    }
+
+    [TestMethod]
+    public void PixelDensityFromSurface_matches_actual_surface_to_view_ratio()
+    {
+        // 800px surface for a 400-DIP view means the OS is rendering at 2x.
+        Assert.AreEqual(2f, RenderScale.PixelDensityFromSurface(800, 400));
+
+        // 1000px / 400dip = 2.5x (e.g. external monitor with non-integer scale,
+        // exactly the case from issue #1523 that the cached MainDisplayInfo path missed).
+        Assert.AreEqual(2.5f, RenderScale.PixelDensityFromSurface(1000, 400));
+
+        // 1x display: surface and DIP sizes match.
+        Assert.AreEqual(1f, RenderScale.PixelDensityFromSurface(400, 400));
+    }
+}


### PR DESCRIPTION
## Summary
- Maui CPU/GPU render modes used to cache `DeviceDisplay.MainDisplayInfo.Density` at init and only refresh on `MainDisplayInfoChanged`. That handler fires when the *main* display info changes, not when the window moves between displays — so on Mac, dragging to an extended monitor with a different scale produced misscaled output (issue #1523).
- Drop `DeviceDisplay` entirely and compute density each paint from the surface SkiaSharp gives us (`args.Info.Width / Width`). Mirrors what WPF (`PresentationSource.TransformToDevice`) and WinUI (`XamlRoot.RasterizationScale`) already do via per-visual scale APIs.
- Formula extracted to a small helper in `LiveChartsCore.SkiaSharpView.Drawing.RenderScale` so it's reachable from CoreTests and reusable from any other backend that hits the same problem.

Fixes #1523.

## Test plan
- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj` — clean across all 9 Maui TFMs (net9.0 / net10.0 × plain / android / ios / maccatalyst / windows), 0 warnings
- [x] `dotnet test --project tests/CoreTests/CoreTests.csproj --framework net8.0` — 476 passed (incl. 2 new `RenderScaleTests`)
- [ ] Manual Mac verification: run a MAUI sample, drag the window to an extended display with a different scale, confirm the chart re-renders at the correct scale instead of jumping/misscaling

> Note: the regression test is a contract guard for the formula, not a fail-on-revert test — the renderer harness can't be exercised without a real Maui multi-monitor app. Flagged in the test commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)