### PR TITLE
fix(scaler): zero both m and mInv when either is non-finite (#1533)

### DIFF
--- a/src/LiveChartsCore/Measure/Scaler.cs
+++ b/src/LiveChartsCore/Measure/Scaler.cs
@@ -84,7 +84,8 @@ public class Scaler
         _m = _deltaPx / _deltaVal;
         _mInv = 1 / _m;
 
-        if (double.IsFinite(_m) && double.IsFinite(_mInv)) return;
+        if (!double.IsNaN(_m) && !double.IsInfinity(_m) &&
+            !double.IsNaN(_mInv) && !double.IsInfinity(_mInv)) return;
         _m = 0;
         _mInv = 0;
     }

--- a/src/LiveChartsCore/Measure/Scaler.cs
+++ b/src/LiveChartsCore/Measure/Scaler.cs
@@ -84,7 +84,7 @@ public class Scaler
         _m = _deltaPx / _deltaVal;
         _mInv = 1 / _m;
 
-        if (!double.IsNaN(_m) && !double.IsInfinity(_m)) return;
+        if (double.IsFinite(_m) && double.IsFinite(_mInv)) return;
         _m = 0;
         _mInv = 0;
     }

--- a/tests/CoreTests/OtherTests/ScaleFunctionsTests.cs
+++ b/tests/CoreTests/OtherTests/ScaleFunctionsTests.cs
@@ -268,4 +268,36 @@ public class ScaleFunctionsTests
             Math.Abs(d33.X - 2) < 0.01 &&
             Math.Abs(d33.Y - 2) < 0.01);
     }
+
+    // Regression for issue #1533: when the draw margin collapses (here, the
+    // explicit DrawMargin's left + right equal the chart width, so the scaler's
+    // pixel delta is 0), ScalePixelsToData must still return finite values.
+    // Otherwise the user-side range math (e.g. positionInData.X - range/2 in
+    // the scrollbar/sections sample) propagates ±Infinity into the section's
+    // Xi/Xj, which then turns into NaN on the next tick (Inf - Inf) and the
+    // section freezes.
+    [TestMethod]
+    public void CartesianScale_ZeroWidthDrawMargin_ReturnsFiniteValues()
+    {
+        var chart = new SKCartesianChart
+        {
+            Width = 150,
+            Height = 100,
+            DrawMargin = new Margin(100, Margin.Auto, 50, Margin.Auto),
+            XAxes = [new Axis { MinLimit = 0, MaxLimit = 100 }],
+            Series = [new LineSeries<double> { Values = [1d, 2d, 3d] }]
+        };
+
+        _ = chart.GetImage();
+
+        var loc = chart.CoreChart.DrawMarginLocation;
+
+        var atMinPx = chart.ScalePixelsToData(new LvcPointD(loc.X, loc.Y));
+        var awayFromMinPx = chart.ScalePixelsToData(new LvcPointD(loc.X + 50, loc.Y));
+
+        Assert.IsTrue(double.IsFinite(atMinPx.X) && double.IsFinite(atMinPx.Y),
+            $"ScalePixelsToData at _minPx returned ({atMinPx.X}, {atMinPx.Y})");
+        Assert.IsTrue(double.IsFinite(awayFromMinPx.X) && double.IsFinite(awayFromMinPx.Y),
+            $"ScalePixelsToData away from _minPx returned ({awayFromMinPx.X}, {awayFromMinPx.Y})");
+    }
 }

--- a/tests/CoreTests/OtherTests/ScaleFunctionsTests.cs
+++ b/tests/CoreTests/OtherTests/ScaleFunctionsTests.cs
@@ -295,9 +295,11 @@ public class ScaleFunctionsTests
         var atMinPx = chart.ScalePixelsToData(new LvcPointD(loc.X, loc.Y));
         var awayFromMinPx = chart.ScalePixelsToData(new LvcPointD(loc.X + 50, loc.Y));
 
-        Assert.IsTrue(double.IsFinite(atMinPx.X) && double.IsFinite(atMinPx.Y),
+        Assert.IsTrue(IsFinite(atMinPx.X) && IsFinite(atMinPx.Y),
             $"ScalePixelsToData at _minPx returned ({atMinPx.X}, {atMinPx.Y})");
-        Assert.IsTrue(double.IsFinite(awayFromMinPx.X) && double.IsFinite(awayFromMinPx.Y),
+        Assert.IsTrue(IsFinite(awayFromMinPx.X) && IsFinite(awayFromMinPx.Y),
             $"ScalePixelsToData away from _minPx returned ({awayFromMinPx.X}, {awayFromMinPx.Y})");
+
+        static bool IsFinite(double v) => !double.IsNaN(v) && !double.IsInfinity(v);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1533 — "Section UI is Frozen on Chart" after fast drag.

Root cause is in `Scaler` (`src/LiveChartsCore/Measure/Scaler.cs`). The degenerate-state guard only checked `_m`, so a zero-width draw margin (`_deltaPx = 0` with finite `_deltaVal`) yielded `_m = 0` (finite, guard passes) but `_mInv = 1/0 = +Infinity` and leaked upstream. `ScalePixelsToData` then returned NaN at the left/top edge and ±Infinity elsewhere — and the issue's scrollbar/sections math turned that into `Inf − Inf = NaN` on the next tick, which `CoreSection.Xi/Xj`'s NaN filter then mapped to `null`. From that point `null − null = null` so the user's drag math became a permanent no-op and the thumb stopped responding — the visible "freeze".

The fix switches the guard to `IsFinite` on both `_m` and `_mInv`, keeping the existing fallback (scaler collapses to constants) without leaking infinities.

- `test(scaler)`: regression for `ScalePixelsToData` returning finite values when `DrawMargin.Left + Right == ControlSize.Width` (zero-width draw margin). Fails on master with `(NaN, 3)`; passes with the fix.
- `fix(scaler)`: one-line guard change.

## Test plan
- [x] `dotnet test tests/CoreTests/CoreTests.csproj --framework net8.0` (477/477 pass)
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj` (121/121 pass)
- [x] New regression test verified by reverting the fix (still fails on master commit `48b45d0d4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)