### PR TITLE
test: regression coverage for #1970 (no zombie shapes after shrink)

### DIFF
--- a/tests/CoreTests/SeriesTests/Issue1970Tests.cs
+++ b/tests/CoreTests/SeriesTests/Issue1970Tests.cs
@@ -1,0 +1,151 @@
+using System.Collections.ObjectModel;
+using CoreTests.CoreObjectsTests;
+using LiveChartsCore;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+
+namespace CoreTests.SeriesTests;
+
+// Regression coverage for https://github.com/Live-Charts/LiveCharts2/issues/1970.
+//
+// The reporter saw old markers/geometries piling up after a real-time data update.
+// Both reported flavors are exercised here:
+//   (a) Series.Values reassigned to a fresh, shorter collection.
+//   (b) ObservableCollection.Clear() + Add() shrinking the bound collection in place.
+// And both reported series types (Line + Scatter).
+//
+// Each test asserts two things after the shrink:
+//   1. Series.everFetched.Count equals the new dataset size — points rendered last
+//      frame but no longer in Values must be soft-deleted and pruned from the set.
+//      This is the contract enforced by ChartPointCleanupContext.CollectPoints,
+//      invoked at the end of every Core{Line,Scatter}Series.Measure pass.
+//   2. CoreCanvas.CountGeometries() equals what a freshly-built chart with the
+//      smaller dataset produces — i.e. no zombie shapes on the canvas, which is
+//      what the user actually sees.
+[TestClass]
+public class Issue1970Tests
+{
+    private const int InitialCount = 20;
+    private const int UpdatedCount = 5;
+
+    [TestMethod]
+    public void LineSeries_ValuesReassignedToSmallerArray_PrunesOldPoints()
+    {
+        var sutSeries = new LineSeries<ObservableValue> { Values = MakeCollection(InitialCount) };
+        var sutChart = NewChart(sutSeries);
+
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+        Assert.AreEqual(InitialCount, sutSeries.everFetched.Count, "first draw should fetch all initial points");
+
+        sutSeries.Values = MakeCollection(UpdatedCount);
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+
+        Assert.AreEqual(
+            UpdatedCount, sutSeries.everFetched.Count,
+            "after Values reassignment, stale ChartPoints must be pruned from everFetched");
+
+        var referenceChart = NewChart(new LineSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) });
+        _ = ChangingPaintTasks.DrawChart(referenceChart);
+
+        Assert.AreEqual(
+            referenceChart.CoreCanvas.CountGeometries(),
+            sutChart.CoreCanvas.CountGeometries(),
+            "after the shrink, the canvas should hold the same number of geometries as a chart " +
+            "freshly built with the smaller dataset (no zombie shapes left over)");
+    }
+
+    [TestMethod]
+    public void LineSeries_ObservableCollectionClearedAndRepopulatedSmaller_PrunesOldPoints()
+    {
+        var values = MakeCollection(InitialCount);
+        var sutSeries = new LineSeries<ObservableValue> { Values = values };
+        var sutChart = NewChart(sutSeries);
+
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+        Assert.AreEqual(InitialCount, sutSeries.everFetched.Count);
+
+        // Exact pattern from the issue body: mutate the same bound collection in place.
+        values.Clear();
+        for (var i = 0; i < UpdatedCount; i++) values.Add(new ObservableValue(i + 1));
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+
+        Assert.AreEqual(
+            UpdatedCount, sutSeries.everFetched.Count,
+            "after Clear()+Add() on the bound ObservableCollection, stale ChartPoints must be pruned");
+
+        var referenceChart = NewChart(new LineSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) });
+        _ = ChangingPaintTasks.DrawChart(referenceChart);
+
+        Assert.AreEqual(
+            referenceChart.CoreCanvas.CountGeometries(),
+            sutChart.CoreCanvas.CountGeometries(),
+            "no zombie shapes should remain on the canvas after the in-place shrink");
+    }
+
+    [TestMethod]
+    public void ScatterSeries_ValuesReassignedToSmallerArray_PrunesOldPoints()
+    {
+        var sutSeries = new ScatterSeries<ObservableValue> { Values = MakeCollection(InitialCount) };
+        var sutChart = NewChart(sutSeries);
+
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+        Assert.AreEqual(InitialCount, sutSeries.everFetched.Count);
+
+        sutSeries.Values = MakeCollection(UpdatedCount);
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+
+        Assert.AreEqual(
+            UpdatedCount, sutSeries.everFetched.Count,
+            "ScatterSeries: after Values reassignment, stale ChartPoints must be pruned");
+
+        var referenceChart = NewChart(new ScatterSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) });
+        _ = ChangingPaintTasks.DrawChart(referenceChart);
+
+        Assert.AreEqual(
+            referenceChart.CoreCanvas.CountGeometries(),
+            sutChart.CoreCanvas.CountGeometries(),
+            "ScatterSeries: no zombie shapes should remain on the canvas after the shrink");
+    }
+
+    [TestMethod]
+    public void ScatterSeries_ObservableCollectionClearedAndRepopulatedSmaller_PrunesOldPoints()
+    {
+        var values = MakeCollection(InitialCount);
+        var sutSeries = new ScatterSeries<ObservableValue> { Values = values };
+        var sutChart = NewChart(sutSeries);
+
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+        Assert.AreEqual(InitialCount, sutSeries.everFetched.Count);
+
+        values.Clear();
+        for (var i = 0; i < UpdatedCount; i++) values.Add(new ObservableValue(i + 1));
+        _ = ChangingPaintTasks.DrawChart(sutChart);
+
+        Assert.AreEqual(
+            UpdatedCount, sutSeries.everFetched.Count,
+            "ScatterSeries: after Clear()+Add() on the bound ObservableCollection, stale ChartPoints must be pruned");
+
+        var referenceChart = NewChart(new ScatterSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) });
+        _ = ChangingPaintTasks.DrawChart(referenceChart);
+
+        Assert.AreEqual(
+            referenceChart.CoreCanvas.CountGeometries(),
+            sutChart.CoreCanvas.CountGeometries(),
+            "ScatterSeries: no zombie shapes should remain on the canvas after the in-place shrink");
+    }
+
+    private static ObservableCollection<ObservableValue> MakeCollection(int count)
+    {
+        var values = new ObservableCollection<ObservableValue>();
+        for (var i = 0; i < count; i++) values.Add(new ObservableValue(i + 1));
+        return values;
+    }
+
+    private static SKCartesianChart NewChart(ISeries series) => new()
+    {
+        Series = [series],
+        Width = 300,
+        Height = 200
+    };
+}

