### PR TITLE
fix(maui): release apple-side handler chain on chart unload (#1725)

### DIFF
--- a/samples/AvaloniaSample/Test/Dispose/View.axaml.cs
+++ b/samples/AvaloniaSample/Test/Dispose/View.axaml.cs
@@ -21,6 +21,14 @@ public partial class View : UserControl
         return GetCharts(swappedOut);
     }
 
+    public void ReattachSameInstance()
+    {
+        var content = this.Find<ContentControl>("content")!;
+        var page = (UserControl1)content.Content!;
+        content.Content = null;
+        content.Content = page;
+    }
+
     private static object[] GetCharts(UserControl1 uc)
     {
         if (uc.Content is not Grid grid) return [];

--- a/samples/AvaloniaSample/Test/Dispose/View.axaml.cs
+++ b/samples/AvaloniaSample/Test/Dispose/View.axaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -10,10 +11,22 @@ public partial class View : UserControl
         InitializeComponent();
     }
 
-    private void Button_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private void Button_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) => _ = ChangeContent();
+
+    public object[] ChangeContent()
     {
         var content = this.Find<ContentControl>("content")!;
+        var swappedOut = (UserControl1)content.Content!;
         content.Content = new UserControl1();
+        return GetCharts(swappedOut);
+    }
+
+    private static object[] GetCharts(UserControl1 uc)
+    {
+        if (uc.Content is not Grid grid) return [];
+        var charts = new List<object>(grid.Children.Count);
+        foreach (var child in grid.Children) charts.Add(child);
+        return [.. charts];
     }
 
     private void InitializeComponent()

--- a/samples/MauiSample/Test/Dispose/View.xaml
+++ b/samples/MauiSample/Test/Dispose/View.xaml
@@ -10,7 +10,5 @@
         </Grid.RowDefinitions>
 
         <Button Grid.Row="0" Clicked="Button_Clicked" Text="Change"></Button>
-
-        <local:NewPage1 Grid.Row="1" x:Name="content"></local:NewPage1>
     </Grid>
 </ContentPage>

--- a/samples/MauiSample/Test/Dispose/View.xaml.cs
+++ b/samples/MauiSample/Test/Dispose/View.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace MauiSample.Test.Dispose;
+namespace MauiSample.Test.Dispose;
 
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class View : ContentPage
@@ -8,15 +8,20 @@ public partial class View : ContentPage
     public View()
     {
         InitializeComponent();
-        _currentView = content;
-    }
-
-    private void Button_Clicked(object sender, EventArgs e)
-    {
-        _ = container.Remove(_currentView);
-        _currentView = null!;
         _currentView = new NewPage1();
         Grid.SetRow(_currentView, 1);
         container.Add(_currentView);
+    }
+
+    private void Button_Clicked(object sender, EventArgs e) => _ = ChangeContent();
+
+    public ContentView ChangeContent()
+    {
+        var swappedOut = _currentView;
+        _ = container.Remove(_currentView);
+        _currentView = new NewPage1();
+        Grid.SetRow(_currentView, 1);
+        container.Add(_currentView);
+        return swappedOut;
     }
 }

--- a/samples/MauiSample/Test/Dispose/View.xaml.cs
+++ b/samples/MauiSample/Test/Dispose/View.xaml.cs
@@ -3,7 +3,7 @@ namespace MauiSample.Test.Dispose;
 [XamlCompilation(XamlCompilationOptions.Compile)]
 public partial class View : ContentPage
 {
-    private ContentView _currentView;
+    private NewPage1 _currentView;
 
     public View()
     {
@@ -15,13 +15,21 @@ public partial class View : ContentPage
 
     private void Button_Clicked(object sender, EventArgs e) => _ = ChangeContent();
 
-    public ContentView ChangeContent()
+    public object[] ChangeContent()
     {
         var swappedOut = _currentView;
         _ = container.Remove(_currentView);
         _currentView = new NewPage1();
         Grid.SetRow(_currentView, 1);
         container.Add(_currentView);
-        return swappedOut;
+        return GetCharts(swappedOut);
+    }
+
+    private static object[] GetCharts(NewPage1 page)
+    {
+        if (page.Content is not Grid grid) return [];
+        var charts = new List<object>(grid.Children.Count);
+        foreach (var child in grid.Children) charts.Add(child);
+        return [.. charts];
     }
 }

--- a/samples/MauiSample/Test/Dispose/View.xaml.cs
+++ b/samples/MauiSample/Test/Dispose/View.xaml.cs
@@ -25,6 +25,13 @@ public partial class View : ContentPage
         return GetCharts(swappedOut);
     }
 
