### PR TITLE
fix(blazor): re-enable Blazor UI tests; SKCanvasView opt-in via UseGPU

### DIFF
--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -354,9 +354,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ToDo: find why not running.
-          # - id: blazor
-          #   workloads: wasm-tools
+          - id: blazor
+            workloads: wasm-tools
           - id: avalonia-browser
             workloads: wasm-tools
           # ToDo: find why not running.

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -256,6 +256,22 @@ framework wants. It is normally already using hardware acceleration, but complet
 framework.
 :::
 
+{{~ if blazor ~}}
+:::tip
+**Blazor is the exception**: `UseGPU` defaults to **`true`** because the WebGL-backed `SKGLView`
+produces desktop-quality charts, while raster mode (`SKCanvasView`) is visibly lower quality. If
+your environment cannot create a WebGL context — for example a headless browser without a software
+WebGL fallback, or a sandbox that blocks the WebGL feature — explicitly opt out:
+
+```csharp
+LiveCharts.Configure(c => c
+    .HasRenderingSettings(s => s.UseGPU = false));
+```
+
+This must run before the first chart is rendered (i.e., in `App.razor`'s `OnInitialized`).
+:::
+{{~ end ~}}
+
 GPU improves the time it takes to render a frame, which results in smoother and more efficient animations,
 but as today, there are some known issues when using the SkiaSharp hardware accelerated views 
 (specially when disposing/re-creating the controls), you can turn on hardware acceleration, 

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -259,16 +259,21 @@ framework.
 {{~ if blazor ~}}
 :::tip
 **Blazor is the exception**: `UseGPU` defaults to **`true`** because the WebGL-backed `SKGLView`
-produces desktop-quality charts, while raster mode (`SKCanvasView`) is visibly lower quality. If
-your environment cannot create a WebGL context — for example a headless browser without a software
-WebGL fallback, or a sandbox that blocks the WebGL feature — explicitly opt out:
+produces desktop-quality charts, while raster mode (`SKCanvasView`) is visibly lower quality.
+
+You will want to opt out of WebGL when:
+- You render **many charts on the same page**. Browsers cap the number of live WebGL contexts (`~8`
+  in Chromium); past that limit older charts go blank with a `Too many active WebGL contexts. Oldest
+  context will be lost.` warning in the console.
+- Your environment cannot create a WebGL context at all (headless browsers without a software
+  WebGL fallback, sandboxed iframes that block the WebGL feature, etc.).
+
+Opt out before the first chart is rendered (i.e. in `App.razor`'s `OnInitialized`):
 
 ```csharp
 LiveCharts.Configure(c => c
     .HasRenderingSettings(s => s.UseGPU = false));
 ```
-
-This must run before the first chart is rendered (i.e., in `App.razor`'s `OnInitialized`).
 :::
 {{~ end ~}}
 

--- a/samples/BlazorSample/App.razor
+++ b/samples/BlazorSample/App.razor
@@ -22,6 +22,14 @@
         // LiveCharts configuration section: // mark
         LiveCharts.Configure(c => c // mark
             .AddLiveChartsAppSettings()); // mark
+
+#if BLAZOR_UI_TESTING
+        // Headless Chrome on the GHA Linux runner has no GPU and (post-Chrome 12x)
+        // no implicit SwiftShader fallback for WebGL, so SKGLView's InitGL probe
+        // fails. Tests run on the SKCanvasView raster path; production users
+        // keep the Blazor default of UseGPU=true (WebGL).
+        LiveCharts.Configure(c => c.HasRenderingSettings(s => s.UseGPU = false));
+#endif
     }
 
     // protected override async Task OnInitializedAsync()

--- a/src/LiveChartsCore/Kernel/RenderingSettings.cs
+++ b/src/LiveChartsCore/Kernel/RenderingSettings.cs
@@ -27,13 +27,38 @@ namespace LiveChartsCore.Kernel;
 /// </summary>
 public class RenderingSettings
 {
+    private bool _useGPU;
+    private bool _useGPUExplicit;
+
     /// <summary>
     /// Indicates whether hardware acceleration is used, this will only work
     /// if the platform and device support it.
     /// This is ignored in Avalonia and Uno-Desktop because in those platforms
     /// the frame rate and rendering cadence is determined by them.
+    /// Default is false, except on Blazor where the default is true (WebGL
+    /// renders desktop-quality charts; raster mode is uglier and only worth
+    /// opting into when WebGL is unavailable).
     /// </summary>
-    public bool UseGPU { get; set; } = false;
+    public bool UseGPU
+    {
+        get => _useGPU;
+        set
+        {
+            _useGPU = value;
+            _useGPUExplicit = true;
+        }
+    }
+
+    /// <summary>
+    /// Sets the default value for <see cref="UseGPU"/> from a view-platform
+    /// initializer. No-op if the consumer has already assigned <see cref="UseGPU"/>
+    /// explicitly, so user configuration always wins over platform defaults.
+    /// </summary>
+    internal void SetPlatformDefaultUseGPU(bool value)
+    {
+        if (_useGPUExplicit) return;
+        _useGPU = value;
+    }
 
     /// Indicates whether the rendering cadence should be aligned with the display refresh rate,
     /// GPU acceleration is required for this to work.

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor
@@ -37,14 +37,30 @@
 -->
 
 <div>
-    <SKGLView
-	    @ref="_glView"
-	    OnPaintSurface="OnPaintGlSurface"
-	    IgnorePixelScaling="true"
-	    @onpointerdown="OnPointerDown"
-	    @onpointermove="OnPointerMove"
-	    @onpointerup="OnPointerUp"
-	    @onpointerout="OnPointerOut"
-	    @onmousewheel="OnWheel">
-    </SKGLView>
+    @if (_useGpu)
+    {
+        <SKGLView
+	        @ref="_glView"
+	        OnPaintSurface="OnPaintGlSurface"
+	        IgnorePixelScaling="true"
+	        @onpointerdown="OnPointerDown"
+	        @onpointermove="OnPointerMove"
+	        @onpointerup="OnPointerUp"
+	        @onpointerout="OnPointerOut"
+	        @onmousewheel="OnWheel">
+        </SKGLView>
+    }
+    else
+    {
+        <SKCanvasView
+	        @ref="_canvasView"
+	        OnPaintSurface="OnPaintCanvasSurface"
+	        IgnorePixelScaling="true"
+	        @onpointerdown="OnPointerDown"
+	        @onpointermove="OnPointerMove"
+	        @onpointerup="OnPointerUp"
+	        @onpointerout="OnPointerOut"
+	        @onmousewheel="OnWheel">
+        </SKCanvasView>
+    }
 </div>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/MotionCanvas.razor.cs
@@ -35,7 +35,17 @@ namespace LiveChartsCore.SkiaSharpView.Blazor;
 /// <inheritdoc cref="CoreMotionCanvas"/>
 public partial class MotionCanvas : IDisposable, IRenderMode
 {
-    private SKGLView _glView = null!;
+    // Blazor's platform default for UseGPU is true: SKGLView (WebGL) renders
+    // desktop-quality charts. Raster mode (SKCanvasView) is uglier and is
+    // mainly useful when WebGL is unavailable (e.g. headless CI without
+    // SwiftShader, sandboxed iframes blocking WebGL contexts). Users opt out
+    // of GPU via:
+    //     LiveCharts.Configure(c => c.HasRenderingSettings(s => s.UseGPU = false));
+    // The flag is read once at instance construction; flipping it later on
+    // the global RenderingSettings has no effect on already-mounted charts.
+    private SKGLView? _glView;
+    private SKCanvasView? _canvasView;
+    private readonly bool _useGpu;
     private DotNetObjectReference<MotionCanvas>? _dotNetRef;
     private DomJsInterop? _dom;
     private IFrameTicker _ticker = null!;
@@ -43,6 +53,18 @@ public partial class MotionCanvas : IDisposable, IRenderMode
     static MotionCanvas()
     {
         _ = LiveChartsSkiaSharp.EnsureInitialized();
+        // Override the framework-wide UseGPU default for Blazor only — and only
+        // if the consumer has not already assigned UseGPU explicitly. WPF /
+        // WinForms / etc. don't call this and keep the false default.
+        LiveCharts.RenderingSettings.SetPlatformDefaultUseGPU(true);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MotionCanvas"/> class.
+    /// </summary>
+    public MotionCanvas()
+    {
+        _useGpu = LiveCharts.RenderingSettings.UseGPU;
     }
 
     /// <summary>
@@ -138,18 +160,24 @@ public partial class MotionCanvas : IDisposable, IRenderMode
     protected virtual void OnPointerOut(PointerEventArgs e) =>
         _ = OnPointerOutCallback.InvokeAsync(e);
 
-    private void OnPaintGlSurface(SKPaintGLSurfaceEventArgs e)
+    private void OnPaintGlSurface(SKPaintGLSurfaceEventArgs e) =>
+        PaintFrame(e.Info.Width, e.Info.Height, e.Surface);
+
+    private void OnPaintCanvasSurface(SKPaintSurfaceEventArgs e) =>
+        PaintFrame(e.Info.Width, e.Info.Height, e.Surface);
+
+    private void PaintFrame(int width, int height, SkiaSharp.SKSurface surface)
     {
-        var sizeChanged = Width != e.Info.Width || Height != e.Info.Height;
+        var sizeChanged = Width != width || Height != height;
         if (sizeChanged)
         {
-            Width = e.Info.Width;
-            Height = e.Info.Height;
+            Width = width;
+            Height = height;
             SizeChanged?.Invoke();
         }
 
         CanvasCore.DrawFrame(
-            new SkiaSharpDrawingContext(CanvasCore, e.Surface.Canvas, SkiaSharp.SKColor.Empty));
+            new SkiaSharpDrawingContext(CanvasCore, surface.Canvas, SkiaSharp.SKColor.Empty));
     }
 
     /// <inheritdoc/>
@@ -172,6 +200,7 @@ public partial class MotionCanvas : IDisposable, IRenderMode
         _ticker?.DisposeTicker();
         _ticker = null!;
         _glView?.Dispose();
+        _canvasView?.Dispose();
         _ = (_dom?.StopFrameTicker(_dotNetRef!));
         _dotNetRef?.Dispose();
         _dotNetRef = null;
@@ -185,14 +214,19 @@ public partial class MotionCanvas : IDisposable, IRenderMode
     public void OnFrameTick()
     {
         if (CanvasCore.IsValid) return;
-        _glView.Invalidate();
+        Invalidate();
     }
 
     void IRenderMode.InitializeRenderMode(CoreMotionCanvas canvas) =>
         throw new NotImplementedException();
 
-    void IRenderMode.InvalidateRenderer() =>
+    void IRenderMode.InvalidateRenderer() => Invalidate();
+
+    private void Invalidate()
+    {
         _glView?.Invalidate();
+        _canvasView?.Invalidate();
+    }
 
     void IRenderMode.DisposeRenderMode() =>
         throw new NotImplementedException();


### PR DESCRIPTION
Closes #957

## Summary
- `RenderingSettings.UseGPU` now tracks whether the consumer assigned it explicitly, plus an internal `SetPlatformDefaultUseGPU(bool)` for view-platform initializers to set their own backend default without overriding consumer config.
- `MotionCanvas.razor` (Blazor) picks `SKGLView` when `UseGPU == true` and `SKCanvasView` when `false`, mirroring WPF's GPU/CPU split. The flag was previously ignored — `SKGLView` was hardcoded — which is the bug surfaced in #957: setting `LiveCharts.RenderingSettings.UseGPU = false` had no effect, so consumers running into the browser's WebGL-context cap (~8 contexts) had no escape hatch.
- Static `MotionCanvas` ctor calls `SetPlatformDefaultUseGPU(true)` — Blazor's effective default stays at GPU/WebGL (so existing consumers see no quality change).
- `BlazorSample/App.razor` explicitly opts into raster under `#if BLAZOR_UI_TESTING` so headless-CI runs hit `SKCanvasView` instead of failing on a WebGL probe.
- `.github/workflows/livecharts.yml`: re-enable the `blazor` row in the `test-browser` matrix.
- `docs/overview/1.2.install.md`: document the Blazor exception alongside the existing Avalonia/Uno tip, including the multi-chart / WebGL-context-cap scenario.

## Why this shape
Blazor's previous `MotionCanvas` hardcoded `SKGLView`, so every existing Blazor consumer is already using WebGL. WebGL renders desktop-quality charts; raster mode is visibly lower-quality, so flipping the default would regress the user-facing look for everyone. The fix here keeps Blazor's effective default at GPU/WebGL but makes `UseGPU=false` actually do something useful — switch to raster — for environments that can't create a WebGL context (headless Chrome on GHA Linux without SwiftShader, sandboxed iframes) **and for pages with many charts that hit Chromium's "Too many active WebGL contexts. Oldest context will be lost." cap**.

Related: [`beto-rodriguez/Factos#17`](https://github.com/beto-rodriguez/Factos/pull/17) adds `--enable-unsafe-swiftshader --use-angle=swiftshader` to Factos's `HeadlessChrome` argument list. Not required for these tests anymore (raster doesn't use WebGL), but useful for any other Factos consumer that wants software WebGL in headless CI.

## Local verification
- `dotnet UITests.dll --select blazor` against the BlazorSample on Windows 11: **`Tests results for blazor — Passed 4, Failed 0` in 31s**, full orchestrator round-trip with `Test session finished` from the SignalR side. No `Compiling native assets with emcc` line in the publish (raster doesn't pull in the native build path).
- A non-test publish of `BlazorSample` still uses `SKGLView` (`canvas.getContext('webgl2')` returns a context in browser devtools, not `null`).

## Test plan
- [ ] CI green; `test-browser (blazor, wasm-tools)` finishes test execution rather than timing out.
- [ ] No behaviour change for existing Blazor consumers: with `UseGPU` unset (the common case) they still get `SKGLView` / WebGL, same charts as today.
- [ ] `test-browser (avalonia-browser, wasm-tools)` still passes.
- [ ] After this lands, the #957 reproducer (10 charts on one page) renders all 10 once `LiveCharts.Configure(c => c.HasRenderingSettings(s => s.UseGPU = false))` is set in `App.razor`'s `OnInitialized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)