### PR TITLE
fix: add ZIndex to Visual / VisualElement so decorations can render above series (#1856)

### DIFF
--- a/docs/samples/general/visualElements/template.md
+++ b/docs/samples/general/visualElements/template.md
@@ -154,6 +154,21 @@ Uses a grid system to place `IDrawnElement` objects.
 {{~ render "~/../samples/ViewModelsSamples/General/VisualElements/TableVisual.cs" ~}}
 ```
 
+### Z-ordering with series
+
+By default, every series whose `ZIndex` is unset draws its fill at `SeriesId + 0.1`, while a `Visual` (or
+`VisualElement`) draws at `0`. That means decorations land **behind** the data they annotate, which is
+rarely what you want for glyphs, callouts or markers.
+
+To bring a visual to the front, set `Visual.ZIndex` (or `VisualElement.ZIndex`) to a value above
+the series stack. A safe ceiling is `1000` (above stacked series and below the crosshair layer):
+
+```csharp
+new RectangleVisual { ZIndex = 1000 };
+```
+
+Set it to `0` (the default) to keep the legacy "behind the series" placement, useful for backgrounds.
+
 ### Update on property change
 
 To do...

--- a/src/LiveChartsCore/VisualElements/Visual.cs
+++ b/src/LiveChartsCore/VisualElements/Visual.cs
@@ -49,6 +49,14 @@ public abstract class Visual : ChartElement, IInternalInteractable
     public TimeSpan AnimationSpeed { get; set; } = TimeSpan.FromMilliseconds(300);
 
     /// <summary>
+    /// Gets or sets the z-index of the drawn task that hosts this visual.
+    /// When 0 (default) the visual is drawn behind series whose paints sit at
+    /// <c>SeriesId + offset</c>. Set a positive value (e.g. 1000) to render
+    /// the visual on top of series.
+    /// </summary>
+    public int ZIndex { get; set => SetProperty(ref field, value); }
+
+    /// <summary>
     /// Gets the drawn element.
     /// </summary>
     protected internal abstract IDrawnElement? DrawnElement { get; }
@@ -68,6 +76,8 @@ public abstract class Visual : ChartElement, IInternalInteractable
 
             _drawnTask = chart.Canvas.AddGeometry(DrawnElement);
         }
+
+        if (ZIndex != 0) _drawnTask.ZIndex = ZIndex;
     }
 
     /// <inheritdoc cref="IInteractable.GetHitBox"/>

--- a/src/LiveChartsCore/VisualElements/VisualElement.cs
+++ b/src/LiveChartsCore/VisualElements/VisualElement.cs
@@ -96,6 +96,14 @@ public abstract class VisualElement : ChartElement, INotifyPropertyChanged, IInt
     /// </value>
     public int ScalesYAt { get; set => SetProperty(ref field, value); }
 
+    /// <summary>
+    /// Gets or sets the z-index applied to every paint produced by this visual element.
+    /// When 0 (default) the underlying paint z-index is left untouched, which means the
+    /// visual is drawn behind series whose paints sit at <c>SeriesId + offset</c>.
+    /// Set a positive value (e.g. 1000) to render the visual on top of series.
+    /// </summary>
+    public int ZIndex { get; set => SetProperty(ref field, value); }
+
     /// <inheritdoc cref="IInteractable.PointerDown"/>
     public event VisualElementHandler? PointerDown;
 
@@ -116,6 +124,9 @@ public abstract class VisualElement : ChartElement, INotifyPropertyChanged, IInt
         foreach (var paintTask in GetPaintTasks())
         {
             if (paintTask is null) continue;
+            // 0 means "do not override"; gauge subclasses bump untouched paints in
+            // OnInvalidated, so leaving 0-valued paints alone keeps that path working.
+            if (ZIndex != 0) paintTask.ZIndex = ZIndex;
             chart.Canvas.AddDrawableTask(paintTask);
         }
 

--- a/tests/CoreTests/OtherTests/VisualElementsTests.cs
+++ b/tests/CoreTests/OtherTests/VisualElementsTests.cs
@@ -156,6 +156,7 @@ public class VisualElementsTests
         Assert.AreEqual(1000d, visual.LabelPaint!.ZIndex);
     }
 
+#if !NET462 // covariant returns on TestRectangleVisual.DrawnElement need .NET 5+
     [TestMethod]
     public void Visual_ZIndexPropagatesToDrawnTask_RendersAboveSeries()
     {
@@ -195,6 +196,7 @@ public class VisualElementsTests
 
         public LiveChartsCore.Painting.Paint?[] GetPaintTasksForTest() => GetPaintTasks();
     }
+#endif
 
     [TestMethod]
     public void GeometryVisual_WithLabelInChartExercisesLabelPaintBranch()

--- a/tests/CoreTests/OtherTests/VisualElementsTests.cs
+++ b/tests/CoreTests/OtherTests/VisualElementsTests.cs
@@ -117,6 +117,46 @@ public class VisualElementsTests
     }
 
     [TestMethod]
+    public void VisualElement_ZIndexPropagatesToPaints_RendersAboveSeries()
+    {
+        // Regression for #1856: VisualElement paints used to default to ZIndex=0
+        // while a default-ZIndex ColumnSeries puts its Fill at SeriesId+0.1, so
+        // visuals were drawn behind the series. Setting VisualElement.ZIndex must
+        // push every paint produced by the visual to that z-index.
+        var visual = new GeometryVisual<RectangleGeometry>
+        {
+            X = 10,
+            Y = 10,
+            Width = 50,
+            Height = 50,
+            Fill = new SolidColorPaint(SKColors.Blue),
+            Stroke = new SolidColorPaint(SKColors.Red),
+            Label = "x",
+            LabelPaint = new SolidColorPaint(SKColors.Black),
+            LabelSize = 12,
+            ZIndex = 1000,
+            LocationUnit = MeasureUnit.Pixels,
+            SizeUnit = MeasureUnit.Pixels
+        };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            Series = [
+                new ColumnSeries<double> { Values = [1d, 2d, 3d] }
+            ],
+            VisualElements = [visual]
+        };
+
+        using var image = chart.GetImage();
+
+        Assert.AreEqual(1000d, visual.Fill!.ZIndex);
+        Assert.AreEqual(1000d, visual.Stroke!.ZIndex);
+        Assert.AreEqual(1000d, visual.LabelPaint!.ZIndex);
+    }
+
+    [TestMethod]
     public void GeometryVisual_WithLabelInChartExercisesLabelPaintBranch()
     {
         // Existing VisualElementsTests.Dispose uses GeometryVisual without a Label/LabelPaint,

--- a/tests/CoreTests/OtherTests/VisualElementsTests.cs
+++ b/tests/CoreTests/OtherTests/VisualElementsTests.cs
@@ -157,6 +157,46 @@ public class VisualElementsTests
     }
 
     [TestMethod]
+    public void Visual_ZIndexPropagatesToDrawnTask_RendersAboveSeries()
+    {
+        // Same regression as above (#1856) but for the Visual base class, used
+        // by the canonical docs samples (RectangleVisual et al.).
+        var visual = new TestRectangleVisual { ZIndex = 1000 };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            Series = [
+                new ColumnSeries<double> { Values = [1d, 2d, 3d] }
+            ],
+            VisualElements = [visual]
+        };
+
+        using var image = chart.GetImage();
+
+        var drawnTask = visual.GetPaintTasksForTest()[0];
+        Assert.IsNotNull(drawnTask);
+        Assert.AreEqual(1000d, drawnTask!.ZIndex);
+    }
+
+    private sealed class TestRectangleVisual : Visual
+    {
+        protected internal override RectangleGeometry DrawnElement { get; } =
+            new RectangleGeometry { Fill = new SolidColorPaint(SKColors.Red) };
+
+        protected override void Measure(LiveChartsCore.Chart chart)
+        {
+            DrawnElement.X = 10;
+            DrawnElement.Y = 10;
+            DrawnElement.Width = 40;
+            DrawnElement.Height = 40;
+        }
+
+        public LiveChartsCore.Painting.Paint?[] GetPaintTasksForTest() => GetPaintTasks();
+    }
+
+    [TestMethod]
     public void GeometryVisual_WithLabelInChartExercisesLabelPaintBranch()
     {
         // Existing VisualElementsTests.Dispose uses GeometryVisual without a Label/LabelPaint,


### PR DESCRIPTION
## Summary

Closes #1856.

- Add `int ZIndex` to `VisualElement` and to `Visual`. Default `0` preserves the legacy "behind series" placement; any non-zero value is pushed to every paint produced by the visual during `Invalidate`, putting the visual on top of (or under, with negative values) the series stack.
- Guarded by `!= 0` so gauge subclasses (`BaseAngularTicksVisual`, `BaseNeedleVisual`) that bump untouched paint z-indices inside `OnInvalidated` keep their existing defaults.
- Doc note added to `docs/samples/general/visualElements/template.md` explaining default ordering vs. setting `ZIndex` for foreground glyphs.

## Why

Before the fix, a default-`ZIndex` series puts its `Fill` at `SeriesId + 0.1`, while every paint owned by a `Visual` / `VisualElement` stayed at `0`. Glyphs and callouts therefore drew **behind** the bars or columns they annotated. The OP's only workaround was setting the *series* `ZIndex` to `-1` to push the series behind `0` — non-obvious and forces the user to reason about series ordering instead of the decoration.

## Test plan

- [x] `tests/CoreTests` `VisualElement_ZIndexPropagatesToPaints_RendersAboveSeries` — covers `GeometryVisual.Fill / Stroke / LabelPaint`. Verified by reverting the Invalidate hunk: expected `1000`, actual `0` → fail. Restored → pass.
- [x] `tests/CoreTests` `Visual_ZIndexPropagatesToDrawnTask_RendersAboveSeries` — covers the `Visual` base via a docs-style `RectangleVisual` subclass + `DrawnTask`. Same revert-verify cycle.
- [x] Full CoreTests suite green locally (483/483, net8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)