### PR TITLE
fix(wpf-templates): unblock direct Series/XAxes bindings inside DataTemplate (#1981)

### DIFF
--- a/generators/LiveChartsGenerators/Templates/UIPropertyTempaltes.cs
+++ b/generators/LiveChartsGenerators/Templates/UIPropertyTempaltes.cs
@@ -158,6 +158,35 @@ namespace {baseTypeSymbol.ContainingNamespace};
         XamlProperty target, FrameworkTemplate template, string propertyName, string propertyType, string sanitizedPropertyType, string declaringType, string docs,
         string converter)
     {
+        // For collection-typed DPs (IEnumerable<TInterface> where TInterface != object),
+        // emit a lazy-init getter that creates an empty ObservableCollection on first
+        // access. Issue #1981: WPF's FrameworkElementFactory silently drops bindings to
+        // a DP that already has a non-default local value, so we cannot pre-init these
+        // collections in the chart constructor. Lazy init in the getter via the
+        // platform's SetCurrentValue (which doesn't clobber an attached binding)
+        // preserves `chart.Series.Add(...)` for code-only callers without breaking
+        // bindings inside DataTemplate.
+        var lazyInnerType = GetLazyInitElementType(target);
+        // Only WPF (verified) needs this — its FrameworkElementFactory drops bindings
+        // when the target DP holds a non-default local value, so we cannot pre-init
+        // collection DPs in the constructor. WPF supports SetCurrentValue, so we lazy-
+        // init in the getter without clobbering an attached binding. Other XAML
+        // platforms (Avalonia/WinUI/MAUI/Uno) do not reproduce #1981 — verified via
+        // Factos UI tests.
+        var emitLazyGetter = template.Key == "WPF";
+        var getter = (lazyInnerType is null || !emitLazyGetter)
+            ? $"get => ({propertyType})GetValue({propertyName}Property);"
+            : @$"get
+        {{
+            var __current = ({propertyType})GetValue({propertyName}Property);
+            if (__current is null)
+            {{
+                __current = new global::System.Collections.ObjectModel.ObservableCollection<{lazyInnerType}>();
+                SetCurrentValue({propertyName}Property, __current);
+            }}
+            return __current;
+        }}";
+
         return @$"
     /// <summary>
     ///    The <see cref=""{propertyName}""/> property definition.
@@ -167,9 +196,26 @@ namespace {baseTypeSymbol.ContainingNamespace};
 
     {docs}{converter}    public {propertyType} {propertyName}
     {{
-        get => ({propertyType})GetValue({propertyName}Property);
+        {getter}
         set => SetValue({propertyName}Property, value);
     }}";
+    }
+
+    private static string? GetLazyInitElementType(XamlProperty target)
+    {
+        if (target.Type is not INamedTypeSymbol named) return null;
+        if (!named.IsGenericType) return null;
+        if (named.ConstructedFrom?.ToDisplayString() != "System.Collections.Generic.IEnumerable<T>") return null;
+        if (named.TypeArguments.Length != 1) return null;
+
+        var inner = named.TypeArguments[0];
+        if (inner.SpecialType == SpecialType.System_Object) return null;
+
+        var displayFormat = new SymbolDisplayFormat(
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters);
+
+        return $"global::{inner.ToDisplayString(displayFormat)}";
     }
 
     private static string GetFormattedAccessibility(Accessibility accessibility)

--- a/samples/AvaloniaSample/VisualTest/Issue1981/View.axaml
+++ b/samples/AvaloniaSample/VisualTest/Issue1981/View.axaml
@@ -1,0 +1,33 @@
+<UserControl
+    x:Class="AvaloniaSample.VisualTest.Issue1981.View"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+    xmlns:vms="using:ViewModelsSamples.VisualTest.Issue1981"
+    x:DataType="vms:ViewModel">
+
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+
+    <ItemsControl ItemsSource="{Binding Items}">
+        <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vms:ChartContainer">
+                <Grid RowDefinitions="Auto,300">
+
+                    <Label
+                        Grid.Row="0"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Content="{Binding Title}"/>
+
+                    <lvc:CartesianChart
+                        Grid.Row="1"
+                        Series="{Binding Series}"
+                        XAxes="{Binding XAxes}"
+                        YAxes="{Binding YAxes}"/>
+                </Grid>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+</UserControl>

