### PR TITLE
fix(charts): release drag state on lost pointer capture (#1576)

### DIFF
--- a/src/_Shared.Native/Events/PressedEventArgs.cs
+++ b/src/_Shared.Native/Events/PressedEventArgs.cs
@@ -35,9 +35,36 @@ namespace LiveChartsCore.Native.Events;
 /// <param name="originalEvent">The original event.</param>
 public class PressedEventArgs(LvcPoint location, bool isSecondaryPress, object originalEvent) : ScreenEventArgs(location, originalEvent)
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PressedEventArgs"/> class with
+    /// an explicit <paramref name="isSyntheticRelease"/> flag.
+    /// </summary>
+    /// <param name="location">The pointer location.</param>
+    /// <param name="isSecondaryPress">Indicates whether the action is secondary.</param>
+    /// <param name="isSyntheticRelease">
+    /// True when the release is not produced by a real user gesture but synthesized
+    /// by the chart (e.g. when an ancestor steals pointer capture mid-drag and the
+    /// chart needs to release its internal pan/drag state). Public release commands
+    /// (PointerReleasedCommand) should ignore synthetic releases since the user has
+    /// not actually lifted the pointer.
+    /// </param>
+    /// <param name="originalEvent">The original event.</param>
+    public PressedEventArgs(LvcPoint location, bool isSecondaryPress, bool isSyntheticRelease, object originalEvent)
+        : this(location, isSecondaryPress, originalEvent)
+    {
+        IsSyntheticRelease = isSyntheticRelease;
+    }
 
     /// <summary>
     /// Gets a value indicating whether the action is a secondary press.
     /// </summary>
     public bool IsSecondaryPress { get; } = isSecondaryPress;
+
+    /// <summary>
+    /// Gets a value indicating whether this release was synthesized by the chart
+    /// rather than produced by a real user gesture (e.g. raised on pointer capture
+    /// loss so internal pan/drag state can be released). Consumers of public release
+    /// hooks such as PointerReleasedCommand should skip synthetic releases.
+    /// </summary>
+    public bool IsSyntheticRelease { get; }
 }

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
@@ -37,6 +37,8 @@ namespace LiveChartsCore.Native;
 internal partial class PointerController : INativePointerController
 {
     private bool _isPinching;
+    private bool _isPointerDown;
+    private LiveChartsCore.Drawing.LvcPoint _lastPointerPosition;
     private DateTime _pressedTime;
 
     public void InitializeController(object view)
@@ -46,6 +48,7 @@ internal partial class PointerController : INativePointerController
         winUIView.PointerPressed += OnUnoSkiaPointerPressed;
         winUIView.PointerMoved += OnUnoSkiaPointerMoved;
         winUIView.PointerReleased += OnUnoSkiaPointerReleased;
+        winUIView.PointerCaptureLost += OnUnoSkiaPointerCaptureLost;
         winUIView.PointerWheelChanged += OnUnoSkiaPointerWheelChanged;
         winUIView.PointerExited += OnUnoSkiaPointerExited;
 
@@ -62,6 +65,7 @@ internal partial class PointerController : INativePointerController
         winUIView.PointerPressed -= OnUnoSkiaPointerPressed;
         winUIView.PointerMoved -= OnUnoSkiaPointerMoved;
         winUIView.PointerReleased -= OnUnoSkiaPointerReleased;
+        winUIView.PointerCaptureLost -= OnUnoSkiaPointerCaptureLost;
         winUIView.PointerWheelChanged -= OnUnoSkiaPointerWheelChanged;
         winUIView.PointerExited -= OnUnoSkiaPointerExited;
 
@@ -81,9 +85,12 @@ internal partial class PointerController : INativePointerController
         _ = element.CapturePointer(e.Pointer);
 #endif
 
+        _isPointerDown = true;
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Pressed?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
 
         _pressedTime = DateTime.Now;
     }
@@ -96,9 +103,11 @@ internal partial class PointerController : INativePointerController
         var p = e.GetCurrentPoint(sender as UIElement);
         if (p is null) return;
 
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Moved?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), e));
+            new(_lastPointerPosition, e));
     }
 
     private void OnUnoSkiaPointerReleased(object sender, PointerRoutedEventArgs e)
@@ -112,9 +121,24 @@ internal partial class PointerController : INativePointerController
         element.ReleasePointerCapture(element.PointerCaptures[0]);
 #endif
 
+        _isPointerDown = false;
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Released?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
+    }
+
+    // See #1576: when an ancestor re-captures the pointer mid-gesture, the chart
+    // never receives PointerReleased. Treat capture loss as a synthetic release.
+    private void OnUnoSkiaPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isPointerDown) return;
+        _isPointerDown = false;
+
+        Released?.Invoke(
+            sender,
+            new(_lastPointerPosition, false, e));
     }
 
     private void OnUnoSkiaPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
@@ -38,6 +38,10 @@ internal partial class PointerController : INativePointerController
 {
     private bool _isPinching;
     private bool _isPointerDown;
+    // Remember the original press's button so the synthetic release we raise on
+    // PointerCaptureLost reports the same button (right-click drags interrupted by
+    // an ancestor capture-steal must not be reported as a primary-button release).
+    private bool _wasSecondaryPress;
     private LiveChartsCore.Drawing.LvcPoint _lastPointerPosition;
     private DateTime _pressedTime;
 
@@ -86,11 +90,12 @@ internal partial class PointerController : INativePointerController
 #endif
 
         _isPointerDown = true;
+        _wasSecondaryPress = p.Properties.IsRightButtonPressed;
         _lastPointerPosition = new(p.Position.X, p.Position.Y);
 
         Pressed?.Invoke(
             sender,
-            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, _wasSecondaryPress, e));
 
         _pressedTime = DateTime.Now;
     }
@@ -138,7 +143,7 @@ internal partial class PointerController : INativePointerController
 
         Released?.Invoke(
             sender,
-            new(_lastPointerPosition, false, e));
+            new(_lastPointerPosition, _wasSecondaryPress, e));
     }
 
     private void OnUnoSkiaPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
@@ -141,9 +141,12 @@ internal partial class PointerController : INativePointerController
         if (!_isPointerDown) return;
         _isPointerDown = false;
 
+        // Mark this Released as synthetic so the shared OnReleased handler skips
+        // PointerReleasedCommand: the user is still holding the button; we are
+        // raising this only so the core chart can release its pan/drag state.
         Released?.Invoke(
             sender,
-            new(_lastPointerPosition, _wasSecondaryPress, e));
+            new(_lastPointerPosition, _wasSecondaryPress, isSyntheticRelease: true, e));
     }
 
     private void OnUnoSkiaPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/_Shared.Native/Platforms/WinUI/PointerController.cs
