### PR TITLE
chore: bump LatestSkiaSharpVersion 3.119.0 → 3.119.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     Because GPU has better support on the latest versions of SkiaSharp,
     and now LiveCharts defaults to GPU when possible.
     -->
-    <LatestSkiaSharpVersion>3.119.0</LatestSkiaSharpVersion>
+    <LatestSkiaSharpVersion>3.119.1</LatestSkiaSharpVersion>
 
     <!--
     Must be compatible with the SkiaSharp version, on WASM the


### PR DESCRIPTION
## Summary

- SkiaSharp 3.119.0's bundled ANGLE access-violates inside `eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE)` on some Windows + GPU/driver combinations. The crash takes down any chart with `UseGPU = true` during startup. The misleading `Error loading EGL entry points: libGLESv2.dll` line in stderr comes from inside ANGLE — the managed P/Invoke target (`libEGL.dll`), DLL search, and entry-point lookup are all correct.
- Reproduced in isolation with `[LibraryImport("libEGL")]` against each version's bundled `libEGL.dll`: 3.119.0 crashes, 3.119.1 returns a valid display, 3.119.2 returns a valid display.
- Both 3.119.1 and 3.119.2 fix the crash. Picking **3.119.1** over 3.119.2 because Uno.Sdk pins SkiaSharp 3.119.1 — staying on the same patch avoids a transitive version conflict for Uno.WinUI consumers while still unblocking the HA-views regression.
- Bumping the central `LatestSkiaSharpVersion` property in `Directory.Build.props` propagates the fix to every view csproj that consumes it (WPF, WinForms, MAUI, Avalonia, Blazor, WinUI, Uno.WinUI).

## Test plan

- [x] Maui Windows sample with `UseGPU = true` survives startup (was crashing on 3.119.0)
- [x] `LiveChartsCore.SkiaSharpView.Maui` builds clean
- [x] `LiveChartsCore.SkiaSharpView.WPF` builds clean
- [x] `LiveChartsCore.SkiaSharpView.WinForms` builds clean
- [x] `LiveChartsCore.SkiaSharpView.Avalonia` builds clean
- [x] `LiveChartsCore.SkiaSharpView.Blazor` builds clean
- [x] `LiveChartsCore.SkiaSharpView.WinUI` builds clean
- [ ] CI runs MAUI/WinUI hardware-accelerated tests (`ShouldLoadHardwareAcceleratedView`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)