+    public void ReattachSameInstance()
+    {
+        _ = container.Remove(_currentView);
+        Grid.SetRow(_currentView, 1);
+        container.Add(_currentView);
+    }
+
     private static object[] GetCharts(NewPage1 page)
     {
         if (page.Content is not Grid grid) return [];

--- a/samples/WPFSample/Test/Dispose/View.xaml.cs
+++ b/samples/WPFSample/Test/Dispose/View.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Controls;
+using System.Collections.Generic;
+using System.Windows.Controls;
 
 namespace WPFSample.Test.Dispose;
 
@@ -12,9 +13,20 @@ public partial class View : UserControl
         InitializeComponent();
     }
 
-    private void Button_Click(object sender, System.Windows.RoutedEventArgs e)
+    private void Button_Click(object sender, System.Windows.RoutedEventArgs e) => _ = ChangeContent();
+
+    public object[] ChangeContent()
     {
-        var content = (ContentControl)FindName("content");
+        var swappedOut = (UserControl1)content.Content;
         content.Content = new UserControl1();
+        return GetCharts(swappedOut);
+    }
+
+    private static object[] GetCharts(UserControl1 uc)
+    {
+        if (uc.Content is not Grid grid) return [];
+        var charts = new List<object>(grid.Children.Count);
+        foreach (var child in grid.Children) charts.Add(child!);
+        return [.. charts];
     }
 }

--- a/samples/WPFSample/Test/Dispose/View.xaml.cs
+++ b/samples/WPFSample/Test/Dispose/View.xaml.cs
@@ -22,6 +22,13 @@ public partial class View : UserControl
         return GetCharts(swappedOut);
     }
 
+    public void ReattachSameInstance()
+    {
+        var page = (UserControl1)content.Content;
+        content.Content = null;
+        content.Content = page;
+    }
+
     private static object[] GetCharts(UserControl1 uc)
     {
         if (uc.Content is not Grid grid) return [];

--- a/samples/WinUISample/WinUISample/Samples/Test/Dispose/View.xaml.cs
+++ b/samples/WinUISample/WinUISample/Samples/Test/Dispose/View.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Controls;
 
 namespace WinUISample.Test.Dispose;
 
@@ -9,8 +10,20 @@ public sealed partial class View : UserControl
         InitializeComponent();
     }
 
-    private void Button_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    private void Button_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e) => _ = ChangeContent();
+
+    public object[] ChangeContent()
     {
+        var swappedOut = (UserControl1)content.Content;
         content.Content = new UserControl1();
+        return GetCharts(swappedOut);
+    }
+
+    private static object[] GetCharts(UserControl1 uc)
+    {
+        if (uc.Content is not Grid grid) return [];
+        var charts = new List<object>(grid.Children.Count);
+        foreach (var child in grid.Children) charts.Add(child);
+        return [.. charts];
     }
 }

--- a/samples/WinUISample/WinUISample/Samples/Test/Dispose/View.xaml.cs
+++ b/samples/WinUISample/WinUISample/Samples/Test/Dispose/View.xaml.cs
@@ -19,6 +19,13 @@ public sealed partial class View : UserControl
         return GetCharts(swappedOut);
     }
 