+++ b/src/_Shared.Native/Platforms/WinUI/PointerController.cs
@@ -33,6 +33,8 @@ namespace LiveChartsCore.Native;
 internal partial class PointerController : INativePointerController
 {
     private bool _isPinching;
+    private bool _isPointerDown;
+    private LiveChartsCore.Drawing.LvcPoint _lastPointerPosition;
     private DateTime _pressedTime;
 
     public void InitializeController(object view)
@@ -42,6 +44,7 @@ internal partial class PointerController : INativePointerController
         winUIView.PointerPressed += OnWindowsPointerPressed;
         winUIView.PointerMoved += OnWindowsPointerMoved;
         winUIView.PointerReleased += OnWindowsPointerReleased;
+        winUIView.PointerCaptureLost += OnWindowsPointerCaptureLost;
         winUIView.PointerWheelChanged += OnWindowsPointerWheelChanged;
         winUIView.PointerExited += OnWindowsPointerExited;
 
@@ -58,6 +61,7 @@ internal partial class PointerController : INativePointerController
         winUIView.PointerPressed -= OnWindowsPointerPressed;
         winUIView.PointerMoved -= OnWindowsPointerMoved;
         winUIView.PointerReleased -= OnWindowsPointerReleased;
+        winUIView.PointerCaptureLost -= OnWindowsPointerCaptureLost;
         winUIView.PointerWheelChanged -= OnWindowsPointerWheelChanged;
         winUIView.PointerExited -= OnWindowsPointerExited;
 
@@ -77,9 +81,12 @@ internal partial class PointerController : INativePointerController
         _ = element.CapturePointer(e.Pointer);
 #endif
 
+        _isPointerDown = true;
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Pressed?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
 
         _pressedTime = DateTime.Now;
     }
@@ -92,9 +99,11 @@ internal partial class PointerController : INativePointerController
         var p = e.GetCurrentPoint(sender as UIElement);
         if (p is null) return;
 
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Moved?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), e));
+            new(_lastPointerPosition, e));
     }
 
     private void OnWindowsPointerReleased(object sender, PointerRoutedEventArgs e)
@@ -108,9 +117,26 @@ internal partial class PointerController : INativePointerController
         element.ReleasePointerCapture(element.PointerCaptures[0]);
 #endif
 
+        _isPointerDown = false;
+        _lastPointerPosition = new(p.Position.X, p.Position.Y);
+
         Released?.Invoke(
             sender,
-            new(new(p.Position.X, p.Position.Y), p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
+    }
+
+    // When an ancestor (e.g. a button wrapping the chart, see #1576) calls
+    // CapturePointer mid-gesture, capture is transferred away from the chart and
+    // PointerReleased is then routed to the ancestor; the chart never sees it and
+    // pan/drag state stays armed. Treat capture loss as a synthetic release.
+    private void OnWindowsPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_isPointerDown) return;
+        _isPointerDown = false;
+
+        Released?.Invoke(
+            sender,
+            new(_lastPointerPosition, false, e));
     }
 
     private void OnWindowsPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/_Shared.Native/Platforms/WinUI/PointerController.cs
+++ b/src/_Shared.Native/Platforms/WinUI/PointerController.cs
@@ -139,9 +139,12 @@ internal partial class PointerController : INativePointerController
         if (!_isPointerDown) return;
         _isPointerDown = false;
 
+        // Mark this Released as synthetic so the shared OnReleased handler skips
+        // PointerReleasedCommand: the user is still holding the button; we are
+        // raising this only so the core chart can release its pan/drag state.
         Released?.Invoke(
             sender,
-            new(_lastPointerPosition, _wasSecondaryPress, e));
+            new(_lastPointerPosition, _wasSecondaryPress, isSyntheticRelease: true, e));
     }
 
     private void OnWindowsPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/_Shared.Native/Platforms/WinUI/PointerController.cs
+++ b/src/_Shared.Native/Platforms/WinUI/PointerController.cs
@@ -34,6 +34,10 @@ internal partial class PointerController : INativePointerController
 {
     private bool _isPinching;
     private bool _isPointerDown;
+    // Remember the original press's button so the synthetic release we raise on
+    // PointerCaptureLost reports the same button (right-click drags interrupted by
+    // an ancestor capture-steal must not be reported as a primary-button release).
+    private bool _wasSecondaryPress;
     private LiveChartsCore.Drawing.LvcPoint _lastPointerPosition;
     private DateTime _pressedTime;
 
@@ -82,11 +86,12 @@ internal partial class PointerController : INativePointerController
 #endif
 
         _isPointerDown = true;
+        _wasSecondaryPress = p.Properties.IsRightButtonPressed;
         _lastPointerPosition = new(p.Position.X, p.Position.Y);
 
         Pressed?.Invoke(
             sender,
-            new(_lastPointerPosition, p.Properties.IsRightButtonPressed, e));
+            new(_lastPointerPosition, _wasSecondaryPress, e));
 
         _pressedTime = DateTime.Now;
     }
@@ -136,7 +141,7 @@ internal partial class PointerController : INativePointerController
 
         Released?.Invoke(
             sender,
-            new(_lastPointerPosition, false, e));
+            new(_lastPointerPosition, _wasSecondaryPress, e));
     }
 
     private void OnWindowsPointerWheelChanged(object sender, PointerRoutedEventArgs e)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
@@ -140,6 +140,15 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
         if (e.KeyModifiers > 0) return;
         var p = e.GetPosition(this);
 
