### PR TITLE
fix(line-series): correct marker z-index constants and split shared LinearGradient samples

### DIFF
--- a/samples/BlazorSample/Pages/Design/LinearGradients/View.razor
+++ b/samples/BlazorSample/Pages/Design/LinearGradients/View.razor
@@ -20,7 +20,10 @@
         new SKPoint(0.5f, 1f)
     );
 
-    private static LinearGradientPaint lineGradient = new LinearGradientPaint(
+    // Use separate paint instances for Stroke and GeometryStroke. Sharing a
+    // single instance would tie both to the same z-index, which forces the line
+    // to render above the marker fill and slice through it.
+    private static LinearGradientPaint MakeLineGradient() => new LinearGradientPaint(
         new[] { new SKColor(0x2D, 0x40, 0x59), new SKColor(0xFF, 0xD3, 0x60) },
         new SKPoint(0f, 0f),
         new SKPoint(1f, 1f)
@@ -43,8 +46,8 @@
             Values = values2,
             GeometrySize = 22,
             Fill = null,
-            Stroke = lineGradient,
-            GeometryStroke = lineGradient
+            Stroke = MakeLineGradient(),
+            GeometryStroke = MakeLineGradient()
         }
     };
 }

--- a/samples/EtoFormsSample/Design/LinearGradients/View.cs
+++ b/samples/EtoFormsSample/Design/LinearGradients/View.cs
@@ -20,7 +20,10 @@ public class View : Panel
             new SKPoint(0.5f, 1f)
         );
 
-        var lineGradient = new LinearGradientPaint(
+        // Use separate paint instances for Stroke and GeometryStroke. Sharing a
+        // single instance would tie both to the same z-index, which forces the
+        // line to render above the marker fill and slice through it.
+        LinearGradientPaint MakeLineGradient() => new(
             new[] { new SKColor(0x2D, 0x40, 0x59), new SKColor(0xFF, 0xD3, 0x60) },
             new SKPoint(0f, 0f),
             new SKPoint(1f, 1f)
@@ -43,8 +46,8 @@ public class View : Panel
                 Values = values2,
                 GeometrySize = 22,
                 Fill = null,
-                Stroke = lineGradient,
-                GeometryStroke = lineGradient
+                Stroke = MakeLineGradient(),
+                GeometryStroke = MakeLineGradient()
             }
         };
 

--- a/samples/WinFormsSample/Design/LinearGradients/View.cs
+++ b/samples/WinFormsSample/Design/LinearGradients/View.cs
@@ -23,7 +23,10 @@ public partial class View : UserControl
             new SKPoint(0.5f, 1f)
         );
 
-        var lineGradient = new LinearGradientPaint(
+        // Use separate paint instances for Stroke and GeometryStroke. Sharing a
+        // single instance would tie both to the same z-index, which forces the
+        // line to render above the marker fill and slice through it.
+        LinearGradientPaint MakeLineGradient() => new(
             [new SKColor(0x2D, 0x40, 0x59), new SKColor(0xFF, 0xD3, 0x60)],
             new SKPoint(0f, 0f),
             new SKPoint(1f, 1f)
@@ -46,8 +49,8 @@ public partial class View : UserControl
                 Values = values2,
                 GeometrySize = 22,
                 Fill = null,
-                Stroke = lineGradient,
-                GeometryStroke = lineGradient
+                Stroke = MakeLineGradient(),
+                GeometryStroke = MakeLineGradient()
             }
         };
 

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -468,12 +468,12 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             if (GeometryFill is not null && GeometryFill != Paint.Default)
             {
                 cartesianChart.Canvas.AddDrawableTask(GeometryFill, zone: CanvasZone.DrawMargin);
-                GeometryFill.ZIndex = actualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
+                GeometryFill.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
             }
             if (GeometryStroke is not null && GeometryStroke != Paint.Default)
             {
                 cartesianChart.Canvas.AddDrawableTask(GeometryStroke, zone: CanvasZone.DrawMargin);
-                GeometryStroke.ZIndex = actualZIndex + PaintConstants.SeriesDataLabelsZIndexOffset;
+                GeometryStroke.ZIndex = actualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
             }
 
             if (!isSegmentEmpty) segmentI++;