--- a/samples/AvaloniaSample/VisualTest/Issue1981/View.axaml.cs
+++ b/samples/AvaloniaSample/VisualTest/Issue1981/View.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
+using LiveChartsCore.Kernel.Sketches;
+
+namespace AvaloniaSample.VisualTest.Issue1981;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public IEnumerable<IChartView> FindCharts(Visual? parent = null)
+    {
+        parent ??= (Visual)Content!;
+
+        foreach (var child in parent.GetVisualChildren())
+        {
+            if (child is IChartView chart)
+                yield return chart;
+
+            foreach (var descendant in FindCharts(child))
+                yield return descendant;
+        }
+    }
+
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/MauiSample/VisualTest/Issue1981/View.xaml
+++ b/samples/MauiSample/VisualTest/Issue1981/View.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="MauiSample.VisualTest.Issue1981.View"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Maui;assembly=LiveChartsCore.SkiaSharpView.Maui"
+    xmlns:vms="clr-namespace:ViewModelsSamples.VisualTest.Issue1981;assembly=ViewModelsSamples">
+
+    <ContentPage.BindingContext>
+        <vms:ViewModel/>
+    </ContentPage.BindingContext>
+
+    <StackLayout BindableLayout.ItemsSource="{Binding Items}" VerticalOptions="Start">
+        <BindableLayout.ItemTemplate>
+            <DataTemplate>
+                <Grid RowDefinitions="Auto,300">
+
+                    <Label
+                        Grid.Row="0"
+                        VerticalOptions="Center"
+                        HorizontalOptions="Center"
+                        Text="{Binding Title}"/>
+
+                    <lvc:CartesianChart
+                        Grid.Row="1"
+                        Series="{Binding Series}"
+                        XAxes="{Binding XAxes}"
+                        YAxes="{Binding YAxes}"/>
+                </Grid>
+            </DataTemplate>
+        </BindableLayout.ItemTemplate>
+    </StackLayout>
+
+</ContentPage>

--- a/samples/MauiSample/VisualTest/Issue1981/View.xaml.cs
+++ b/samples/MauiSample/VisualTest/Issue1981/View.xaml.cs
@@ -1,0 +1,23 @@
+using LiveChartsCore.Kernel.Sketches;
+
+namespace MauiSample.VisualTest.Issue1981;
+
+[XamlCompilation(XamlCompilationOptions.Compile)]
+public partial class View : ContentPage
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public IEnumerable<IChartView> FindCharts(Element? parent = null)
+    {
+        parent ??= Content!;
+
+        foreach (var child in parent.GetVisualTreeDescendants())
+        {
+            if (child is IChartView chart)
+                yield return chart;
+        }
+    }
+}

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -122,6 +122,7 @@ public static class Index
         "VisualTest/TwoChartsOneSeries",
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
+        "VisualTest/Issue1981",
         "VisualTest/Tabs",
 
         "Test/ChangeSeriesInstance",

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -122,7 +122,6 @@ public static class Index
         "VisualTest/TwoChartsOneSeries",
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
-        "VisualTest/Issue1981",
         "VisualTest/Tabs",
 
         "Test/ChangeSeriesInstance",