+        // Arm _isPointerDown BEFORE invoking the user's command. If the command
+        // synchronously transfers capture (e.g. focuses or captures another
+        // element) Avalonia raises PointerCaptureLost immediately, and the
+        // recovery handler must observe the flag set so it can synthesize a
+        // pointer-up. Otherwise the chart is left in the same stuck-drag state
+        // #1576 fixes.
+        _isPointerDown = true;
+        _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
+
         if (PointerPressedCommand is not null)
         {
             var args = new PointerCommandArgs(this, new(p.X, p.Y), e);
@@ -151,8 +160,6 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
             e.GetCurrentPoint(this).Properties.IsRightButtonPressed ||
             (DateTime.Now - _lastPresed).TotalMilliseconds < 500;
 
-        _isPointerDown = true;
-        _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
         CoreChart?.InvokePointerDown(_lastPointerPosition, isSecondary);
         _lastPresed = DateTime.Now;
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
@@ -53,6 +53,8 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
     private DateTime _lastPresed;
     private readonly int _tolearance = 50;
     private bool _wasInViewport;
+    private bool _isPointerDown;
+    private LvcPoint _lastPointerPosition;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SourceGenChart"/> class.
@@ -69,6 +71,7 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
         PointerMoved += OnPointerMoved;
         PointerReleased += OnPointerReleased;
         PointerExited += OnPointerLeave;
+        PointerCaptureLost += OnPointerCaptureLost;
 
         SizeChanged += (s, e) =>
             CoreChart.Update();
@@ -148,7 +151,9 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
             e.GetCurrentPoint(this).Properties.IsRightButtonPressed ||
             (DateTime.Now - _lastPresed).TotalMilliseconds < 500;
 
-        CoreChart?.InvokePointerDown(new LvcPoint((float)p.X, (float)p.Y), isSecondary);
+        _isPointerDown = true;
+        _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
+        CoreChart?.InvokePointerDown(_lastPointerPosition, isSecondary);
         _lastPresed = DateTime.Now;
     }
 
@@ -164,7 +169,8 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
                 PointerMoveCommand.Execute(args);
         }
 
-        CoreChart?.InvokePointerMove(new LvcPoint((float)p.X, (float)p.Y));
+        _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
+        CoreChart?.InvokePointerMove(_lastPointerPosition);
     }
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
@@ -179,7 +185,20 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
                 PointerReleasedCommand.Execute(args);
         }
 
-        CoreChart?.InvokePointerUp(new LvcPoint((float)p.X, (float)p.Y), e.GetCurrentPoint(this).Properties.IsRightButtonPressed);
+        _isPointerDown = false;
+        _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
+        CoreChart?.InvokePointerUp(_lastPointerPosition, e.GetCurrentPoint(this).Properties.IsRightButtonPressed);
+    }
+
+    // When an ancestor (e.g. a button wrapping the chart, see #1576) re-captures
+    // the pointer mid-gesture, the chart never receives PointerReleased and pan/drag
+    // state stays armed; any subsequent PointerMoved keeps panning. Treat capture
+    // loss as a synthetic pointer-up so the drag state always releases.
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        if (!_isPointerDown) return;
+        _isPointerDown = false;
+        CoreChart?.InvokePointerUp(_lastPointerPosition, false);
     }
 
     private void OnPointerLeave(object? sender, PointerEventArgs e) =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs
@@ -175,6 +175,12 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        // Always clear the press flag, even when bailing out via the tolerance
+        // early-return below; otherwise a fast press-release leaves _isPointerDown
+        // stuck true and a later unrelated PointerCaptureLost would fire a phantom
+        // synthetic pointer-up.
+        _isPointerDown = false;
+
         if ((DateTime.Now - _lastPresed).TotalMilliseconds < _tolearance) return;
         var p = e.GetPosition(this);
 
@@ -185,7 +191,6 @@ public abstract partial class SourceGenChart : UserControl, IChartView, ICustomH
                 PointerReleasedCommand.Execute(args);
         }
 
-        _isPointerDown = false;
         _lastPointerPosition = new LvcPoint((float)p.X, (float)p.Y);
         CoreChart?.InvokePointerUp(_lastPointerPosition, e.GetCurrentPoint(this).Properties.IsRightButtonPressed);
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
@@ -114,12 +114,18 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         if (Keyboard.Modifiers > 0) return;
         _ = CaptureMouse();
 
+        // Arm _isPointerDown BEFORE invoking the user's command. If the command
+        // synchronously transfers capture (e.g. focuses or captures another
+        // element) WPF raises LostMouseCapture immediately, and the recovery
+        // handler must observe the flag set so it can synthesize a pointer-up.
+        // Otherwise the chart is left in the same stuck-drag state #1576 fixes.
+        _isPointerDown = true;
+
         var p = e.GetPosition(this);
         var cArgs = new PointerCommandArgs(this, new(p.X, p.Y), e);
         if (PointerPressedCommand?.CanExecute(cArgs) == true)
             PointerPressedCommand.Execute(cArgs);
 
-        _isPointerDown = true;
         CoreChart?.InvokePointerDown(new(p.X, p.Y), e.ChangedButton == MouseButton.Right);
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
@@ -147,11 +147,17 @@ public abstract partial class SourceGenChart : UserControl, IChartView
     {
         var p = e.GetPosition(this);
 
+        // Clear _isPointerDown BEFORE invoking the user's command. If the command
+        // synchronously changes capture (e.g. focuses or captures another element)
+        // WPF raises LostMouseCapture immediately; with the flag still set the
+        // recovery handler would then synthesize a redundant pointer-up after the
+        // real release. Clearing first keeps the release path single-shot.
+        _isPointerDown = false;
+
         var cArgs = new PointerCommandArgs(this, new(p.X, p.Y), e);
         if (PointerReleasedCommand?.CanExecute(cArgs) == true)
             PointerReleasedCommand.Execute(cArgs);
 
-        _isPointerDown = false;
         CoreChart?.InvokePointerUp(new(p.X, p.Y), e.ChangedButton == MouseButton.Right);
         ReleaseMouseCapture();
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs
@@ -46,6 +46,8 @@ namespace LiveChartsGeneratedCode;
 /// <inheritdoc cref="IChartView" />
 public abstract partial class SourceGenChart : UserControl, IChartView
 {
+    private bool _isPointerDown;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Chart"/> class.
     /// </summary>
@@ -64,6 +66,7 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         MouseMove += OnMouseMove;
         MouseUp += Chart_MouseUp;
         MouseLeave += OnMouseLeave;
+        LostMouseCapture += OnLostMouseCapture;
 
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
@@ -116,6 +119,7 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         if (PointerPressedCommand?.CanExecute(cArgs) == true)
             PointerPressedCommand.Execute(cArgs);
 
+        _isPointerDown = true;
         CoreChart?.InvokePointerDown(new(p.X, p.Y), e.ChangedButton == MouseButton.Right);
     }
 
@@ -141,8 +145,23 @@ public abstract partial class SourceGenChart : UserControl, IChartView
         if (PointerReleasedCommand?.CanExecute(cArgs) == true)
             PointerReleasedCommand.Execute(cArgs);
 
+        _isPointerDown = false;
         CoreChart?.InvokePointerUp(new(p.X, p.Y), e.ChangedButton == MouseButton.Right);
         ReleaseMouseCapture();
+    }
+
+    // When an ancestor (e.g. a ToggleButton wrapping the chart, see #1576) calls
+    // CaptureMouse() during the same mouse-down burst, capture is transferred away
+    // from the chart and the chart never receives MouseUp; pan/drag state then stays
+    // armed and any subsequent MouseMove keeps panning. Treat capture loss as a
+    // synthetic pointer-up so the drag state always releases.
+    private void OnLostMouseCapture(object sender, MouseEventArgs e)
+    {
+        if (!_isPointerDown) return;
+        _isPointerDown = false;
+
+        var p = Mouse.GetPosition(this);
+        CoreChart?.InvokePointerUp(new(p.X, p.Y), false);
     }
 
     private void OnMouseLeave(object sender, MouseEventArgs e) =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
