### PR TITLE
ci: speed up LiveCharts workflow (nuget+workload cache, conditional install, decouple collect-packages)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -44,6 +44,7 @@ runs:
         workloads: ${{ inputs.workloads }}
 
     - name: Install Coverage Tools
+      if: ${{ inputs.test-type == 'core' || inputs.test-type == 'snapshot' }}
       shell: pwsh
       run:
         dotnet tool install -g dotnet-coverage

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -54,6 +54,7 @@ runs:
       uses: actions/download-artifact@v7.0.0
       with:
         path: ./artifacts
+        pattern: "*-package"
 
     - name: Configure NuGet sources 
       if: ${{ inputs.test-type == 'factos' || inputs.test-type == 'factos-android' || inputs.test-type == 'factos-ios' }}

--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -18,8 +18,31 @@ runs:
           **/*.props
           global.json
 
-    - name: Install Workloads
+    - name: Resolve DOTNET_ROOT for workload cache
       if: ${{ inputs.workloads != '' }}
+      id: dotnet-root
+      shell: pwsh
+      run: |
+        $root = $env:DOTNET_ROOT
+        if (-not $root) { $root = Join-Path $HOME ".dotnet" }
+        $root = $root -replace '\\','/'
+        "path=$root" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Cache .NET workloads
+      if: ${{ inputs.workloads != '' }}
+      id: workload-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.dotnet-root.outputs.path }}/sdk-manifests
+          ${{ steps.dotnet-root.outputs.path }}/packs
+          ${{ steps.dotnet-root.outputs.path }}/metadata
+          ${{ steps.dotnet-root.outputs.path }}/library-packs
+          ${{ steps.dotnet-root.outputs.path }}/template-packs
+        key: ${{ runner.os }}-dotnet-workloads-${{ inputs.workloads }}-${{ hashFiles('.github/workloads/rollback.json') }}
+
+    - name: Install Workloads
+      if: ${{ inputs.workloads != '' && steps.workload-cache.outputs.cache-hit != 'true' }}
       shell: pwsh
       run: |
         $rollback = "${{ github.workspace }}/.github/workloads/rollback.json"

--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -12,6 +12,11 @@ runs:
       uses: actions/setup-dotnet@v5.0.1
       with:
         dotnet-version: '10.0.201'
+        cache: true
+        cache-dependency-path: |
+          **/*.csproj
+          **/*.props
+          global.json
 
     - name: Install Workloads
       if: ${{ inputs.workloads != '' }}

--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -104,7 +104,6 @@ jobs:
           name: nuget-packages
           pattern: "*-package"
           retention-days: 30
-          delete-merged: true
 
   # ============================================================
   # Section 1: Core & Snapshot Tests (no pack dependency needed)
@@ -275,7 +274,7 @@ jobs:
           - id: wpf-net10w19041
           - id: wpf-net462
 
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -301,7 +300,7 @@ jobs:
           - id: uno
             tf: net10.0-desktop
             workloads: android
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -333,7 +332,7 @@ jobs:
           - id: uno
             tf: net10.0-desktop
             workloads: maui
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -364,7 +363,7 @@ jobs:
           # - id: uno
           #   tf: net10.0-browserwasm
           #   workloads: wasm-tools android
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -394,7 +393,7 @@ jobs:
           # - id: uno
           #   tf: net10.0-android
           #   workloads: android
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1
@@ -424,7 +423,7 @@ jobs:
           # - id: uno
           #   tf: net10.0-ios
           #   workloads: ios android
-    needs: [pack, collect-packages, prepare]
+    needs: [pack, prepare]
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.1


### PR DESCRIPTION
## Summary

Four independent CI speedups, each in its own commit. No behavior change for the user — just faster checks.

- **NuGet cache** — `actions/setup-dotnet@v5` has a built-in cache for `~/.nuget/packages`. Every job currently does a cold restore (~30–60s); cache hits eliminate that.
- **Workload cache** — `dotnet workload install maui/wasm-tools` pulls multi-GB of packs and runs cold in every workload-needy job (1–3 min each). Now cached under `\$DOTNET_ROOT`, keyed on OS + workload list + `rollback.json` hash.
- **Conditional `dotnet-coverage` install** — UI test jobs (factos / factos-android / factos-ios) installed `dotnet-coverage` but never used it. Skipped now.
- **Decouple `collect-packages` from test critical path** — `collect-packages` no longer gates `test-windows/linux/mac/browser/android/ios`. Tests download per-target `*-package` artifacts directly and start the moment `pack` finishes. The merged `nuget-packages` artifact still gets produced for the PR-comment download link. `delete-merged: true` was dropped so the originals persist (~2x artifact storage during the 30-day retention window).

## Expected gains

- ~30–60s saved per job × ~30 jobs (NuGet cache) — biggest win on second-and-onward runs
- 1–3 min saved per workload-needy job (workload cache) — biggest single saving on the windows/mac UI matrices
- ~30–60s shaved off the critical path between `pack` and UI tests (collect-packages decoupling)
- ~5–15s saved per UI test job (no-op coverage install removed)

Numbers are estimates; we'll have a real comparison after the first cached run.

## Test plan

- [ ] First run will populate caches (no NuGet/workload speedup yet) — confirm nothing breaks
- [ ] Second run on the same branch should hit caches — confirm wall-clock drop
- [ ] Verify UI test matrix still gets per-target packages (pattern: `*-package`)
- [ ] Verify `nuget-packages` merged artifact is still produced and the PR comment download link works
- [ ] Confirm `dotnet-coverage` is still installed for `test-core` and `test-snapshot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)