--- a/samples/ViewModelsSamples/VisualTest/Issue1981/ViewModel.cs
+++ b/samples/ViewModelsSamples/VisualTest/Issue1981/ViewModel.cs
@@ -1,0 +1,43 @@
+using LiveChartsCore;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.SkiaSharpView;
+
+namespace ViewModelsSamples.VisualTest.Issue1981;
+
+public class ChartContainer
+{
+    public string Title { get; set; } = string.Empty;
+    public ISeries[] Series { get; set; } = [];
+    public ICartesianAxis[] XAxes { get; set; } = [];
+    public ICartesianAxis[] YAxes { get; set; } = [];
+}
+
+public class ViewModel
+{
+    public ChartContainer[] Items { get; set; } =
+    [
+        new ChartContainer
+        {
+            Title = "Sales",
+            Series =
+            [
+                new LineSeries<int> { Name = "Q1", Values = [3, 5, 2, 8, 4] },
+                new LineSeries<int> { Name = "Q2", Values = [6, 2, 7, 3, 5] },
+            ],
+            XAxes = [ new Axis { Name = "Month" } ],
+            YAxes = [ new Axis { Name = "Units" } ],
+        },
+        new ChartContainer
+        {
+            Title = "Marketing",
+            Series =
+            [
+                new LineSeries<int> { Name = "A", Values = [1, 4, 6, 2, 9] },
+                new LineSeries<int> { Name = "B", Values = [5, 3, 4, 7, 2] },
+                new LineSeries<int> { Name = "C", Values = [8, 6, 3, 5, 4] },
+            ],
+            XAxes = [ new Axis { Name = "Month" } ],
+            YAxes = [ new Axis { Name = "Leads" } ],
+        }
+    ];
+}

--- a/samples/WPFSample/VisualTest/Issue1981/View.xaml
+++ b/samples/WPFSample/VisualTest/Issue1981/View.xaml
@@ -1,0 +1,36 @@
+<UserControl
+    x:Class="WPFSample.VisualTest.Issue1981.View"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
+    xmlns:vms="clr-namespace:ViewModelsSamples.VisualTest.Issue1981;assembly=ViewModelsSamples">
+
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+
+    <ItemsControl ItemsSource="{Binding Items}">
+        <ItemsControl.ItemTemplate>
+            <DataTemplate DataType="{x:Type vms:ChartContainer}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="300"/>
+                    </Grid.RowDefinitions>
+
+                    <Label
+                        Grid.Row="0"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Content="{Binding Title}"/>
+
+                    <lvc:CartesianChart
+                        Grid.Row="1"
+                        Series="{Binding Series}"
+                        XAxes="{Binding XAxes}"
+                        YAxes="{Binding YAxes}"/>
+                </Grid>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+</UserControl>

--- a/samples/WPFSample/VisualTest/Issue1981/View.xaml.cs
+++ b/samples/WPFSample/VisualTest/Issue1981/View.xaml.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using LiveChartsCore.Kernel.Sketches;
+
+namespace WPFSample.VisualTest.Issue1981;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public IEnumerable<IChartView> FindCharts(DependencyObject? parent = null)
+    {
+        parent ??= (DependencyObject)Content;
+
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+
+            if (child is IChartView typedChild)
+                yield return typedChild;
+
+            foreach (var descendant in FindCharts(child))
+                yield return descendant;
+        }
+    }
+}

--- a/samples/WinUISample/WinUISample/Samples/VisualTest/Issue1981/View.xaml
+++ b/samples/WinUISample/WinUISample/Samples/VisualTest/Issue1981/View.xaml
@@ -1,0 +1,36 @@
+<UserControl
+    x:Class="WinUISample.VisualTest.Issue1981.View"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:lvc="using:LiveChartsCore.SkiaSharpView.WinUI"
+    xmlns:vms="using:ViewModelsSamples.VisualTest.Issue1981"
+    mc:Ignorable="d">
+
+    <UserControl.DataContext>
+        <vms:ViewModel/>
+    </UserControl.DataContext>
+
+    <ItemsControl ItemsSource="{Binding Items}">
+        <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vms:ChartContainer">
+                <Grid RowDefinitions="Auto,300">
+
+                    <TextBlock
+                        Grid.Row="0"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Text="{Binding Title}"/>
+
+                    <lvc:CartesianChart
+                        Grid.Row="1"
+                        Series="{Binding Series}"
+                        XAxes="{Binding XAxes}"
+                        YAxes="{Binding YAxes}"/>
+                </Grid>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+</UserControl>