@@ -144,9 +144,17 @@ public abstract partial class SourceGenChart : ChartView, IChartView
 
     internal override void OnReleased(object? sender, LiveChartsCore.Native.Events.PressedEventArgs args)
     {
-        var cArgs = new PointerCommandArgs(this, new(args.Location.X, args.Location.Y), args);
-        if (ReleasedCommand?.CanExecute(cArgs) == true)
-            ReleasedCommand.Execute(cArgs);
+        // Synthetic releases are raised by the shared PointerController on
+        // PointerCaptureLost (see #1576). The user has not actually lifted the
+        // pointer, so we must not invoke the public ReleasedCommand — only forward
+        // to the core chart so internal pan/drag state can be released. WinUI/Uno
+        // and WPF/Avalonia follow the same rule from their own platform paths.
+        if (!args.IsSyntheticRelease)
+        {
+            var cArgs = new PointerCommandArgs(this, new(args.Location.X, args.Location.Y), args);
+            if (ReleasedCommand?.CanExecute(cArgs) == true)
+                ReleasedCommand.Execute(cArgs);
+        }
 
         CoreChart.InvokePointerUp(args.Location, args.IsSecondaryPress);
     }

--- a/src/skiasharp/_Shared.WinUI/SourceGenChart.cs
+++ b/src/skiasharp/_Shared.WinUI/SourceGenChart.cs
@@ -147,9 +147,17 @@ public abstract partial class SourceGenChart : UserControl, IChartView
 
     private void OnReleased(object? sender, LiveChartsCore.Native.Events.PressedEventArgs args)
     {
-        var cArgs = new PointerCommandArgs(this, new(args.Location.X, args.Location.Y), args);
-        if (PointerReleasedCommand?.CanExecute(cArgs) == true)
-            PointerReleasedCommand.Execute(cArgs);
+        // Synthetic releases are raised by the chart itself when an ancestor steals
+        // pointer capture mid-drag (see #1576). The user has not actually lifted the
+        // pointer, so we must not invoke the public PointerReleasedCommand — only
+        // forward to the core chart so internal pan/drag state can be released. WPF
+        // and Avalonia follow the same rule from their own capture-loss handlers.
+        if (!args.IsSyntheticRelease)
+        {
+            var cArgs = new PointerCommandArgs(this, new(args.Location.X, args.Location.Y), args);
+            if (PointerReleasedCommand?.CanExecute(cArgs) == true)
+                PointerReleasedCommand.Execute(cArgs);
+        }
 
         CoreChart?.InvokePointerUp(args.Location, args.IsSecondaryPress);
     }

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -32,6 +32,7 @@ using System.Windows.Input;
 #endif
 
 #if AVALONIA_UI_TESTING
+using System;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -153,6 +154,57 @@ public class PointerCaptureLostTests
             Assert.False(
                 (bool)isPanningField.GetValue(coreChart)!,
                 "Chart._isPanning should be reset after PointerCaptureLost");
+        });
+    }
+#endif
+
+#if AVALONIA_UI_TESTING
+    // Sister regression for the Avalonia OnPointerReleased tolerance early-return.
+    // Pre-fix: _isPointerDown was assigned AFTER the < _tolearance bail-out, so a
+    // fast press-release left the flag stuck true and a later unrelated
+    // PointerCaptureLost would synthesize a phantom pointer-up. The hoisted
+    // assignment must clear the flag before the early-return is taken.
+    [AppTestMethod]
+    public async Task Avalonia_fast_press_release_clears_pointer_down_flag()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (Control)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+        var isPointerDownField = sourceGenChartType!.GetField(
+            "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPointerDownField);
+        var lastPresedField = sourceGenChartType.GetField(
+            "_lastPresed", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(lastPresedField);
+
+        // OnPointerReleased shadows InputElement's protected virtual; specify
+        // parameter types to avoid AmbiguousMatchException.
+        var onReleased = sourceGenChartType.GetMethod(
+            "OnPointerReleased",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(object), typeof(PointerReleasedEventArgs)],
+            modifiers: null);
+        Assert.NotNull(onReleased);
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            // Simulate the moment right after a real press: pointer-down armed and
+            // _lastPresed pinned to "now" so the next OnPointerReleased call hits the
+            // tolerance early-return — the very branch that used to leak the flag.
+            isPointerDownField!.SetValue(chart, true);
+            lastPresedField!.SetValue(chart, DateTime.Now);
+
+            // The handler does not dereference its args before the early-return.
+            _ = onReleased!.Invoke(chart, [chart, null]);
+
+            Assert.False(
+                (bool)isPointerDownField.GetValue(chart)!,
+                "_isPointerDown must be cleared even when OnPointerReleased takes the tolerance early-return; otherwise a later unrelated PointerCaptureLost would fire a phantom synthetic pointer-up.");
         });
     }
 #endif

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -34,6 +34,7 @@ using System.Windows.Input;
 #if AVALONIA_UI_TESTING
 using System.Reflection;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Threading;
 #endif
 
@@ -57,19 +58,14 @@ public class PointerCaptureLostTests
         await sut.Chart.WaitUntilChartRenders();
 
         var chart = (FrameworkElement)sut.Chart;
-        var view = (IChartView)sut.Chart;
+        var coreChart = ((IChartView)sut.Chart).CoreChart;
 
         var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
         Assert.NotNull(sourceGenChartType);