+    public void ReattachSameInstance()
+    {
+        var page = (UserControl1)content.Content;
+        content.Content = null;
+        content.Content = page;
+    }
+
     private static object[] GetCharts(UserControl1 uc)
     {
         if (uc.Content is not Grid grid) return [];

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
@@ -92,6 +92,18 @@ public abstract partial class SourceGenChart : ChartView, IChartView
     {
         StopObserving();
         CoreChart?.Unload();
+#if IOS || MACCATALYST
+        // Maui doesn't auto-DisconnectHandler when an Element leaves the visual tree.
+        // On Apple, ChartViewHandler.ConnectHandler attaches PointerController's
+        // UIKit gesture recognizers (UILongPress/UIPinch/UIPan/UIHover) to the
+        // platform UIView; UIKit holds the recognizers' selector target (the
+        // controller) strongly, the handler subscribes to the controller via
+        // instance methods, and Handler.VirtualView pins the chart — leaking
+        // every chart removed from the visual tree (#1725). Other platforms
+        // exhibit the same +=/-= pattern but don't leak in practice (no
+        // equivalent native-peer pinning), so scope this to Apple.
+        Handler?.DisconnectHandler();
+#endif
     }
 
     private ISeries InflateSeriesTemplate(object item)

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
@@ -66,8 +66,14 @@ public abstract partial class SourceGenMapChart : ChartView, IGeoMapView
     private void OnLoaded(object? sender, EventArgs e) =>
         CoreChart?.Load();
 
-    private void OnUnloaded(object? sender, EventArgs e) =>
+    private void OnUnloaded(object? sender, EventArgs e)
+    {
         CoreChart?.Unload();
+#if IOS || MACCATALYST
+        // See SourceGenChart.OnUnloaded for the rationale (#1725).
+        Handler?.DisconnectHandler();
+#endif
+    }
 
     void IGeoMapView.InvokeOnUIThread(Action action) =>
         MainThread.BeginInvokeOnMainThread(action);

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -36,6 +36,12 @@ public class DisposeTests
         var weakRefs = new List<WeakReference>();
 
         const int Iterations = 5;
+        // The Test/Dispose sample's swapped-in page hosts a CartesianChart, PieChart,
+        // PolarChart, and GeoMap. The probe walks Grid.Children, so any future change to
+        // the sample layout (extra children, wrapper panel) will diverge from this number
+        // and fail the sanity check below — telling us the probe needs updating instead
+        // of silently dropping coverage of the leak we were trying to canary.
+        const int ChartsPerPage = 4;
         for (var i = 0; i < Iterations; i++)
         {
             // Add the weak refs in a non-async helper so the swapped-out chart references
@@ -57,12 +63,17 @@ public class DisposeTests
         GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
 
         var alive = weakRefs.Count(r => r.IsAlive);
+        var expected = Iterations * ChartsPerPage;
         Assert.True(
-            alive == 0 && weakRefs.Count >= Iterations,
-            $"{alive}/{weakRefs.Count} unloaded chart instances were still alive after GC. " +
-            "An unloaded chart must not be rooted by anything in the app. The likely cause is " +
-            "a `this`-capturing event subscription in the chart that is never detached, or a " +
-            "static collection / accumulator field that the chart was added to. See " +
+            alive == 0 && weakRefs.Count == expected,
+            $"{alive}/{weakRefs.Count} unloaded chart instances were still alive after GC " +
+            $"(expected {expected} tracked: {Iterations} swaps x {ChartsPerPage} charts/page). " +
+            "If the count differs, the visual-tree probe in the platform's ChangeContent() " +
+            "is no longer finding every chart and this canary has stopped covering part of " +
+            "the leak scenario — update GetCharts() / ChartsPerPage to match the sample. " +
+            "If alive > 0, an unloaded chart is rooted by something in the app — likely a " +
+            "`this`-capturing event subscription that is never detached, or a static " +
+            "collection / accumulator field. See " +
             "https://github.com/Live-Charts/LiveCharts2/issues/1725.");
     }
 

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -1,0 +1,79 @@
+using Factos;
+using SharedUITests.Helpers;
+using Xunit;
+
+#if MAUI_UI_TESTING
+using Microsoft.Maui.Controls;
+#endif
+
+// to run these tests, see the UITests project, specially the program.cs file.
+// to enable IDE intellisense for these tests, go to Directory.Build.props and set UITesting to true.
+
+namespace SharedUITests;
+
+public class DisposeTests
+{
+    public AppController App => AppController.Current;
+
+#if MAUI_UI_TESTING
+    // https://github.com/Live-Charts/LiveCharts2/issues/1725
+    //
+    // A chart removed from the visual tree must be collectable — its inner MotionCanvas /
+    // SKCanvasView occupy substantial memory and the original report describes them piling up
+    // page-after-page. Today the symptom does not reproduce on Maui 10 because Maui's
+    // Application.RequestedThemeChanged uses a WeakEventManager, so a chart's `this`-capturing
+    // theme subscription does not actually root the chart. This test is a canary: if a future
+    // Maui (or our own code) regresses to holding charts strongly via an app-level event,
+    // accumulator field, or static collection, this test fires.
+    //
+    // We weak-ref the charts directly, not the parent page. In Maui 10+, Element.Parent is a
+    // WeakReference, so a strong root on a chart does not propagate up to its parent — testing
+    // page survival would silently miss a real chart leak.
+    [AppTestMethod]
+    public async Task UnloadedChartsShouldBeCollectable_Issue1725()
+    {
+        var sut = await App.NavigateTo<Samples.Test.Dispose.View>();
+        await Task.Delay(1000);
+
+        var weakRefs = new List<WeakReference>();
+
+        const int Iterations = 5;
+        for (var i = 0; i < Iterations; i++)
+        {
+            // Inline the call so the swapped-out page is never bound to a named local; a local
+            // declared inside this loop would be hoisted by the async state machine into a
+            // long-lived field that survives across the awaits below, masking the leak.
+            CaptureChartWeakRefs(sut.ChangeContent(), weakRefs);
+            await Task.Delay(500);
+        }
+
+        // One untracked extra swap to push the most-recent tracked instance out of any
+        // transient reference Maui's layout/dispatcher holds for the latest unload.
+        _ = sut.ChangeContent();
+
+        // Let Maui's dispatcher drain any queued unload work.
+        await Task.Delay(2000);
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        var alive = weakRefs.Count(r => r.IsAlive);
+        Assert.True(
+            alive == 0 && weakRefs.Count >= Iterations,
+            $"{alive}/{weakRefs.Count} unloaded chart instances were still alive after GC. " +
+            "An unloaded chart must not be rooted by anything in the app. The likely cause is " +
+            "a `this`-capturing event subscription in the chart that is never detached, or a " +
+            "static collection / accumulator field that the chart was added to. See " +
+            "https://github.com/Live-Charts/LiveCharts2/issues/1725.");
+    }
+
+    private static void CaptureChartWeakRefs(ContentView swappedOutPage, List<WeakReference> weakRefs)
+    {
+        if (swappedOutPage.Content is not Grid grid) return;
+        foreach (var child in grid.Children)
+            if (child is View view)
+                weakRefs.Add(new WeakReference(view));
+    }
+#endif
+}

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -2,10 +2,6 @@ using Factos;
 using SharedUITests.Helpers;
 using Xunit;
 
-#if MAUI_UI_TESTING
-using Microsoft.Maui.Controls;
-#endif
-
 // to run these tests, see the UITests project, specially the program.cs file.
 // to enable IDE intellisense for these tests, go to Directory.Build.props and set UITesting to true.
 
@@ -15,20 +11,22 @@ public class DisposeTests
 {
     public AppController App => AppController.Current;
 
-#if MAUI_UI_TESTING
+#if XAML_UI_TESTING
     // https://github.com/Live-Charts/LiveCharts2/issues/1725
     //
     // A chart removed from the visual tree must be collectable — its inner MotionCanvas /
     // SKCanvasView occupy substantial memory and the original report describes them piling up
-    // page-after-page. Today the symptom does not reproduce on Maui 10 because Maui's
-    // Application.RequestedThemeChanged uses a WeakEventManager, so a chart's `this`-capturing
-    // theme subscription does not actually root the chart. This test is a canary: if a future
-    // Maui (or our own code) regresses to holding charts strongly via an app-level event,
-    // accumulator field, or static collection, this test fires.
+    // page-after-page on Maui 8. The symptom no longer reproduces on Maui 10 (Application
+    // events are routed through a WeakEventManager) but the same invariant — unloaded chart
+    // is GC-able — should hold on every Xaml platform we ship. This canary fires if a future
+    // platform release (or our own code) regresses to a strong app-level root on charts:
+    // a `this`-capturing event subscription that's never detached, an accumulator field, a
+    // static collection, etc.
     //
-    // We weak-ref the charts directly, not the parent page. In Maui 10+, Element.Parent is a
-    // WeakReference, so a strong root on a chart does not propagate up to its parent — testing
-    // page survival would silently miss a real chart leak.
+    // Each platform's Test/Dispose/View exposes `ChangeContent()` that swaps the inner
+    // content for a fresh one and returns the chart objects from the swapped-out instance.
+    // We weak-ref the charts directly because Maui 10's Element.Parent is a WeakReference,
+    // so testing leaks via "did the parent page survive?" silently misses real chart leaks.
     [AppTestMethod]
     public async Task UnloadedChartsShouldBeCollectable_Issue1725()
     {
@@ -40,18 +38,18 @@ public class DisposeTests
         const int Iterations = 5;
         for (var i = 0; i < Iterations; i++)
         {
-            // Inline the call so the swapped-out page is never bound to a named local; a local
-            // declared inside this loop would be hoisted by the async state machine into a
-            // long-lived field that survives across the awaits below, masking the leak.
-            CaptureChartWeakRefs(sut.ChangeContent(), weakRefs);
+            // Add the weak refs in a non-async helper so the swapped-out chart references
+            // are never bound to locals that the async state machine could hoist into
+            // long-lived fields surviving across the awaits below.
+            AddWeakRefs(weakRefs, sut.ChangeContent());
             await Task.Delay(500);
         }
 
         // One untracked extra swap to push the most-recent tracked instance out of any
-        // transient reference Maui's layout/dispatcher holds for the latest unload.
+        // transient reference the platform's layout/dispatcher holds for the latest unload.
         _ = sut.ChangeContent();
 
-        // Let Maui's dispatcher drain any queued unload work.
+        // Let the platform's dispatcher drain any queued unload work.
         await Task.Delay(2000);
 
         GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
@@ -68,12 +66,10 @@ public class DisposeTests
             "https://github.com/Live-Charts/LiveCharts2/issues/1725.");
     }
 
-    private static void CaptureChartWeakRefs(ContentView swappedOutPage, List<WeakReference> weakRefs)
+    private static void AddWeakRefs(List<WeakReference> refs, object[] objects)
     {
-        if (swappedOutPage.Content is not Grid grid) return;
-        foreach (var child in grid.Children)
-            if (child is View view)
-                weakRefs.Add(new WeakReference(view));
+        foreach (var o in objects)
+            refs.Add(new WeakReference(o));
     }
 #endif
 }

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -82,5 +82,25 @@ public class DisposeTests
         foreach (var o in objects)
             refs.Add(new WeakReference(o));
     }
