### PR TITLE
fix(animations): runtime AnimationsSpeed/EasingFunction reach existing visuals

### DIFF
--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -229,20 +229,45 @@ public abstract class Chart
     public IChartTooltip? Tooltip { get; protected set; }
 
     /// <summary>
-    /// Gets the animations speed.
+    /// Gets the animations speed. Setting this also refreshes <see cref="Animation"/> so
+    /// already-created chart-default geometries pick up the new duration without recreation.
     /// </summary>
     /// <value>
     /// The animations speed.
     /// </value>
-    public TimeSpan ActualAnimationsSpeed { get; protected set; }
+    public TimeSpan ActualAnimationsSpeed
+    {
+        get;
+        protected set
+        {
+            field = value;
+            Animation.Duration = (long)value.TotalMilliseconds;
+        }
+    }
 
     /// <summary>
-    /// Gets the easing function.
+    /// Gets the easing function. Setting this also refreshes <see cref="Animation"/> so
+    /// already-created chart-default geometries pick up the new function without recreation.
     /// </summary>
     /// <value>
     /// The easing function.
     /// </value>
-    public Func<float, float>? ActualEasingFunction { get; protected set; } = EasingFunctions.QuadraticOut;
+    public Func<float, float>? ActualEasingFunction
+    {
+        get;
+        protected set
+        {
+            field = value;
+            Animation.EasingFunction = value;
+        }
+    } = EasingFunctions.QuadraticOut;
+
+    /// <summary>
+    /// Shared animation reference used by chart-default geometries (geometries that don't
+    /// have a per-element override). Mutated in-place by <see cref="ActualAnimationsSpeed"/>
+    /// and <see cref="ActualEasingFunction"/> so existing visuals pick up new settings.
+    /// </summary>
+    internal Animation Animation { get; } = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
 
     /// <summary>
     /// Gets the visual elements.

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -74,6 +74,11 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     internal DoubleMotionProperty? _animatableMin;
     internal DoubleMotionProperty? _animatableMax;
 
+    // Shared by every geometry this axis animates. Mutated in-place on each Invalidate so
+    // AnimationsSpeed/EasingFunction changes reach already-created visuals — every MotionProperty
+    // holds a reference to this same instance, not a copy.
+    private readonly Animation _animation = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
+
     #endregion
 
     #region properties
@@ -302,6 +307,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        var animation = GetAnimation(cartesianChart);
 
         var controlSize = cartesianChart.ControlSize;
         var drawLocation = cartesianChart.DrawMarginLocation;
@@ -314,18 +320,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
         if (_animatableMin is null || _animatableMax is null)
         {
-            _animatableMin = new DoubleMotionProperty(min)
-            {
-                Animation = new Animation(
-                    EasingFunction ?? cartesianChart.ActualEasingFunction,
-                    AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed)
-            };
-            _animatableMax = new DoubleMotionProperty(max)
-            {
-                Animation = new Animation(
-                    EasingFunction ?? cartesianChart.ActualEasingFunction,
-                    AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed)
-            };
+            _animatableMin = new DoubleMotionProperty(min) { Animation = animation };
+            _animatableMax = new DoubleMotionProperty(max) { Animation = animation };
         }
 
         _animatableMin.SetMovement(min, Animatable.Empty);
@@ -1035,6 +1031,16 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         return labeler;
     }
 
+    private Animation GetAnimation(Chart chart)
+    {
+        if (AnimationsSpeed is null && EasingFunction is null)
+            return chart.Animation;
+
+        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
+        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        return _animation;
+    }
+
     private LvcSize GetPossibleMaxLabelSize()
     {
         if (LabelsPaint is null) return new LvcSize();
@@ -1096,7 +1102,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
                 VerticalAlign = Align.Middle
             };
 
-            _nameGeometry.Animate(EasingFunction ?? cartesianChart.ActualEasingFunction, AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+            _nameGeometry.Animate(GetAnimation(cartesianChart));
             isNew = true;
         }
 
@@ -1169,9 +1175,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     }
 
     private void InitializeLine(BaseLineGeometry lineGeometry, CartesianChartEngine cartesianChart) =>
-        lineGeometry.Animate(
-            EasingFunction ?? cartesianChart.ActualEasingFunction,
-            AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+        lineGeometry.Animate(GetAnimation(cartesianChart));
 
     private void InitializeTick(
         AxisVisualSeprator visualSeparator, CartesianChartEngine cartesianChart, TLineGeometry? subTickGeometry = null)
@@ -1188,9 +1192,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             visualSeparator.Tick = tickGeometry;
         }
 