-
         var isPointerDownField = sourceGenChartType!.GetField(
             "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
-        var onLostCapture = sourceGenChartType.GetMethod(
-            "OnLostMouseCapture", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(isPointerDownField);
-        Assert.NotNull(onLostCapture);
 
-        var coreChart = view.CoreChart;
         var chartType = WalkBaseTypes(coreChart.GetType(), "Chart");
         Assert.NotNull(chartType);
         var isPanningField = chartType!.GetField(
@@ -78,25 +74,28 @@ public class PointerCaptureLostTests
 
         await chart.Dispatcher.InvokeAsync(() =>
         {
-            // Simulate the state right after a MouseDown on the chart: the WPF-side
-            // flag is set and the core chart is panning.
+            // Put the chart into the same state it would have right after a real
+            // MouseDown: the WPF-side flag tracking "user is pressing" is set, and
+            // the core chart's pan/drag state is armed.
             isPointerDownField!.SetValue(chart, true);
             isPanningField!.SetValue(coreChart, true);
 
-            // An ancestor steals capture (the #1576 ToggleButton scenario). No MouseUp
-            // will arrive at the chart; the LostMouseCapture handler must clean up.
-            var args = new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            // Drive a real LostMouseCapture event through WPF's routed-event system.
+            // The chart's handler (subscribed via +=) is what we're testing — we don't
+            // reflect on it, so we cannot get a name-clash with UIElement's protected
+            // virtual of the same name.
+            chart.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
             {
-                RoutedEvent = Mouse.LostMouseCaptureEvent
-            };
-            _ = onLostCapture!.Invoke(chart, [chart, args]);
+                RoutedEvent = Mouse.LostMouseCaptureEvent,
+                Source = chart
+            });
 
             Assert.False(
                 (bool)isPointerDownField.GetValue(chart)!,
-                "_isPointerDown should be reset by OnLostMouseCapture");
+                "_isPointerDown should be reset after LostMouseCapture");
             Assert.False(
                 (bool)isPanningField.GetValue(coreChart)!,
-                "Chart._isPanning should be reset by OnLostMouseCapture");
+                "Chart._isPanning should be reset after LostMouseCapture");
         });
     }
 #endif
@@ -113,19 +112,25 @@ public class PointerCaptureLostTests
         await sut.Chart.WaitUntilChartRenders();
 
         var chart = (Control)sut.Chart;
-        var view = (IChartView)sut.Chart;
+        var coreChart = ((IChartView)sut.Chart).CoreChart;
 
         var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
         Assert.NotNull(sourceGenChartType);
-
         var isPointerDownField = sourceGenChartType!.GetField(
             "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
-        var onCaptureLost = sourceGenChartType.GetMethod(
-            "OnPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(isPointerDownField);
+
+        // OnPointerCaptureLost shadows InputElement's protected virtual of the same
+        // name (single-arg signature), so we must specify the parameter types to
+        // disambiguate; the simple overload throws AmbiguousMatchException.
+        var onCaptureLost = sourceGenChartType.GetMethod(
+            "OnPointerCaptureLost",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(object), typeof(PointerCaptureLostEventArgs)],
+            modifiers: null);
         Assert.NotNull(onCaptureLost);
 
-        var coreChart = view.CoreChart;
         var chartType = WalkBaseTypes(coreChart.GetType(), "Chart");
         Assert.NotNull(chartType);
         var isPanningField = chartType!.GetField(
@@ -137,16 +142,17 @@ public class PointerCaptureLostTests
             isPointerDownField!.SetValue(chart, true);
             isPanningField!.SetValue(coreChart, true);
 
-            // PointerCaptureLostEventArgs has no public constructor; pass null since
-            // OnPointerCaptureLost does not read its argument.
+            // PointerCaptureLostEventArgs has no public constructor and Avalonia's
+            // RaiseEvent path therefore can't be exercised from a test. Invoke the
+            // handler directly; it doesn't read its argument, so null is safe.
             _ = onCaptureLost!.Invoke(chart, [chart, null]);
 
             Assert.False(
                 (bool)isPointerDownField.GetValue(chart)!,
-                "_isPointerDown should be reset by OnPointerCaptureLost");
+                "_isPointerDown should be reset after PointerCaptureLost");
             Assert.False(
                 (bool)isPanningField.GetValue(coreChart)!,
-                "Chart._isPanning should be reset by OnPointerCaptureLost");
+                "Chart._isPanning should be reset after PointerCaptureLost");
         });
     }
 #endif

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -55,6 +55,57 @@ public class PointerCaptureLostTests
     public AppController App => AppController.Current;
 
 #if WPF_UI_TESTING
+    // regression sister to Wpf_lost_mouse_capture_releases_drag_state.
+    // Pre-fix: _isPointerDown was set AFTER PointerPressedCommand executed. If user
+    // code inside the command synchronously transferred capture (e.g. CaptureMouse
+    // on another element, Focus, etc.), WPF raised LostMouseCapture on the chart
+    // immediately and the recovery handler bailed because the flag was still false
+    // — the chart stayed armed and a later MouseMove would pan with no button held.
+    // The flag must be set before the command runs so the recovery handler always
+    // observes it.
+    [AppTestMethod]
+    public async Task Wpf_pointer_pressed_command_observes_pointer_down_armed()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (FrameworkElement)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+        var isPointerDownField = sourceGenChartType!.GetField(
+            "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPointerDownField);
+        var mouseDown = sourceGenChartType.GetMethod(
+            "Chart_MouseDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(mouseDown);
+
+        var commandProperty = chart.GetType().GetProperty("PointerPressedCommand");
+        Assert.NotNull(commandProperty);
+
+        bool? observedFlag = null;
+        var probe = new ProbeCommand(() => observedFlag = (bool)isPointerDownField!.GetValue(chart)!);
+
+        await chart.Dispatcher.InvokeAsync(() =>
+        {
+            commandProperty!.SetValue(chart, probe);
+
+            // Drive Chart_MouseDown directly. The probe records the value of
+            // _isPointerDown at the moment the user's command fires, which is
+            // exactly the ordering the recovery handler relies on.
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.MouseDownEvent,
+                Source = chart,
+            };
+            _ = mouseDown!.Invoke(chart, [chart, args]);
+        });
+
+        Assert.True(
+            observedFlag,
+            "_isPointerDown must be armed before PointerPressedCommand fires; otherwise a capture transfer triggered from inside the command would leave the LostMouseCapture recovery handler unable to detect the in-flight gesture (#1576).");
+    }
+
     // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576
     // when an ancestor (e.g. a ToggleButton wrapping the chart) calls CaptureMouse
     // during the same mouse-down burst, capture is stolen from the chart and the
@@ -355,12 +406,6 @@ public class PointerCaptureLostTests
         return tcs.Task;
     }
 