+
+    // Smoke test: a chart removed and immediately re-added (same instance) must
+    // survive the round-trip. Specifically guards the Apple-side fix in
+    // SourceGenChart.OnUnloaded — `Handler?.DisconnectHandler()` plus the
+    // platform's auto-disconnect default must leave the element ready for a
+    // fresh handler on the next attach. If we ever reuse a handler with a
+    // disposed PointerController (recognizers nulled by DisposeController on
+    // Mac/iOS), this test crashes in InitializeController.
+    [AppTestMethod]
+    public async Task ChartShouldSurviveReattachOfSameInstance_Issue1725()
+    {
+        var sut = await App.NavigateTo<Samples.Test.Dispose.View>();
+        await Task.Delay(1000);
+
+        for (var i = 0; i < 3; i++)
+        {
+            sut.ReattachSameInstance();
+            await Task.Delay(500);
+        }
+    }
 #endif
 }


### PR DESCRIPTION
## Summary

Supersedes #2205. The canary that PR shipped (commits preserved on this branch) was meant to be a no-op on Maui 10, but on Mac Catalyst and iOS it fires deterministically — 20/20 charts retained across 5 page swaps. Confirmed locally on lcmac.

## Root cause

`ChartViewHandler.ConnectHandler` attaches `PointerController`'s UIKit gesture recognizers (`UILongPress` / `UIPinch` / `UIPan` / `UIHover`) to the platform `UIView`. On Apple this creates a chain that pins the chart:

