### PR TITLE
ci: sanitize workload cache key (commas not allowed)

### DIFF
--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -18,7 +18,7 @@ runs:
           **/*.props
           global.json
 
-    - name: Resolve DOTNET_ROOT for workload cache
+    - name: Resolve DOTNET_ROOT and workload cache key
       if: ${{ inputs.workloads != '' }}
       id: dotnet-root
       shell: pwsh
@@ -27,6 +27,9 @@ runs:
         if (-not $root) { $root = Join-Path $HOME ".dotnet" }
         $root = $root -replace '\\','/'
         "path=$root" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        # GitHub cache keys can't contain commas; collapse "wasm-tools, maui" to "wasm-tools-maui"
+        $key = ("${{ inputs.workloads }}" -replace '[, ]+','-').Trim('-')
+        "key=$key" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Cache .NET workloads
       if: ${{ inputs.workloads != '' }}
@@ -39,7 +42,7 @@ runs:
           ${{ steps.dotnet-root.outputs.path }}/metadata
           ${{ steps.dotnet-root.outputs.path }}/library-packs
           ${{ steps.dotnet-root.outputs.path }}/template-packs
-        key: ${{ runner.os }}-dotnet-workloads-${{ inputs.workloads }}-${{ hashFiles('.github/workloads/rollback.json') }}
+        key: ${{ runner.os }}-dotnet-workloads-${{ steps.dotnet-root.outputs.key }}-${{ hashFiles('.github/workloads/rollback.json') }}
 
     - name: Install Workloads
       if: ${{ inputs.workloads != '' && steps.workload-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Summary

Follow-up to #2202. The workload cache key embedded `inputs.workloads` directly, which is `\"wasm-tools, maui\"` for some matrix entries — and GitHub Actions rejects cache keys containing commas:

\`\`\`
Key Validation Error: Windows-dotnet-workloads-wasm-tools, maui-... cannot contain commas.
\`\`\`

That failure cascaded: the pack strategy cancelled, the UI test matrix never ran. Seen on https://github.com/Live-Charts/LiveCharts2/actions/runs/25285789061.

The fix sanitizes the workload list inside the existing pwsh step that resolves `DOTNET_ROOT`, collapsing commas + whitespace runs into a hyphen (so `wasm-tools, maui` becomes `wasm-tools-maui`), and uses that as the key segment.

## Test plan

- [ ] Workflow run on this PR completes without a cache key validation error
- [ ] First run populates the cache; second run shows a hit on \`Windows-dotnet-workloads-wasm-tools-maui-…\`
- [ ] Single-workload matrix entries (e.g. \`maui\`) still produce a valid key
- [ ] No-workload jobs still skip the workload steps entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)