-    private sealed class ProbeCommand(Action onExecute) : ICommand
-    {
-        public event EventHandler? CanExecuteChanged { add { } remove { } }
-        public bool CanExecute(object? parameter) => true;
-        public void Execute(object? parameter) => onExecute();
-    }
 #endif
 
 #if WPF_UI_TESTING || AVALONIA_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING
@@ -369,6 +414,15 @@ public class PointerCaptureLostTests
         for (var t = start; t is not null; t = t.BaseType)
             if (t.Name == name) return t;
         return null;
+    }
+#endif
+
+#if WPF_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING
+    private sealed class ProbeCommand(System.Action onExecute) : System.Windows.Input.ICommand
+    {
+        public event System.EventHandler? CanExecuteChanged { add { } remove { } }
+        public bool CanExecute(object? parameter) => true;
+        public void Execute(object? parameter) => onExecute();
     }
 #endif
 }

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -39,6 +39,14 @@ using Avalonia.Input;
 using Avalonia.Threading;
 #endif
 
+#if WINUI_UI_TESTING || UNO_UI_TESTING
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using LiveChartsCore.Native.Events;
+using Microsoft.UI.Xaml;
+#endif
+
 namespace SharedUITests.Events;
 
 public class PointerCaptureLostTests
@@ -209,7 +217,106 @@ public class PointerCaptureLostTests
     }
 #endif
 
-#if WPF_UI_TESTING || AVALONIA_UI_TESTING
+#if WINUI_UI_TESTING || UNO_UI_TESTING
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576 on the
+    // WinUI/Uno-Skia native pointer controller: when an ancestor steals capture
+    // mid-gesture the controller raises a synthetic Released so the chart can
+    // release its pan/drag state. That synthetic release used to hard-code
+    // IsSecondaryPress=false, which mis-reported right-click drags as primary
+    // releases. The controller now snapshots the original press button at press
+    // time and replays it on PointerCaptureLost.
+    [AppTestMethod]
+    public async Task WinUI_pointer_capture_lost_preserves_secondary_press_flag()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (FrameworkElement)sut.Chart;
+
+        var (pc, captureLost) = ResolvePointerControllerAndCaptureLostMethod(chart);
+
+        var pcType = pc.GetType();
+        var isDownField = pcType.GetField("_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isDownField);
+        var wasSecondaryField = pcType.GetField("_wasSecondaryPress", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(wasSecondaryField);
+
+        var releasedEvent = pcType.GetEvent("Released");
+        Assert.NotNull(releasedEvent);
+
+        PressedEventArgs? captured = null;
+        PressedHandler observer = (_, args) => captured = args;
+        releasedEvent!.AddEventHandler(pc, observer);
+        try
+        {
+            await RunOnDispatcherAsync(chart, () =>
+            {
+                // simulate the state right after a real right-button press: the
+                // controller is armed and remembers the press was secondary. The
+                // capture-lost replay must surface that secondary flag back out.
+                isDownField!.SetValue(pc, true);
+                wasSecondaryField!.SetValue(pc, true);
+
+                // The handler does not dereference its args (we asserted this in
+                // the source), so null sender / null PointerRoutedEventArgs is safe.
+                _ = captureLost.Invoke(pc, [null!, null!]);
+            });
+        }
+        finally
+        {
+            releasedEvent.RemoveEventHandler(pc, observer);
+        }
+
+        Assert.NotNull(captured);
+        Assert.True(
+            captured!.IsSecondaryPress,
+            "synthetic Released raised on PointerCaptureLost must replay the original press's secondary-button flag; otherwise right-click drags interrupted by capture-loss are reported as primary releases.");
+    }
+
+    private static (object Controller, MethodInfo CaptureLost) ResolvePointerControllerAndCaptureLostMethod(FrameworkElement chart)
+    {
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+
+        var pcField = sourceGenChartType!.GetField("_pointerController", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(pcField);
+        var pc = pcField!.GetValue(chart);
+        Assert.NotNull(pc);
+
+        var pcType = pc!.GetType();
+        // Each platform partial owns its own handler name; only one of the two
+        // exists in the assembly being tested. Probe both so a single test method
+        // covers the WinUI sample and the Uno-Skia sample.
+        var captureLost =
+            pcType.GetMethod("OnWindowsPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic) ??
+            pcType.GetMethod("OnUnoSkiaPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(captureLost);
+        return (pc, captureLost!);
+    }
+
+    private static Task RunOnDispatcherAsync(FrameworkElement chart, Action work)
+    {
+        var tcs = new TaskCompletionSource<object?>();
+        if (!chart.DispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                work();
+                tcs.SetResult(null);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        }))
+        {
+            tcs.SetException(new InvalidOperationException("Failed to enqueue work on the chart's DispatcherQueue."));
+        }
+        return tcs.Task;
+    }
+#endif
+
+#if WPF_UI_TESTING || AVALONIA_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING
     private static Type? WalkBaseTypes(Type? start, string name)
     {
         for (var t = start; t is not null; t = t.BaseType)

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -43,6 +43,7 @@ using Avalonia.Threading;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using LiveChartsCore.Native.Events;
 using Microsoft.UI.Xaml;
 #endif
@@ -273,6 +274,45 @@ public class PointerCaptureLostTests
             "synthetic Released raised on PointerCaptureLost must replay the original press's secondary-button flag; otherwise right-click drags interrupted by capture-loss are reported as primary releases.");
     }
 
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576 on the
+    // WinUI/Uno-Skia chart: the synthetic Released that the controller raises on
+    // PointerCaptureLost flows through the shared OnReleased handler, which used
+    // to fire PointerReleasedCommand for any release. The user has not actually
+    // lifted the pointer when capture is stolen, so the public command must NOT
+    // fire — only the core chart's internal pan/drag state should release.
+    [AppTestMethod]
+    public async Task WinUI_pointer_capture_lost_does_not_fire_pointer_released_command()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (FrameworkElement)sut.Chart;
+
+        var (pc, captureLost) = ResolvePointerControllerAndCaptureLostMethod(chart);
+
+        var pcType = pc.GetType();
+        var isDownField = pcType.GetField("_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isDownField);
+
+        var commandProperty = chart.GetType().GetProperty("PointerReleasedCommand");
+        Assert.NotNull(commandProperty);
+
+        var commandFired = false;
+        var probe = new ProbeCommand(() => commandFired = true);
+
+        await RunOnDispatcherAsync(chart, () =>
+        {
+            commandProperty!.SetValue(chart, probe);
+            isDownField!.SetValue(pc, true);
+
+            _ = captureLost.Invoke(pc, [null!, null!]);
+        });
+
+        Assert.False(
+            commandFired,
+            "PointerReleasedCommand must not be invoked when capture-loss synthesizes a release; the user has not actually lifted the pointer and the command's contract is 'real user release'.");
+    }
+
     private static (object Controller, MethodInfo CaptureLost) ResolvePointerControllerAndCaptureLostMethod(FrameworkElement chart)
     {
         var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
@@ -313,6 +353,13 @@ public class PointerCaptureLostTests
             tcs.SetException(new InvalidOperationException("Failed to enqueue work on the chart's DispatcherQueue."));
         }
         return tcs.Task;
+    }
+
+    private sealed class ProbeCommand(Action onExecute) : ICommand
+    {
+        public event EventHandler? CanExecuteChanged { add { } remove { } }
+        public bool CanExecute(object? parameter) => true;
+        public void Execute(object? parameter) => onExecute();
     }
 #endif
 

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -460,7 +460,62 @@ public class PointerCaptureLostTests
 
 #endif
 
