### PR TITLE
fix(visual-elements): enforce Align.Start on user-provided title geometry

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
@@ -49,6 +49,11 @@ public class DrawnLabelVisual : Visual
     /// <param name="labelGeometry">The label.</param>
     public DrawnLabelVisual(LabelGeometry labelGeometry)
     {
+        // Chart.AddTitleToChart positions the title at (X, 0) and expects the
+        // bbox top-left at that point. BaseLabelGeometry defaults to Align.Middle,
+        // which would center the bbox on Y=0 and clip the top half.
+        labelGeometry.HorizontalAlign = Align.Start;
+        labelGeometry.VerticalAlign = Align.Start;
         _drawnElement = labelGeometry;
     }
 

--- a/tests/CoreTests/OtherTests/DrawnLabelTitleAlignmentTests.cs
+++ b/tests/CoreTests/OtherTests/DrawnLabelTitleAlignmentTests.cs
@@ -1,0 +1,33 @@
+using LiveChartsCore.Drawing;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+// Regression for code-only chart titles being clipped at the top in WinForms /
+// Blazor / Eto / Console samples.
+// Root cause: BaseLabelGeometry defaults HorizontalAlign and VerticalAlign to
+// Align.Middle. Chart.AddTitleToChart positions the title at (X, 0) and assumes
+// the bbox top-left lives at that point (i.e. Align.Start). With the user-
+// provided LabelGeometry going through DrawnLabelVisual(LabelGeometry) unchanged,
+// the bbox was centered on Y=0 and the top half rendered at negative Y.
+[TestClass]
+public class DrawnLabelTitleAlignmentTests
+{
+    [TestMethod]
+    public void DrawnLabelVisual_Ctor_With_LabelGeometry_Forces_Align_Start()
+    {
+        var label = new LabelGeometry { Text = "title" };
+
+        // sanity: BaseLabelGeometry's defaults are still Middle, so this test
+        // exercises the constructor's override (not pre-set values).
+        Assert.AreEqual(Align.Middle, label.HorizontalAlign);
+        Assert.AreEqual(Align.Middle, label.VerticalAlign);
+
+        _ = new DrawnLabelVisual(label);
+
+        Assert.AreEqual(Align.Start, label.HorizontalAlign);
+        Assert.AreEqual(Align.Start, label.VerticalAlign);
+    }
+}


### PR DESCRIPTION
## Summary

`DrawnLabelVisual`'s parameterless constructor already initializes its internal `LabelGeometry` with `HorizontalAlign = VerticalAlign = Align.Start` to match `Chart.AddTitleToChart`'s positioning contract (it sets the title at `(X, 0)` expecting the bbox top-left at that point). The `DrawnLabelVisual(LabelGeometry)` overload, however, kept the caller's geometry untouched — and `BaseLabelGeometry` defaults to `Align.Middle` — so titles built in code-only samples (WinForms, Blazor, Eto, Console) were vertically centered on `Y=0` and the top half rendered above the canvas. XAML platforms (WPF / Avalonia / MAUI / WinUI) were unaffected because `XamlDrawnLabelVisual` already initializes its internal geometry with `Align.Start`.

The fix applies the same `Start` defaults to the caller's geometry so the constructor's behavior is consistent across overloads.

## Test plan

- [x] New unit test `DrawnLabelTitleAlignmentTests.DrawnLabelVisual_Ctor_With_LabelGeometry_Forces_Align_Start` (verified to fail without the fix and pass with it)
- [ ] Visually verify the WinForms `Lines/Basic` sample shows the full title (no top clipping)
- [ ] Visually verify the Blazor `Lines/Basic` sample shows the full title

🤖 Generated with [Claude Code](https://claude.com/claude-code)