### PR TITLE
ci: revert .NET workload cache (regressed pack times)

### DIFF
--- a/.github/actions/setup-dotnet-and-workloads/action.yml
+++ b/.github/actions/setup-dotnet-and-workloads/action.yml
@@ -18,34 +18,8 @@ runs:
           **/*.props
           global.json
 
-    - name: Resolve DOTNET_ROOT and workload cache key
-      if: ${{ inputs.workloads != '' }}
-      id: dotnet-root
-      shell: pwsh
-      run: |
-        $root = $env:DOTNET_ROOT
-        if (-not $root) { $root = Join-Path $HOME ".dotnet" }
-        $root = $root -replace '\\','/'
-        "path=$root" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-        # GitHub cache keys can't contain commas; collapse "wasm-tools, maui" to "wasm-tools-maui"
-        $key = ("${{ inputs.workloads }}" -replace '[, ]+','-').Trim('-')
-        "key=$key" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-    - name: Cache .NET workloads
-      if: ${{ inputs.workloads != '' }}
-      id: workload-cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ${{ steps.dotnet-root.outputs.path }}/sdk-manifests
-          ${{ steps.dotnet-root.outputs.path }}/packs
-          ${{ steps.dotnet-root.outputs.path }}/metadata
-          ${{ steps.dotnet-root.outputs.path }}/library-packs
-          ${{ steps.dotnet-root.outputs.path }}/template-packs
-        key: ${{ runner.os }}-dotnet-workloads-${{ steps.dotnet-root.outputs.key }}-${{ hashFiles('.github/workloads/rollback.json') }}
-
     - name: Install Workloads
-      if: ${{ inputs.workloads != '' && steps.workload-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.workloads != '' }}
       shell: pwsh
       run: |
         $rollback = "${{ github.workspace }}/.github/workloads/rollback.json"


### PR DESCRIPTION
## Summary

The workload cache from #2202 made things worse: workload-needy pack jobs went from ~3 min to **16-22 min** on PR #2204 (avalonia-skiasharp 16m24s, maui-skiasharp 17m33s, uno-skiasharp 22m26s). Non-workload packs were unaffected (1-3 min).

## Root cause

`$DOTNET_ROOT/packs` doesn't only hold workload packs — it also holds the SDK's framework reference packs (`Microsoft.NETCore.App.Ref`, `Microsoft.WindowsDesktop.App.Ref`, etc., for every targeted TFM). Caching the whole directory swept those in, making the cache multi-GB and turning the save/restore step itself into the bottleneck.

## Fix

Revert the workload cache only. Keep the NuGet cache, conditional dotnet-coverage install, and collect-packages decoupling from #2202.

If we re-attempt workload caching later, scope the path to the workload-specific subdirectories (`sdk-manifests`, `metadata/workloads`, plus a glob-filtered subset of `packs/`) — not all of `$DOTNET_ROOT/packs`.

## Test plan

- [ ] Workload-needy pack jobs (avalonia-skiasharp, maui-skiasharp, uno-skiasharp) return to their pre-#2202 timing
- [ ] Non-workload pack jobs unaffected
- [ ] No cache-related warnings/errors in workload jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)