-#if WPF_UI_TESTING || AVALONIA_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING
+#if MAUI_UI_TESTING
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576 on
+    // MAUI: MAUI on Windows uses the same shared PointerController as WinUI/Uno
+    // and the controller raises a synthetic Released on PointerCaptureLost.
+    // Pre-fix, MAUI's OnReleased unconditionally invoked ReleasedCommand, so
+    // MAUI/Windows apps still received a public release callback when capture
+    // was stolen mid-drag. The guard in OnReleased must skip the command when
+    // args.IsSyntheticRelease is set.
+    [AppTestMethod]
+    public async Task Maui_synthetic_release_does_not_fire_released_command()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (Microsoft.Maui.Controls.View)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+
+        // OnReleased is internal override; reflect into it so we can drive a
+        // synthetic-release directly without going through the platform
+        // PointerController.
+        var onReleased = sourceGenChartType!.GetMethod(
+            "OnReleased",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(object), typeof(LiveChartsCore.Native.Events.PressedEventArgs)],
+            modifiers: null);
+        Assert.NotNull(onReleased);
+
+        var commandProperty = chart.GetType().GetProperty("ReleasedCommand");
+        Assert.NotNull(commandProperty);
+
+        var commandFired = false;
+        var probe = new ProbeCommand(() => commandFired = true);
+
+        await Microsoft.Maui.ApplicationModel.MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            commandProperty!.SetValue(chart, probe);
+
+            var args = new LiveChartsCore.Native.Events.PressedEventArgs(
+                new LiveChartsCore.Drawing.LvcPoint(0, 0),
+                isSecondaryPress: false,
+                isSyntheticRelease: true,
+                originalEvent: chart);
+
+            _ = onReleased!.Invoke(chart, [chart, args]);
+        });
+
+        Assert.False(
+            commandFired,
+            "ReleasedCommand must not be invoked when args.IsSyntheticRelease is set; capture-loss is not a real user release and the public command's contract is 'real user release' (#1576).");
+    }
+#endif
+
+#if WPF_UI_TESTING || AVALONIA_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING || MAUI_UI_TESTING
     private static Type? WalkBaseTypes(Type? start, string name)
     {
         for (var t = start; t is not null; t = t.BaseType)
@@ -469,7 +524,7 @@ public class PointerCaptureLostTests
     }
 #endif
 
-#if WPF_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING
+#if WPF_UI_TESTING || WINUI_UI_TESTING || UNO_UI_TESTING || MAUI_UI_TESTING
     private sealed class ProbeCommand(System.Action onExecute) : System.Windows.Input.ICommand
     {
         public event System.EventHandler? CanExecuteChanged { add { } remove { } }

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -1,0 +1,162 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Factos;
+using LiveChartsCore.Kernel.Sketches;
+using SharedUITests.Helpers;
+using Xunit;
+
+#if WPF_UI_TESTING
+using System.Reflection;
+using System.Windows;
+using System.Windows.Input;
+#endif
+
+#if AVALONIA_UI_TESTING
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Threading;
+#endif
+
+namespace SharedUITests.Events;
+
+public class PointerCaptureLostTests
+{
+    public AppController App => AppController.Current;
+
+#if WPF_UI_TESTING
+    // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576
+    // when an ancestor (e.g. a ToggleButton wrapping the chart) calls CaptureMouse
+    // during the same mouse-down burst, capture is stolen from the chart and the
+    // chart never sees MouseUp; pan/drag state stays armed and any subsequent
+    // MouseMove keeps panning. The chart must treat capture loss as a synthetic
+    // pointer-up so the drag state always releases.
+    [AppTestMethod]
+    public async Task Wpf_lost_mouse_capture_releases_drag_state()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (FrameworkElement)sut.Chart;
+        var view = (IChartView)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+
+        var isPointerDownField = sourceGenChartType!.GetField(
+            "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        var onLostCapture = sourceGenChartType.GetMethod(
+            "OnLostMouseCapture", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPointerDownField);
+        Assert.NotNull(onLostCapture);
+
+        var coreChart = view.CoreChart;
+        var chartType = WalkBaseTypes(coreChart.GetType(), "Chart");
+        Assert.NotNull(chartType);
+        var isPanningField = chartType!.GetField(
+            "_isPanning", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPanningField);
+
+        await chart.Dispatcher.InvokeAsync(() =>
+        {
+            // Simulate the state right after a MouseDown on the chart: the WPF-side
+            // flag is set and the core chart is panning.
+            isPointerDownField!.SetValue(chart, true);
+            isPanningField!.SetValue(coreChart, true);
+
+            // An ancestor steals capture (the #1576 ToggleButton scenario). No MouseUp
+            // will arrive at the chart; the LostMouseCapture handler must clean up.
+            var args = new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.LostMouseCaptureEvent
+            };
+            _ = onLostCapture!.Invoke(chart, [chart, args]);
+
+            Assert.False(
+                (bool)isPointerDownField.GetValue(chart)!,
+                "_isPointerDown should be reset by OnLostMouseCapture");
+            Assert.False(
+                (bool)isPanningField.GetValue(coreChart)!,
+                "Chart._isPanning should be reset by OnLostMouseCapture");
+        });
+    }
+#endif
+
+#if AVALONIA_UI_TESTING
+    // regression mirror for https://github.com/Live-Charts/LiveCharts2/issues/1576
+    // Avalonia has the same class of issue when an ancestor re-captures the pointer
+    // mid-gesture (reported by MajesticBevans in the same thread). The chart must
+    // treat capture loss as a synthetic pointer-up.
+    [AppTestMethod]
+    public async Task Avalonia_pointer_capture_lost_releases_drag_state()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (Control)sut.Chart;
+        var view = (IChartView)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+
+        var isPointerDownField = sourceGenChartType!.GetField(
+            "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        var onCaptureLost = sourceGenChartType.GetMethod(
+            "OnPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPointerDownField);
+        Assert.NotNull(onCaptureLost);
+
+        var coreChart = view.CoreChart;
+        var chartType = WalkBaseTypes(coreChart.GetType(), "Chart");
+        Assert.NotNull(chartType);
+        var isPanningField = chartType!.GetField(
+            "_isPanning", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPanningField);
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            isPointerDownField!.SetValue(chart, true);
+            isPanningField!.SetValue(coreChart, true);
+
+            // PointerCaptureLostEventArgs has no public constructor; pass null since
+            // OnPointerCaptureLost does not read its argument.
+            _ = onCaptureLost!.Invoke(chart, [chart, null]);
+
+            Assert.False(
+                (bool)isPointerDownField.GetValue(chart)!,
+                "_isPointerDown should be reset by OnPointerCaptureLost");
+            Assert.False(
+                (bool)isPanningField.GetValue(coreChart)!,
+                "Chart._isPanning should be reset by OnPointerCaptureLost");
+        });
+    }
+#endif
+
+#if WPF_UI_TESTING || AVALONIA_UI_TESTING
+    private static Type? WalkBaseTypes(Type? start, string name)
+    {
+        for (var t = start; t is not null; t = t.BaseType)
+            if (t.Name == name) return t;
+        return null;
+    }
+#endif
+}