- UIKit holds the recognizers' selector target (the `PointerController`) strongly — it's a native-peer pin via the gesture-recognizer/RunLoop graph
- `ChartViewHandler` subscribes to `PointerController.Pressed`/`Moved`/etc via instance-method delegates → handler is rooted by the controller
- `Handler.VirtualView` keeps the chart alive
- Maui does **not** auto-call `DisconnectHandler` when an Element leaves the visual tree

Stubbing `Application.RequestedThemeChanged` and `DeviceDisplay.MainDisplayInfoChanged` (the two prior leak hypotheses on Apple) did not change the canary outcome — both ruled out as the leak vector.

## Fix

Call `Handler?.DisconnectHandler()` from `OnUnloaded` in `SourceGenChart.cs` and `SourceGenMapChart.maui.cs`, gated `#if IOS || MACCATALYST`. This triggers `ChartViewHandler.DisconnectHandler` → `PointerController.DisposeController` → recognizers removed from the platform view → chain breaks → chart is collectable. Reattach is safe; Maui rebuilds handlers on next `Loaded`.

Apple-only because Windows/WinUI's `PointerController` has the same `+=`/`-=` subscription pattern but doesn't leak in practice (no equivalent native-peer pinning); modifying tested-clean territory would be untested motion.

## Test plan

- [x] Mac Catalyst: full UITests run on lcmac, **11/11 pass**, 50s
- [x] iOS 26.1 sim (iPhone 11): full UITests run on lcmac, pass
- [x] Canary used is the existing one in `tests/SharedUITests/DisposeTests.cs` (no test changes needed for verification)
- [x] CI: cross-platform run (Mac Catalyst + iOS Maui were the 2 failing jobs in #2205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)