-        tickGeometry.Animate(
-            EasingFunction ?? cartesianChart.ActualEasingFunction,
-            AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+        tickGeometry.Animate(GetAnimation(cartesianChart));
     }
 
     private void InitializeSubticks(
@@ -1218,8 +1220,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         if (hasRotation) textGeometry.RotateTransform = r;
 
         textGeometry.Animate(
-            EasingFunction ?? cartesianChart.ActualEasingFunction,
-            AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+            GetAnimation(cartesianChart),
             BaseLabelGeometry.XProperty,
             BaseLabelGeometry.YProperty,
             BaseLabelGeometry.OpacityProperty);

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -86,6 +86,8 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -262,8 +264,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
                 {
                     var l = new TLabel { X = secondary - helper.uwm + helper.cp, Y = high, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -397,7 +398,7 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     {
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
-        visual.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+        visual.Animate(GetAnimation(chart.CoreChart));
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.SoftDeleteOrDisposePoint(ChartPoint, Scaler, Scaler)"/>

--- a/src/LiveChartsCore/CoreColumnSeries.cs
+++ b/src/LiveChartsCore/CoreColumnSeries.cs
@@ -58,6 +58,8 @@ public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TErrorGeometry>
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -299,8 +301,7 @@ public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TErrorGeometry>
                 {
                     var l = new TLabel { X = secondary - helper.uwm + helper.cp, Y = helper.p, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -349,16 +350,15 @@ public abstract class CoreColumnSeries<TModel, TVisual, TLabel, TErrorGeometry>
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
 
-        var easing = EasingFunction ?? chart.CoreChart.ActualEasingFunction;
-        var speed = AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed;
+        var animation = GetAnimation(chart.CoreChart);
 
-        visual.Animate(easing, speed);
+        visual.Animate(animation);
 
         if (chartPoint.Context.AdditionalVisuals is not null)
         {
             var e = (ErrorVisual<TErrorGeometry>)chartPoint.Context.AdditionalVisuals;
-            e.YError.Animate(easing, speed);
-            e.XError.Animate(easing, speed);
+            e.YError.Animate(animation);
+            e.XError.Animate(animation);
         }
     }
 

--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -107,6 +107,8 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -301,8 +303,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
                 {
                     var l = new TLabel { X = secondary - uwm, Y = high, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -405,7 +406,7 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
     {
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
-        visual.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+        visual.Animate(GetAnimation(chart.CoreChart));
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.SoftDeleteOrDisposePoint(ChartPoint, Scaler, Scaler)"/>

--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -109,6 +109,8 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
         }
 
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -262,8 +264,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
                 {
                     var l = new TLabel { X = secondary - uws * 0.5f, Y = primary - uws * 0.5f, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -349,7 +350,7 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
     {
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
-        visual.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+        visual.Animate(GetAnimation(chart.CoreChart));
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.SoftDeleteOrDisposePoint(ChartPoint, Scaler, Scaler)"/>

--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -124,6 +124,8 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -226,7 +228,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
                         fillPath.Pivot = p;
                         if (isNew)
                         {
-                            fillPath.Animate(EasingFunction ?? cartesianChart.ActualEasingFunction, AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+                            fillPath.Animate(GetAnimation(cartesianChart));
                         }
                     }
                     if (Stroke is not null && Stroke != Paint.Default)
@@ -237,7 +239,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
                         strokePath.Pivot = p;
                         if (isNew)
                         {
-                            strokePath.Animate(EasingFunction ?? cartesianChart.ActualEasingFunction, AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+                            strokePath.Animate(GetAnimation(cartesianChart));
                         }
                     }
 
@@ -430,8 +432,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
                     {
                         var l = new TLabel { X = x - hgs, Y = p - hgs, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                         l.Animate(
-                            EasingFunction ?? cartesianChart.ActualEasingFunction,
-                            AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                            GetAnimation(cartesianChart),
                             BaseLabelGeometry.XProperty,
                             BaseLabelGeometry.YProperty);
                         label = l;
@@ -743,13 +744,12 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
         if (chartPoint.Context.AdditionalVisuals is not CubicSegmentVisualPoint visual)
             throw new Exception("Unable to initialize the point instance.");
 
-        var easing = EasingFunction ?? chart.CoreChart.ActualEasingFunction;
-        var speed = AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed;
+        var animation = GetAnimation(chart.CoreChart);
 
-        visual.Geometry.Animate(easing, speed);
-        visual.Segment.Animate(easing, speed);
-        visual.YError?.Animate(easing, speed);
-        visual.XError?.Animate(easing, speed);
+        visual.Geometry.Animate(animation);
+        visual.Segment.Animate(animation);
+        visual.YError?.Animate(animation);
+        visual.XError?.Animate(animation);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.SoftDeleteOrDisposePoint(ChartPoint, Scaler, Scaler)"/>

--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -140,6 +140,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     public override void Invalidate(Chart chart)
     {
         var pieChart = (PieChartEngine)chart;
+        _ = GetAnimation(pieChart);
 
         var drawLocation = pieChart.DrawMarginLocation;
         var drawMarginSize = pieChart.DrawMarginSize;
@@ -418,8 +419,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
                 {
                     var l = new TLabel { X = cx, Y = cy, RotateTransform = actualRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? chart.ActualEasingFunction,
-                        AnimationsSpeed ?? chart.ActualAnimationsSpeed,
+                        GetAnimation(chart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -526,12 +526,13 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
 
+        var animation = GetAnimation(chart.CoreChart);
+
         if ((SeriesProperties & SeriesProperties.Gauge) == 0)
-            visual.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+            visual.Animate(animation);
         else
             visual.Animate(
-                EasingFunction ?? chart.CoreChart.ActualEasingFunction,
-                AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed,
+                animation,
                 BaseDoughnutGeometry.StartAngleProperty,
                 BaseDoughnutGeometry.SweepAngleProperty);
     }

--- a/src/LiveChartsCore/CorePolarAxis.cs
+++ b/src/LiveChartsCore/CorePolarAxis.cs
@@ -59,6 +59,10 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
     private Bounds? _visibleDataBounds = null;
     private LvcColor _labelsBackground = new(255, 255, 255);
 
+    // Shared Animation reference; mutated in-place so AnimationsSpeed/EasingFunction changes
+    // reach every existing geometry without recreating it.
+    private readonly Animation _animation = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
+
     #endregion
 
     #region properties
@@ -173,6 +177,7 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
     public override void Invalidate(Chart chart)
     {
         var polarChart = (PolarChartEngine)chart;
+        _ = GetAnimation(polarChart);
 
         if (_dataBounds is null) throw new Exception("DataBounds not found");
 
@@ -277,7 +282,7 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
                     visualSeparator.Label = textGeometry;
                     if (hasRotation) textGeometry.RotateTransform = r;
 
-                    textGeometry.Animate(EasingFunction ?? chart.ActualEasingFunction, AnimationsSpeed ?? chart.ActualAnimationsSpeed);
+                    textGeometry.Animate(GetAnimation(chart));
 
                     textGeometry.X = l.X;
                     textGeometry.Y = l.Y;
@@ -294,7 +299,7 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
 
                         linearSeparator.Separator = lineGeometry;
 
-                        lineGeometry.Animate(EasingFunction ?? chart.ActualEasingFunction, AnimationsSpeed ?? chart.ActualAnimationsSpeed);
+                        lineGeometry.Animate(GetAnimation(chart));
 
                         lineGeometry.Opacity = 0;
                         lineGeometry.CompleteTransition(null);
@@ -306,7 +311,7 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
 
                         polarSeparator.Circle = circleGeometry;
 
-                        circleGeometry.Animate(EasingFunction ?? chart.ActualEasingFunction, AnimationsSpeed ?? chart.ActualAnimationsSpeed);
+                        circleGeometry.Animate(GetAnimation(chart));
 
                         var h = Math.Sqrt(Math.Pow(l.X - scaler.CenterX, 2) + Math.Pow(l.Y - scaler.CenterY, 2));
                         var radius = (float)h;
@@ -591,5 +596,15 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
         }
 
         return labeler;
+    }
+
+    private Animation GetAnimation(Chart chart)
+    {
+        if (AnimationsSpeed is null && EasingFunction is null)
+            return chart.Animation;
+
+        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
+        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        return _animation;
     }
 }

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -164,6 +164,8 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
     public override void Invalidate(Chart chart)
     {
         var polarChart = (PolarChartEngine)chart;
+        _ = GetAnimation(polarChart);
+
         var angleAxis = polarChart.GetAngleAxis(this);
         var radiusAxis = polarChart.GetRadiusAxis(this);
 
@@ -269,7 +271,7 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
                         Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
                         if (isNew)
                         {
-                            fillPath.Animate(EasingFunction ?? polarChart.ActualEasingFunction, AnimationsSpeed ?? polarChart.ActualAnimationsSpeed);
+                            fillPath.Animate(GetAnimation(polarChart));
                         }
                     }
                     if (Stroke is not null && Stroke != Paint.Default)
@@ -279,7 +281,7 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
                         Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
                         if (isNew)
                         {
-                            strokePath.Animate(EasingFunction ?? polarChart.ActualEasingFunction, AnimationsSpeed ?? polarChart.ActualAnimationsSpeed);
+                            strokePath.Animate(GetAnimation(polarChart));
                         }
                     }
 
@@ -391,8 +393,7 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
                     {
                         var l = new TLabel { X = x - hgs, Y = scaler.CenterY - hgs, RotateTransform = (float)actualRotation, MaxWidth = (float)DataLabelsMaxWidth };
                         l.Animate(
-                            EasingFunction ?? chart.ActualEasingFunction,
-                            AnimationsSpeed ?? chart.ActualAnimationsSpeed,
+                            GetAnimation(chart),
                             BaseLabelGeometry.XProperty,
                             BaseLabelGeometry.YProperty);
                         label = l;
@@ -743,8 +744,10 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
         if (chartPoint.Context.AdditionalVisuals is not CubicSegmentVisualPoint visual)
             throw new Exception("Unable to initialize the point instance.");
 
-        visual.Geometry.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
-        visual.Segment.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+        var animation = GetAnimation(chart.CoreChart);
+
+        visual.Geometry.Animate(animation);
+        visual.Segment.Animate(animation);
     }
 
     /// <summary>

--- a/src/LiveChartsCore/CoreRowSeries.cs
+++ b/src/LiveChartsCore/CoreRowSeries.cs
@@ -62,6 +62,8 @@ public abstract class CoreRowSeries<TModel, TVisual, TLabel, TErrorGeometry>
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -305,8 +307,7 @@ public abstract class CoreRowSeries<TModel, TVisual, TLabel, TErrorGeometry>
                 {
                     var l = new TLabel { X = helper.p, Y = secondary - helper.uwm + helper.cp, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -355,16 +356,15 @@ public abstract class CoreRowSeries<TModel, TVisual, TLabel, TErrorGeometry>
         var chart = chartPoint.Context.Chart;
         if (chartPoint.Context.Visual is not TVisual visual) throw new Exception("Unable to initialize the point instance.");
 
-        var easing = EasingFunction ?? chart.CoreChart.ActualEasingFunction;
-        var speed = AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed;
+        var animation = GetAnimation(chart.CoreChart);
 
-        visual.Animate(easing, speed);
+        visual.Animate(animation);
 
         if (chartPoint.Context.AdditionalVisuals is not null)
         {
             var e = (ErrorVisual<TErrorGeometry>)chartPoint.Context.AdditionalVisuals;
-            e.YError.Animate(easing, speed);
-            e.XError.Animate(easing, speed);
+            e.YError.Animate(animation);
+            e.XError.Animate(animation);
         }
     }
 

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -122,6 +122,8 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -304,8 +306,7 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
                 {
                     var l = new TLabel { X = x - hgs, Y = y - hgs, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
-                        EasingFunction ?? cartesianChart.ActualEasingFunction,
-                        AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                        GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
                         BaseLabelGeometry.YProperty);
                     label = l;
@@ -386,16 +387,15 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
 
         if (visual is null) throw new Exception("Unable to initialize the point instance.");
 
-        var easing = EasingFunction ?? chart.CoreChart.ActualEasingFunction;
-        var speed = AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed;
+        var animation = GetAnimation(chart.CoreChart);
 
-        visual.Animate(easing, speed);
+        visual.Animate(animation);
 
         if (chartPoint.Context.AdditionalVisuals is not null)
         {
             var e = (ErrorVisual<TErrorGeometry>)chartPoint.Context.AdditionalVisuals;
-            e.YError.Animate(easing, speed);
-            e.XError.Animate(easing, speed);
+            e.YError.Animate(animation);
+            e.XError.Animate(animation);
         }
     }
 

--- a/src/LiveChartsCore/CoreSection.cs
+++ b/src/LiveChartsCore/CoreSection.cs
@@ -230,7 +230,7 @@ public abstract class CoreSection<TSizedGeometry, TLabelGeometry> : CoreSection
                     Height = yj - yi
                 };
 
-                _fillSizedGeometry.Animate(cartesianChart.ActualEasingFunction, cartesianChart.ActualAnimationsSpeed);
+                _fillSizedGeometry.Animate(cartesianChart);
             }
 
             _fillSizedGeometry.X = xi;
@@ -285,7 +285,7 @@ public abstract class CoreSection<TSizedGeometry, TLabelGeometry> : CoreSection
                 };
 
                 _labelGeometry.Animate(
-                    cartesianChart.ActualEasingFunction, cartesianChart.ActualAnimationsSpeed,
+                    cartesianChart,
                     BaseLabelGeometry.XProperty, BaseLabelGeometry.YProperty);
 
                 _labelGeometry.VerticalAlign = Align.Start;

--- a/src/LiveChartsCore/CoreStepLineSeries.cs
+++ b/src/LiveChartsCore/CoreStepLineSeries.cs
@@ -89,6 +89,8 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
     public override void Invalidate(Chart chart)
     {
         var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
         var primaryAxis = cartesianChart.GetYAxis(this);
         var secondaryAxis = cartesianChart.GetXAxis(this);
 
@@ -180,7 +182,7 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
                         fillPath.Pivot = p;
                         if (isNew)
                         {
-                            fillPath.Animate(EasingFunction ?? cartesianChart.ActualEasingFunction, AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+                            fillPath.Animate(GetAnimation(cartesianChart));
                         }
                     }
                     if (Stroke is not null && Stroke != Paint.Default)
@@ -191,7 +193,7 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
                         strokePath.Pivot = p;
                         if (isNew)
                         {
-                            strokePath.Animate(EasingFunction ?? cartesianChart.ActualEasingFunction, AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed);
+                            strokePath.Animate(GetAnimation(cartesianChart));
                         }
                     }
 
@@ -337,8 +339,7 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
                     {
                         var l = new TLabel { X = x - hgs, Y = p - hgs, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                         l.Animate(
-                            EasingFunction ?? cartesianChart.ActualEasingFunction,
-                            AnimationsSpeed ?? cartesianChart.ActualAnimationsSpeed,
+                            GetAnimation(cartesianChart),
                             BaseLabelGeometry.XProperty,
                             BaseLabelGeometry.YProperty);
                         label = l;
@@ -519,8 +520,10 @@ public abstract class CoreStepLineSeries<TModel, TVisual, TLabel, TPathGeometry,
         if (chartPoint.Context.AdditionalVisuals is not SegmentVisualPoint visual)
             throw new Exception("Unable to initialize the point instance.");
 
-        visual.Geometry.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
-        visual.Segment.Animate(EasingFunction ?? chart.CoreChart.ActualEasingFunction, AnimationsSpeed ?? chart.CoreChart.ActualAnimationsSpeed);
+        var animation = GetAnimation(chart.CoreChart);
+
+        visual.Geometry.Animate(animation);
+        visual.Segment.Animate(animation);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.SoftDeleteOrDisposePoint(ChartPoint, Scaler, Scaler)"/>

--- a/src/LiveChartsCore/Drawing/Animation.cs
+++ b/src/LiveChartsCore/Drawing/Animation.cs
@@ -88,18 +88,18 @@ public class Animation
     /// <summary>
     /// Gets or sets the easing function.
     /// </summary>
-    public Func<float, float>? EasingFunction { get; }
+    public Func<float, float>? EasingFunction { get; set; }
 
     /// <summary>
     /// Gets or sets the duration of the transition in Milliseconds.
     /// </summary>
-    public long Duration { get; }
+    public long Duration { get; set; }
 
     /// <summary>
-    /// Gets or sets how many times the animation needs to repeat before it is completed, 
+    /// Gets or sets how many times the animation needs to repeat before it is completed,
     /// use int.MaxValue to repeat it indefinitely number of times.
     /// </summary>
-    public int RepeatTimes { get; }
+    public int RepeatTimes { get; set; }
 
     internal int RepeatCount { get; set; } = 0;
 }

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -343,19 +343,22 @@ public static class Extensions
         Animate(animatable, new Animation(easingFunction, speed), properties);
 
     /// <summary>
-    /// Sets the transition of the given <paramref name="properties"/> to the animations config in the chart,
-    /// if the properties are not set, then all the animatable properties in the object will use the given animation.
+    /// Sets the transition of the given <paramref name="properties"/> to the chart's shared
+    /// <see cref="Chart.Animation"/> instance, if the properties are not set, then all the
+    /// animatable properties in the object will use the given animation. Because the animation
+    /// is shared and mutated in-place when <see cref="Chart.ActualAnimationsSpeed"/> or
+    /// <see cref="Chart.ActualEasingFunction"/> change, callers using this overload pick up
+    /// chart-level animation changes without recreating their geometries.
     /// </summary>
     /// <param name="animatable">The animatable object.</param>
     /// <param name="chart">
-    /// The chart, an animation will be built based on the <see cref="Chart.ActualAnimationsSpeed"/>
-    /// and <see cref="Chart.ActualEasingFunction"/>.
+    /// The chart whose <see cref="Chart.Animation"/> is referenced.
     /// </param>
     /// <param name="properties">
     /// The properties, if this argument is not set then all the animatable properties in the object will use the given animation.
     /// </param>
     public static void Animate(this Animatable animatable, Chart chart, params PropertyDefinition[]? properties) =>
-        Animate(animatable, new Animation(chart.ActualEasingFunction, chart.ActualAnimationsSpeed), properties);
+        Animate(animatable, chart.Animation, properties);
 
     /// <summary>
     /// Sets the transition of the given <paramref name="properties"/> to the animations config in the chart

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -343,19 +343,21 @@ public static class Extensions
         Animate(animatable, new Animation(easingFunction, speed), properties);
 
     /// <summary>
-    /// Sets the transition of the given <paramref name="properties"/> to the chart's shared
-    /// <see cref="Chart.Animation"/> instance, if the properties are not set, then all the
-    /// animatable properties in the object will use the given animation. Because the animation
-    /// is shared and mutated in-place when <see cref="Chart.ActualAnimationsSpeed"/> or
-    /// <see cref="Chart.ActualEasingFunction"/> change, callers using this overload pick up
-    /// chart-level animation changes without recreating their geometries.
+    /// Points the given <paramref name="properties"/> at the chart's shared
+    /// <see cref="Chart.Animation"/> instance. When <paramref name="properties"/> is null or
+    /// empty, every animatable property on <paramref name="animatable"/> is bound to the same
+    /// instance. Because that instance is mutated in-place when
+    /// <see cref="Chart.ActualAnimationsSpeed"/> or <see cref="Chart.ActualEasingFunction"/>
+    /// change, callers using this overload pick up chart-level animation changes without
+    /// recreating their geometries.
     /// </summary>
     /// <param name="animatable">The animatable object.</param>
     /// <param name="chart">
     /// The chart whose <see cref="Chart.Animation"/> is referenced.
     /// </param>
     /// <param name="properties">
-    /// The properties, if this argument is not set then all the animatable properties in the object will use the given animation.
+    /// The properties to bind; when null or empty, every animatable property on
+    /// <paramref name="animatable"/> is bound to <see cref="Chart.Animation"/>.
     /// </param>
     public static void Animate(this Animatable animatable, Chart chart, params PropertyDefinition[]? properties) =>
         Animate(animatable, chart.Animation, properties);

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -98,6 +98,11 @@ public abstract class Series<TModel, TVisual, TLabel>
     private LvcPoint _dataPadding = new(0.5f, 0.5f);
     private bool _showDataLabels;
 
+    // Shared by every geometry this series animates. Mutated in-place on each Invalidate so
+    // AnimationsSpeed/EasingFunction changes reach already-created visuals — every MotionProperty
+    // holds a reference to this same instance, not a copy.
+    private readonly Animation _animation = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Series{TModel, TVisual, TLabel}"/> class.
     /// </summary>
@@ -445,6 +450,25 @@ public abstract class Series<TModel, TVisual, TLabel>
 
     void ISeries.OnDataPointerDown(IChartView chart, IEnumerable<ChartPoint> points, LvcPoint pointer) =>
         OnDataPointerDown(chart, points, pointer);
+
+    /// <summary>
+    /// Returns the <see cref="Animation"/> instance that every geometry this series animates
+    /// should reference. With no per-series override, the chart's shared <see cref="Chart.Animation"/>
+    /// is returned directly so chart-level <see cref="Chart.ActualAnimationsSpeed"/> /
+    /// <see cref="Chart.ActualEasingFunction"/> changes propagate to already-created visuals.
+    /// With a per-series override, a series-owned instance is mutated in-place from the active
+    /// settings.
+    /// </summary>
+    /// <param name="chart">The chart whose <see cref="Chart.Animation"/> is used as the fallback.</param>
+    protected Animation GetAnimation(Chart chart)
+    {
+        if (AnimationsSpeed is null && EasingFunction is null)
+            return chart.Animation;
+
+        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
+        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        return _animation;
+    }
 
     /// <summary>
     /// Called when a point was measured.

--- a/tests/CoreTests/OtherTests/AnimationsSpeedPropagationTests.cs
+++ b/tests/CoreTests/OtherTests/AnimationsSpeedPropagationTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+// Regression for https://github.com/Live-Charts/LiveCharts2/issues/1926.
+// Before the fix, every visual baked in a per-call Animation instance at creation time, so
+// changing the chart's AnimationsSpeed at runtime did not reach existing visuals — the user
+// had to recreate the series. The fix shares a single Animation reference per series/axis/chart
+// and mutates it in place, so the change propagates without recreation.
+[TestClass]
+public class AnimationsSpeedPropagationTests
+{
+    [TestMethod]
+    public void ColumnSeries_VisualMotion_PicksUpChartLevelAnimationsSpeed()
+    {
+        var initialSpeed = TimeSpan.FromMilliseconds(123);
+        var newSpeed = TimeSpan.FromMilliseconds(456);
+
+        var series = new ColumnSeries<double> { Values = [1d, 2d, 3d] };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            AnimationsSpeed = initialSpeed,
+            Series = [series],
+        };
+
+        _ = chart.GetImage();
+
+        var firstPoint = series.everFetched.First();
+        var visual = (RoundedRectangleGeometry?)firstPoint.Context.Visual
+            ?? throw new InvalidOperationException("expected RoundedRectangleGeometry visual");
+
+        var xMotion = DrawnGeometry.XProperty.GetMotion(visual)!;
+
+        Assert.AreEqual((long)initialSpeed.TotalMilliseconds, xMotion.Animation!.Duration,
+            "initial duration should match chart-level AnimationsSpeed.");
+
+        chart.AnimationsSpeed = newSpeed;
+        _ = chart.GetImage();
+
+        Assert.AreEqual((long)newSpeed.TotalMilliseconds, xMotion.Animation!.Duration,
+            "duration on the existing visual should follow chart-level AnimationsSpeed changes " +
+            "without recreating the series.");
+    }
+
+    [TestMethod]
+    public void Axis_LabelMotion_PicksUpChartLevelAnimationsSpeed()
+    {
+        var initialSpeed = TimeSpan.FromMilliseconds(150);
+        var newSpeed = TimeSpan.FromMilliseconds(750);
+
+        var x = new Axis();
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            AnimationsSpeed = initialSpeed,
+            Series = [new LineSeries<double> { Values = [1d, 2d, 3d] }],
+            XAxes = [x],
+        };
+
+        _ = chart.GetImage();
+
+        var label = x.activeSeparators[chart.CoreChart].Values
+            .Select(s => (s as LiveChartsCore.Kernel.Helpers.AxisVisualSeprator)?.Label)
+            .First(l => l is not null)!;
+
+        var labelXMotion = BaseLabelGeometry.XProperty.GetMotion(label)!;
+
+        Assert.AreEqual((long)initialSpeed.TotalMilliseconds, labelXMotion.Animation!.Duration);
+
+        chart.AnimationsSpeed = newSpeed;
+        _ = chart.GetImage();
+
+        Assert.AreEqual((long)newSpeed.TotalMilliseconds, labelXMotion.Animation!.Duration,
+            "axis-label motion should follow chart AnimationsSpeed changes without rebuild.");
+    }
+
+    [TestMethod]
+    public void ColumnSeries_VisualMotion_PicksUpRuntimePerSeriesOverride()
+    {
+        // The chart-level setting is irrelevant here: the series carries a per-series override
+        // both before and after, and we mutate the override at runtime. Existing visuals must
+        // pick up the new override value without recreation.
+        var seriesInitial = TimeSpan.FromMilliseconds(75);
+        var seriesNew = TimeSpan.FromMilliseconds(925);
+
+        var series = new ColumnSeries<double>
+        {
+            Values = [1d, 2d, 3d],
+            AnimationsSpeed = seriesInitial,
+        };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            AnimationsSpeed = TimeSpan.FromMilliseconds(300),
+            Series = [series],
+        };
+
+        _ = chart.GetImage();
+
+        var visual = (RoundedRectangleGeometry?)series.everFetched.First().Context.Visual
+            ?? throw new InvalidOperationException("expected RoundedRectangleGeometry visual");
+
+        var xMotion = DrawnGeometry.XProperty.GetMotion(visual)!;
+
+        Assert.AreEqual((long)seriesInitial.TotalMilliseconds, xMotion.Animation!.Duration,
+            "initial duration should follow the per-series override, not the chart-level value.");
+
+        series.AnimationsSpeed = seriesNew;
+        _ = chart.GetImage();
+
+        Assert.AreEqual((long)seriesNew.TotalMilliseconds, xMotion.Animation!.Duration,
+            "mutating Series.AnimationsSpeed at runtime should propagate to existing visuals.");
+    }
+
+    // Per-frame behavioral test, modelled after TransitionsTesting.cs. Drives chart Measure
+    // manually with controlled time (CoreMotionCanvas.DebugElapsedMilliseconds) to verify that
+    // when AnimationsSpeed is changed at runtime, the next data-driven SetMovement uses the new
+    // duration AND the geometry interpolates between FromValue and ToValue at the expected rate.
+    // A reference-identity test (above) only checks that Animation.Duration was mutated; this
+    // confirms that the value the renderer would actually paint follows the new speed.
+    [TestMethod]
+    public void RuntimeAnimationsSpeedChange_Interpolates_AtNewSpeed()
+    {
+        var initialSpeed = TimeSpan.FromMilliseconds(100);
+        var newSpeed = TimeSpan.FromMilliseconds(500);
+
+        var values = new ObservableCollection<double> { 50d };
+        var series = new ColumnSeries<double> { Values = values };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            AnimationsSpeed = initialSpeed,
+            // SK chart constructor sets EasingFunction = null (animations off). Restore a real
+            // function so transitions actually interpolate; Lineal makes the math trivial.
+            EasingFunction = EasingFunctions.Lineal,
+            Series = [series],
+            // Fixed Y range so changing the column value moves Y deterministically. With
+            // auto-limits a single-value dataset always renders the bar at the same height.
+            YAxes = [new Axis { MinLimit = 0, MaxLimit = 200 }],
+        };
+
+        var coreChart = (CartesianChartEngine)chart.CoreChart;
+
+        try
+        {
+            // Frame 0: first measure. Visual is created and animated 0 → pixelForValue50.
+            CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+            coreChart.IsLoaded = true;
+            coreChart._isFirstDraw = true;
+            coreChart.Measure();
+
+            var visual = (RoundedRectangleGeometry?)series.everFetched.First().Context.Visual
+                ?? throw new InvalidOperationException("expected RoundedRectangleGeometry visual");
+
+            var yMotion = (MotionProperty<float>)DrawnGeometry.YProperty.GetMotion(visual)!;
+
+            // Step past the initial animation so we have a stable starting state. Just advancing
+            // time and re-measuring is enough — Measure re-asserts visual.Y, but with the same
+            // pixel value, so SetMovement collapses to ToValue.
+            CoreMotionCanvas.DebugElapsedMilliseconds = (long)initialSpeed.TotalMilliseconds + 50;
+            coreChart.Measure();
+
+            var stableY = visual.Y;
+            Assert.AreEqual((long)initialSpeed.TotalMilliseconds, yMotion.Animation!.Duration,
+                "before runtime change, the Animation.Duration should still be the initial speed.");
+
+            // Now: change AnimationsSpeed AND change the data. The next measure should record a
+            // new SetMovement using the new speed.
+            chart.AnimationsSpeed = newSpeed;
+            values[0] = 100d;
+            var measureT = CoreMotionCanvas.DebugElapsedMilliseconds;
+            coreChart.Measure();
+
+            Assert.AreEqual((long)newSpeed.TotalMilliseconds, yMotion.Animation.Duration,
+                "after the runtime change, SetMovement should run with the new speed.");
+
+            var fromY = yMotion.FromValue;
+            var toY = yMotion.ToValue;
+            Assert.AreNotEqual(fromY, toY, "values changed; transition should be non-trivial.");
+            Assert.AreEqual(stableY, fromY,
+                "the new transition should pick up the previous (stable) Y as its FromValue.");
+
+            // Verify per-frame interpolation against the linear formula.
+            void AssertProgress(float p)
+            {
+                CoreMotionCanvas.DebugElapsedMilliseconds = measureT + (long)(p * newSpeed.TotalMilliseconds);
+                var actual = visual.Y;
+                var expected = fromY + p * (toY - fromY);
+                Assert.IsTrue(Math.Abs(actual - expected) < 0.01f,
+                    $"at p={p}, expected Y≈{expected}, got {actual}.");
+            }
+
+            AssertProgress(0f);
+            AssertProgress(0.25f);
+            AssertProgress(0.5f);
+            AssertProgress(0.75f);
+            AssertProgress(1f);
+
+            // Past the end of the new animation (which is 500ms long), Y should sit at ToValue.
+            CoreMotionCanvas.DebugElapsedMilliseconds = measureT + (long)newSpeed.TotalMilliseconds + 50;
+            Assert.AreEqual(toY, visual.Y);
+
+            // Sanity check that the OLD speed (100ms) is no longer in play: at measureT + 100ms,
+            // a properly-mutated Animation gives p=0.2 — under the bug, p=1.0 (animation already
+            // completed because Duration was still 100ms).
+            CoreMotionCanvas.DebugElapsedMilliseconds = measureT + (long)initialSpeed.TotalMilliseconds;
+            var underNewSpeed = fromY + (initialSpeed.TotalMilliseconds / newSpeed.TotalMilliseconds) * (toY - fromY);
+            Assert.IsTrue(Math.Abs(visual.Y - underNewSpeed) < 0.01f,
+                "if the bug regressed, Y would equal ToValue here (old 100ms duration); " +
+                "with the fix, it should be only ~20% of the way through the new 500ms transition.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1926. Mutating `Chart.AnimationsSpeed` (or per-series/axis overrides) at runtime now propagates to already-created visuals — no more recreating the series to apply new animation settings.

## What changed

Each visual previously baked in a per-call `Animation` instance at creation time, so later changes to `AnimationsSpeed` / `EasingFunction` had nowhere to land. The fix:

- `Animation.Duration` / `EasingFunction` / `RepeatTimes` are now settable.
- `Chart` owns a single shared `Animation` instance; `ActualAnimationsSpeed` / `ActualEasingFunction` setters mutate it in place.
- Each `Series` / `Axis` gets a `GetAnimation(chart)` helper that returns `chart.Animation` when there's no per-element override (the common path — chart-level changes flow automatically) or a scope-owned mutable instance when there is. Every `MotionProperty` references one of those instances.
- `GetAnimation(chart)` is also called once at the top of every `Series` / `Axis` `Invalidate`, so per-element override mutations propagate to existing visuals too.
- The `Animate(this Animatable, Chart)` extension now uses `chart.Animation` instead of constructing a new instance per call (sections, visual elements).

## Behavior matrix

| Scope | `Series.AnimationsSpeed` | At first render | Chart-level change at runtime | Override change at runtime |
|---|---|---|---|---|
| **No override** | `null` (default) | uses `Chart.Animation` | ✅ propagates | n/a |
| **With override** | e.g. `100ms` | uses series-owned `_animation` | ✅ ignored (correct) | ✅ propagates |

The only remaining gap (rare): toggling the override `null ↔ value` at runtime on already-rendered visuals — they stay on whichever `Animation` instance they were created with. Not addressed; would require re-pointing every existing `MotionProperty.Animation`, which is a much bigger change for an exotic case.

## Test plan

- [x] CoreTests 485/485 (3 new reference-identity regressions + 1 per-frame behavioral regression)
- [x] SnapshotTests 124/124
- [x] LiveChartsCore, SkiaSharpView, WPF, Avalonia all build clean
- [x] Verified each regression test fails when the corresponding piece of the fix is reverted
- [x] Per-frame test follows `TransitionsTesting` pattern: drives `Measure` manually under `CoreMotionCanvas.DebugElapsedMilliseconds`, mutates `AnimationsSpeed` mid-flight, asserts `visual.Y` matches the linear-easing formula at p ∈ {0, 0.25, 0.5, 0.75, 1}, plus a bug-detection check at `t = old-duration` that would resolve to `ToValue` under the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)