--- a/tests/SnapshotTests/Issue1970Tests.cs
+++ b/tests/SnapshotTests/Issue1970Tests.cs
@@ -1,0 +1,153 @@
+using System.Collections.ObjectModel;
+using LiveChartsCore;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using SkiaSharp;
+
+namespace SnapshotTests;
+
+// Pixel-level regression coverage for https://github.com/Live-Charts/LiveCharts2/issues/1970.
+//
+// The reporter saw old markers/geometries piling up after a real-time data update.
+// Each test renders three frames:
+//   * Before: chart with the full dataset (rendered for diagnostic value, also used as
+//     the committed reference snapshot so reviewers can see the starting state).
+//   * After: same chart instance, after Values are shrunk.
+//   * Reference: a brand-new chart built directly with the smaller dataset.
+// The "After" image must match the "Reference" image bit-for-bit (within the same
+// tolerance the rest of the snapshot suite uses) — any zombie marker, line segment,
+// or fill remnant would shift pixels and fail the comparison.
+//
+// Both the reassignment path (Series.Values = newCollection) and the in-place mutation
+// path (ObservableCollection.Clear() + Add()) are covered for both Line and Scatter,
+// matching the two flavors in the issue body.
+[TestClass]
+public sealed class Issue1970Tests
+{
+    private const int InitialCount = 20;
+    private const int UpdatedCount = 5;
+    private const int Width = 600;
+    private const int Height = 400;
+
+    [TestMethod]
+    public void LineSeries_ValuesReassignedToSmallerArray_NoZombieShapes()
+    {
+        var sutSeries = new LineSeries<ObservableValue> { Values = MakeCollection(InitialCount) };
+        var sutChart = NewChart(sutSeries);
+
+        using var beforeImage = sutChart.GetImage();
+
+        sutSeries.Values = MakeCollection(UpdatedCount);
+        using var afterImage = sutChart.GetImage();
+
+        AssertMatchesFreshChart(
+            afterImage, beforeImage,
+            new LineSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) },
+            $"{nameof(Issue1970Tests)}_{nameof(LineSeries_ValuesReassignedToSmallerArray_NoZombieShapes)}");
+    }
+
+    [TestMethod]
+    public void LineSeries_ObservableCollectionClearedAndRepopulatedSmaller_NoZombieShapes()
+    {
+        var values = MakeCollection(InitialCount);
+        var sutSeries = new LineSeries<ObservableValue> { Values = values };
+        var sutChart = NewChart(sutSeries);
+
+        using var beforeImage = sutChart.GetImage();
+
+        // Exact pattern from the issue body: mutate the same bound collection in place.
+        values.Clear();
+        for (var i = 0; i < UpdatedCount; i++) values.Add(new ObservableValue(i + 1));
+        using var afterImage = sutChart.GetImage();
+
+        AssertMatchesFreshChart(
+            afterImage, beforeImage,
+            new LineSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) },
+            $"{nameof(Issue1970Tests)}_{nameof(LineSeries_ObservableCollectionClearedAndRepopulatedSmaller_NoZombieShapes)}");
+    }
+
+    [TestMethod]
+    public void ScatterSeries_ValuesReassignedToSmallerArray_NoZombieShapes()
+    {
+        var sutSeries = new ScatterSeries<ObservableValue> { Values = MakeCollection(InitialCount) };
+        var sutChart = NewChart(sutSeries);
+
+        using var beforeImage = sutChart.GetImage();
+
+        sutSeries.Values = MakeCollection(UpdatedCount);
+        using var afterImage = sutChart.GetImage();
+
+        AssertMatchesFreshChart(
+            afterImage, beforeImage,
+            new ScatterSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) },
+            $"{nameof(Issue1970Tests)}_{nameof(ScatterSeries_ValuesReassignedToSmallerArray_NoZombieShapes)}");
+    }
+
+    [TestMethod]
+    public void ScatterSeries_ObservableCollectionClearedAndRepopulatedSmaller_NoZombieShapes()
+    {
+        var values = MakeCollection(InitialCount);
+        var sutSeries = new ScatterSeries<ObservableValue> { Values = values };
+        var sutChart = NewChart(sutSeries);
+
+        using var beforeImage = sutChart.GetImage();
+
+        values.Clear();
+        for (var i = 0; i < UpdatedCount; i++) values.Add(new ObservableValue(i + 1));
+        using var afterImage = sutChart.GetImage();
+
+        AssertMatchesFreshChart(
+            afterImage, beforeImage,
+            new ScatterSeries<ObservableValue> { Values = MakeCollection(UpdatedCount) },
+            $"{nameof(Issue1970Tests)}_{nameof(ScatterSeries_ObservableCollectionClearedAndRepopulatedSmaller_NoZombieShapes)}");
+    }
+
+    private static void AssertMatchesFreshChart(
+        SKImage afterImage, SKImage beforeImage, ISeries freshSeries, string testName)
+    {
+        var freshChart = NewChart(freshSeries);
+        using var freshImage = freshChart.GetImage();
+
+        var result = Extensions.Compare(
+            freshImage, afterImage,
+            perChannelTolerance: 2,
+            maxDifferentPixelsRatio: 0.001);
+
+        if (!result.IsSuccessful)
+        {
+            // Save all three frames for diagnosis: before-shrink, after-shrink, and the
+            // fresh small reference. Any zombie shape shows up as a difference between
+            // the latter two.
+            if (!Directory.Exists("SnapshotsDiff")) _ = Directory.CreateDirectory("SnapshotsDiff");
+            SaveImage(beforeImage, Path.Combine("SnapshotsDiff", $"{testName}[BEFORE].png"));
+            SaveImage(afterImage, Path.Combine("SnapshotsDiff", $"{testName}[AFTER].png"));
+            SaveImage(freshImage, Path.Combine("SnapshotsDiff", $"{testName}[EXPECTED].png"));
+        }
+
+        Assert.IsTrue(
+            result.IsSuccessful,
+            $"after-shrink image differs from a fresh small-dataset render — zombie shapes likely remain. {result.Message}");
+    }
+
+    private static ObservableCollection<ObservableValue> MakeCollection(int count)
+    {
+        var values = new ObservableCollection<ObservableValue>();
+        for (var i = 0; i < count; i++) values.Add(new ObservableValue(i + 1));
+        return values;
+    }
+
+    private static SKCartesianChart NewChart(ISeries series) => new()
+    {
+        Series = [series],
+        Width = Width,
+        Height = Height
+    };
+
+    private static void SaveImage(SKImage image, string path)
+    {
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.OpenWrite(path);
+        data.SaveTo(stream);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #1970 reported old markers/geometries piling up after a real-time data update on `LineSeries` and `ScatterSeries` (originally seen on `2.0.0-rc5.4`). On current `master` the cleanup pass in `ChartPointCleanupContext.CollectPoints` (invoked by every `Core{Line,Scatter}Series.Measure`) handles this correctly, so this PR is regression coverage only — no library changes.

Two tests landed, one per layer:

- **`tests/CoreTests/SeriesTests/Issue1970Tests.cs`** — asserts `Series.everFetched.Count` drops to the new dataset size after a shrink, and `CoreCanvas.CountGeometries()` matches a chart freshly built with the smaller dataset (no zombie shapes on the canvas).
- **`tests/SnapshotTests/Issue1970Tests.cs`** — renders before/after frames around the shrink and asserts the after-frame is byte-equivalent (within the suite's standard tolerance) to a fresh chart with the smaller dataset. Any leftover marker, segment, or fill remnant would shift pixels and fail. On failure all three frames (before, after, expected) are written to `SnapshotsDiff/`.

Both tests cover the matrix the issue described: `LineSeries` + `ScatterSeries` × `Values =` reassignment + `ObservableCollection.Clear() + Add()`.

Closes #1970.

## Test plan
- [x] `dotnet test tests/CoreTests/CoreTests.csproj --framework net8.0 --filter "FullyQualifiedName~Issue1970Tests"` — 4/4 passed
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj --filter "FullyQualifiedName~Issue1970Tests"` — 4/4 passed
- [x] Full `CoreTests` suite still green (485/485)

🤖 Generated with [Claude Code](https://claude.com/claude-code)