--- a/samples/WinUISample/WinUISample/Samples/VisualTest/Issue1981/View.xaml.cs
+++ b/samples/WinUISample/WinUISample/Samples/VisualTest/Issue1981/View.xaml.cs
@@ -1,0 +1,32 @@
+using LiveChartsCore.Kernel.Sketches;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace WinUISample.VisualTest.Issue1981;
+
+public sealed partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public IEnumerable<IChartView> FindCharts(DependencyObject? parent = null)
+    {
+        parent ??= (DependencyObject)Content!;
+
+        var count = VisualTreeHelper.GetChildrenCount(parent);
+
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+
+            if (child is IChartView chart)
+                yield return chart;
+
+            foreach (var descendant in FindCharts(child))
+                yield return descendant;
+        }
+    }
+}

--- a/src/skiasharp/_Shared/SourceGenCartesianChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenCartesianChart.shared.cs
@@ -86,11 +86,17 @@ public partial class SourceGenCartesianChart : SGChart, ICartesianChartView
     /// <inheritdoc cref="SGChart.InitializeObservedProperties"/>
     protected override void InitializeObservedProperties()
     {
+        SyncContext = new object();
+#if !WPF_LVC
+        // WPF lazy-inits these in the property getter via SetCurrentValue
+        // (issue #1981) so this constructor-time SetValue would block the
+        // FrameworkElementFactory binding. Other platforms pre-init here so
+        // `chart.Series.Add(...)` works pre-Loaded.
         XAxes = new ObservableCollection<ICartesianAxis>();
         YAxes = new ObservableCollection<ICartesianAxis>();
         Series = new ObservableCollection<ISeries>();
         Sections = new ObservableCollection<IChartElement>();
         VisualElements = new ObservableCollection<IChartElement>();
-        SyncContext = new object();
+#endif
     }
 }

--- a/src/skiasharp/_Shared/SourceGenPieChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenPieChart.shared.cs
@@ -53,8 +53,14 @@ public partial class SourceGenPieChart : SGChart, IPieChartView
     /// <inheritdoc cref="SGChart.InitializeObservedProperties"/>
     protected override void InitializeObservedProperties()
     {
+        SyncContext = new object();
+#if !WPF_LVC
+        // WPF lazy-inits these in the property getter via SetCurrentValue
+        // (issue #1981) so this constructor-time SetValue would block the
+        // FrameworkElementFactory binding. Other platforms pre-init here so
+        // `chart.Series.Add(...)` works pre-Loaded.
         Series = new ObservableCollection<ISeries>();
         VisualElements = new ObservableCollection<IChartElement>();
-        SyncContext = new object();
+#endif
     }
 }

--- a/src/skiasharp/_Shared/SourceGenPolarChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenPolarChart.shared.cs
@@ -71,10 +71,16 @@ public partial class SourceGenPolarChart : SGChart, IPolarChartView
     /// <inheritdoc cref="SGChart.InitializeObservedProperties"/>
     protected override void InitializeObservedProperties()
     {
+        SyncContext = new object();
+#if !WPF_LVC
+        // WPF lazy-inits these in the property getter via SetCurrentValue
+        // (issue #1981) so this constructor-time SetValue would block the
+        // FrameworkElementFactory binding. Other platforms pre-init here so
+        // `chart.Series.Add(...)` works pre-Loaded.
         AngleAxes = new ObservableCollection<IPolarAxis>();
         RadiusAxes = new ObservableCollection<IPolarAxis>();
         Series = new ObservableCollection<ISeries>();
         VisualElements = new ObservableCollection<IChartElement>();
-        SyncContext = new object();
+#endif
     }
 }