--- a/tests/CoreTests/OtherTests/LineSeriesGeometryZIndexTests.cs
+++ b/tests/CoreTests/OtherTests/LineSeriesGeometryZIndexTests.cs
@@ -1,0 +1,56 @@
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+// CoreLineSeries was assigning the wrong PaintConstants to its geometry
+// paints — SeriesGeometryStrokeZIndexOffset for GeometryFill, and
+// SeriesDataLabelsZIndexOffset for GeometryStroke. CoreStepLineSeries and
+// CorePolarLineSeries already used the correctly-named constants.
+//
+// In addition to being misleading, this collided GeometryStroke with
+// DataLabelsPaint (both at offset 0.5), which is order-dependent.
+[TestClass]
+public class LineSeriesGeometryZIndexTests
+{
+    [TestMethod]
+    public void LineSeries_GeometryPaintZIndices_Match_NamedConstants()
+    {
+        var geometryFill = new SolidColorPaint(SKColors.White);
+        var geometryStroke = new SolidColorPaint(SKColors.Black, 4);
+
+        var chart = new SKCartesianChart
+        {
+            Width = 200,
+            Height = 200,
+            Series = [
+                new LineSeries<double>
+                {
+                    Values = [1, 2, 3, 4],
+                    GeometryFill = geometryFill,
+                    GeometryStroke = geometryStroke
+                }
+            ]
+        };
+
+        using var image = chart.GetImage();
+
+        // Default series have ZIndex == null, so actualZIndex == 0 in
+        // CoreLineSeries and the paint ZIndex equals the offset itself.
+        Assert.AreEqual(
+            PaintConstants.SeriesGeometryFillZIndexOffset,
+            geometryFill.ZIndex,
+            "GeometryFill.ZIndex must use SeriesGeometryFillZIndexOffset.");
+        Assert.AreEqual(
+            PaintConstants.SeriesGeometryStrokeZIndexOffset,
+            geometryStroke.ZIndex,
+            "GeometryStroke.ZIndex must use SeriesGeometryStrokeZIndexOffset.");
+
+        // Stroke must render above Fill so the marker outline isn't hidden.
+        Assert.IsTrue(geometryStroke.ZIndex > geometryFill.ZIndex);
+    }
+}


### PR DESCRIPTION
## Summary

Two issues, both visible in the WinForms / Blazor LinearGradients samples (line series markers showing the gradient slicing through the marker fill):

1. **`CoreLineSeries` z-index constants were misnamed.** GeometryFill was using `SeriesGeometryStrokeZIndexOffset` (0.4) and GeometryStroke was using `SeriesDataLabelsZIndexOffset` (0.5), leaving `SeriesGeometryFillZIndexOffset` (0.3) / `SeriesGeometryStrokeZIndexOffset` (0.4) unused for line markers and colliding GeometryStroke with DataLabelsPaint. `CoreStepLineSeries` and `CorePolarLineSeries` already used the correctly-named constants. Fixed to match.

2. **The samples shared a single `LinearGradientPaint` instance between `Stroke` and `GeometryStroke`.** `CoreLineSeries.Invalidate` writes `Stroke.ZIndex` first and `GeometryStroke.ZIndex` last, so when both reference the same paint the line stroke ends up at the higher z-index — drawn above the white `GeometryFill` and slicing through every marker's interior. The XAML samples (WPF / Avalonia / MAUI / WinUI) already used separate instances because each `{lvc:LinearGradientPaint ...}` markup-extension expansion produces its own paint. The WinForms / Blazor / Eto samples now do the same via a small factory.

The constants correction (#1) does not address the shared-instance ambiguity — that needed the sample fix (#2).

## Test plan

- [x] New unit test `LineSeriesGeometryZIndexTests.LineSeries_GeometryPaintZIndices_Match_NamedConstants` (verified to fail without the constants fix)
- [x] WinForms and Eto sample projects build clean
- [ ] Visually verify the WinForms `Design/LinearGradients` sample renders markers with clean white interiors (no line slicing through)
- [ ] Visually verify the Blazor `Design/LinearGradients` sample
- [ ] Visually verify the Eto `Design/LinearGradients` sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)