--- a/tests/SharedUITests/Events/PointerCaptureLostTests.cs
+++ b/tests/SharedUITests/Events/PointerCaptureLostTests.cs
@@ -106,6 +106,58 @@ public class PointerCaptureLostTests
             "_isPointerDown must be armed before PointerPressedCommand fires; otherwise a capture transfer triggered from inside the command would leave the LostMouseCapture recovery handler unable to detect the in-flight gesture (#1576).");
     }
 
+    // regression sister to Wpf_lost_mouse_capture_releases_drag_state.
+    // Pre-fix: _isPointerDown was cleared AFTER PointerReleasedCommand executed.
+    // If user code inside the command synchronously changed capture (e.g.
+    // focused or captured another element), WPF raised LostMouseCapture on the
+    // chart immediately and the recovery handler synthesized a redundant
+    // pointer-up on top of the real release. Clearing the flag first keeps the
+    // release path single-shot.
+    [AppTestMethod]
+    public async Task Wpf_pointer_released_command_observes_pointer_down_cleared()
+    {
+        var sut = await App.NavigateTo<Samples.General.FirstChart.View>();
+        await sut.Chart.WaitUntilChartRenders();
+
+        var chart = (FrameworkElement)sut.Chart;
+
+        var sourceGenChartType = WalkBaseTypes(chart.GetType(), "SourceGenChart");
+        Assert.NotNull(sourceGenChartType);
+        var isPointerDownField = sourceGenChartType!.GetField(
+            "_isPointerDown", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(isPointerDownField);
+        var mouseUp = sourceGenChartType.GetMethod(
+            "Chart_MouseUp", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(mouseUp);
+
+        var commandProperty = chart.GetType().GetProperty("PointerReleasedCommand");
+        Assert.NotNull(commandProperty);
+
+        bool? observedFlag = null;
+        var probe = new ProbeCommand(() => observedFlag = (bool)isPointerDownField!.GetValue(chart)!);
+
+        await chart.Dispatcher.InvokeAsync(() =>
+        {
+            commandProperty!.SetValue(chart, probe);
+
+            // Pre-arm the flag (as if a real press had just occurred) and drive
+            // Chart_MouseUp directly. The probe records the value of
+            // _isPointerDown at the moment the user's command fires.
+            isPointerDownField!.SetValue(chart, true);
+
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Mouse.MouseUpEvent,
+                Source = chart,
+            };
+            _ = mouseUp!.Invoke(chart, [chart, args]);
+        });
+
+        Assert.False(
+            observedFlag,
+            "_isPointerDown must be cleared before PointerReleasedCommand fires; otherwise a capture change triggered from inside the command would cause LostMouseCapture to synthesize a redundant pointer-up on top of the real release (#1576).");
+    }
+
     // regression for https://github.com/Live-Charts/LiveCharts2/issues/1576
     // when an ancestor (e.g. a ToggleButton wrapping the chart) calls CaptureMouse
     // during the same mouse-down burst, capture is stolen from the chart and the


### PR DESCRIPTION
## Summary
- Fixes #1576 across WPF, Avalonia, WinUI and Uno-Skia: when an ancestor (e.g. a `ToggleButton` wrapping the chart) calls `CaptureMouse` / `CapturePointer` mid-gesture, capture is transferred away from the chart and the chart never receives `MouseUp` / `PointerReleased`. Pan/drag state then stays armed and any subsequent move keeps panning even after the user has released the mouse.
- Subscribes to `LostMouseCapture` (WPF) / `PointerCaptureLost` (Avalonia, WinUI, Uno-Skia) and treats capture loss as a synthetic pointer-up. A new `_isPointerDown` flag prevents a double-up when the chart releases capture itself from the normal up path.

## Why the original report was hard to reproduce
The bug only triggers with an ancestor that captures input on press (`Button` / `ToggleButton` / `Thumb` / `ScrollBar`). A bare `<CartesianChart/>` in a window won't repro — `@MajesticBevans` mentioned the same in Avalonia in the issue thread.

## Files
- `src/skiasharp/LiveChartsCore.SkiaSharp.WPF/SourceGenChart.cs` — `LostMouseCapture` handler.
- `src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/SourceGenChart.cs` — `PointerCaptureLost` handler.
- `src/_Shared.Native/Platforms/WinUI/PointerController.cs` — fires synthetic `Released` from `PointerCaptureLost` (covers WinUI, MAUI-on-Windows, Uno-WinUI per the file's reach comment).
- `src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs` — same shape for Uno-Skia.
- `tests/SharedUITests/Events/PointerCaptureLostTests.cs` — Factos regression for WPF + Avalonia (see "Test plan" caveat).

## Test plan
- [x] WPF chart project builds clean.
- [x] Avalonia chart project builds clean.
- [x] WinUI sample builds clean.
- [x] Both samples build clean with `UITesting=true` (the regression test compiles in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)