--- a/tests/SharedUITests/CartesianChartTests.cs
+++ b/tests/SharedUITests/CartesianChartTests.cs
@@ -40,6 +40,37 @@ public class CartesianChartTests
     }
 #endif
 
+#if XAML_UI_TESTING
+    // Regression for https://github.com/Live-Charts/LiveCharts2/issues/1981.
+    // Inside a DataTemplate, WPF's FrameworkElementFactory skips applying a
+    // binding when the target DP already has a non-default local value. The
+    // chart used to set Series/XAxes/YAxes to a fresh ObservableCollection
+    // in its constructor, which silently swallowed direct bindings on those
+    // properties. The fix lazy-inits those collections in the property getter
+    // (via SetCurrentValue) so the constructor leaves the DP at its default,
+    // letting the binding attach normally.
+    //
+    // The same sample runs across every XAML platform so any platform with
+    // similar template-binding semantics is caught here.
+
+    [AppTestMethod]
+    public async Task ShouldBindSeriesAndAxesInsideDataTemplate()
+    {
+        var sut = await App.NavigateTo<Samples.VisualTest.Issue1981.View>();
+
+        await Task.Delay(2000);
+
+        var charts = sut.FindCharts().ToList();
+        Assert.NotEmpty(charts);
+
+        foreach (var chart in charts)
+        {
+            await chart.WaitUntilChartRenders();
+            Assert.ChartIsLoaded(chart);
+        }
+    }
+#endif
+
 #if !BLAZOR_UI_TESTING
     // this test makes no sense in blazor.
 


### PR DESCRIPTION
## Summary

Fixes [#1981](https://github.com/Live-Charts/LiveCharts2/issues/1981).

WPF's \`FrameworkElementFactory\` silently drops a binding when the target \`DependencyProperty\` already holds a non-default local value. The chart constructor was setting \`Series\` / \`XAxes\` / \`YAxes\` / \`Sections\` / \`VisualElements\` to a fresh \`ObservableCollection\` in \`InitializeObservedProperties()\` via the CLR setter, so any direct binding in a \`DataTemplate\` (e.g. \`Series=\"{Binding ...}\"\`) was swallowed and the chart rendered empty.

## Approach

WPF-only — verified via Factos that Avalonia, MAUI, WinUI, and Uno do **not** reproduce #1981.

- \`UIPropertyTempaltes\` emits a lazy-init getter for collection-typed DPs (\`IEnumerable<TInterface>\`) only on the WPF template. The getter creates an \`ObservableCollection<T>\` on first access and stores it via \`SetCurrentValue\`, which preserves any attached binding.
- Shared cartesian / polar / pie \`InitializeObservedProperties\` is gated on \`#if !WPF_LVC\` so non-WPF platforms keep their existing constructor pre-init.
- \`chart.Series.Add(...)\` pre-Loaded keeps working on every platform — public API unchanged.

## Verification (Factos UI tests on Windows)

| Platform | Tests | Bug present? |
|---|---|---|
| WPF | 16/16 ✓ | yes (regression test fails when fix is reverted) |
| Avalonia | 15/15 ✓ | no |
| WinUI | 15/15 ✓ | no |
| MAUI | 14/14 ✓ | no |
| Uno | 15/15 ✓ | no |

CoreTests: 481/481 ✓.

## Test plan

- [x] WPF regression test added in \`SharedUITests/CartesianChartTests.cs\` (\`ShouldBindSeriesAndAxesInsideDataTemplate\`) and verified to fail on master without the fix
- [x] Sample (\`VisualTest/Issue1981\`) added for every XAML platform; the test runs gated on \`XAML_UI_TESTING\` so any future regression on Avalonia / MAUI / WinUI / Uno is caught in CI
- [x] CoreTests still pass on net8.0
- [x] Existing DataTemplate sample (\`VisualTest/DataTemplate\`, SeriesSource path) still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)