### PR TITLE
fix(avalonia-gauge): respect XAML CornerRadius=0 against theme override (#2008)

### DIFF
--- a/samples/AvaloniaSample/VisualTest/Issue2008Repro/View.axaml
+++ b/samples/AvaloniaSample/VisualTest/Issue2008Repro/View.axaml
@@ -1,0 +1,92 @@
+<UserControl
+    x:Class="AvaloniaSample.VisualTest.Issue2008Repro.View"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:lvc="using:LiveChartsCore.SkiaSharpView.Avalonia"
+    xmlns:local="using:AvaloniaSample.VisualTest.Issue2008Repro">
+
+    <UserControl.Resources>
+        <ControlTheme x:Key="{x:Type local:Gauge}" TargetType="local:Gauge">
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="Template">
+                <ControlTemplate TargetType="local:Gauge">
+                    <Grid VerticalAlignment="Top" RowDefinitions="Auto,Auto">
+                        <lvc:PieChart
+                            Width="380"
+                            Height="380"
+                            CornerRadius="0"
+                            InitialRotation="-225"
+                            MaxAngle="270"
+                            MaxValue="{TemplateBinding MaxValue}"
+                            MinValue="{TemplateBinding MinValue}">
+                            <lvc:PieChart.Series>
+                                <lvc:SeriesCollection>
+                                    <lvc:XamlGaugeSeries
+                                        CornerRadius="0"
+                                        Fill="{lvc:SolidColorPaint Color='#FF7F50'}"
+                                        GaugeValue="{TemplateBinding Value}"
+                                        InnerRadius="60"
+                                        MaxRadialColumnWidth="120"
+                                        ShowDataLabels="False" />
+                                    <lvc:XamlGaugeBackgroundSeries
+                                        Fill="{lvc:SolidColorPaint Color='#A9A9A9'}"
+                                        InnerRadius="60"
+                                        MaxRadialColumnWidth="120" />
+                                </lvc:SeriesCollection>
+                            </lvc:PieChart.Series>
+                        </lvc:PieChart>
+
+                        <TextBlock
+                            Grid.Row="1"
+                            HorizontalAlignment="Center"
+                            Text="{TemplateBinding Label}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+    </UserControl.Resources>
+
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Top"
+        Orientation="Horizontal"
+        Spacing="50">
+
+        <!--  Not Template Control  -->
+        <StackPanel>
+            <TextBlock Text="Not template (CornerRadius=0)" HorizontalAlignment="Center" />
+            <lvc:PieChart
+                Width="380"
+                Height="380"
+                VerticalAlignment="Top"
+                InitialRotation="-225"
+                MaxAngle="270"
+                MaxValue="250"
+                MinValue="0">
+                <lvc:PieChart.Series>
+                    <lvc:XamlGaugeSeries
+                        CornerRadius="0"
+                        Fill="{lvc:SolidColorPaint Color='#9ACD32'}"
+                        GaugeValue="90"
+                        InnerRadius="60"
+                        MaxRadialColumnWidth="120"
+                        ShowDataLabels="False" />
+                    <lvc:XamlGaugeBackgroundSeries
+                        Fill="{lvc:SolidColorPaint Color='#5A64B5F6'}"
+                        InnerRadius="60"
+                        MaxRadialColumnWidth="120" />
+                </lvc:PieChart.Series>
+            </lvc:PieChart>
+        </StackPanel>
+
+        <!--  Template Control  -->
+        <local:Gauge
+            x:Name="templatedGauge"
+            Label="Template control"
+            MaxValue="250"
+            MinValue="0"
+            Value="90" />
+
+    </StackPanel>
+</UserControl>

--- a/samples/AvaloniaSample/VisualTest/Issue2008Repro/View.axaml.cs
+++ b/samples/AvaloniaSample/VisualTest/Issue2008Repro/View.axaml.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.SkiaSharpView.Avalonia;
+
+namespace AvaloniaSample.VisualTest.Issue2008Repro;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+    }
+
+    public Gauge TemplatedGauge => this.Find<Gauge>("templatedGauge")!;
+
+    public IPieSeries? FindTemplatedGaugeSeries()
+    {
+        // walk the templated PieChart to find its first non-fill IPieSeries.
+        var chart = FindDescendantPieChart(TemplatedGauge);
+        return ((IPieChartView)chart!).Series
+            .OfType<IPieSeries>()
+            .FirstOrDefault(s => !s.IsFillSeries);
+    }
+
+    private static PieChart? FindDescendantPieChart(Visual root)
+    {
+        foreach (var child in root.GetVisualChildren())
+        {
+            if (child is PieChart c) return c;
+            var hit = FindDescendantPieChart(child);
+            if (hit is not null) return hit;
+        }
+        return null;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}
+
+public class Gauge : TemplatedControl
+{
+    public static readonly StyledProperty<double> ValueProperty =
+        AvaloniaProperty.Register<Gauge, double>(nameof(Value), 0d);
+
+    public static readonly StyledProperty<double> MaxValueProperty =
+        AvaloniaProperty.Register<Gauge, double>(nameof(MaxValue), 100d);
+
+    public static readonly StyledProperty<double> MinValueProperty =
+        AvaloniaProperty.Register<Gauge, double>(nameof(MinValue), 0d);
+
+    public static readonly StyledProperty<string> LabelProperty =
+        AvaloniaProperty.Register<Gauge, string>(nameof(Label), string.Empty);
+
+    public double Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public double MaxValue
+    {
+        get => GetValue(MaxValueProperty);
+        set => SetValue(MaxValueProperty, value);
+    }
+
+    public double MinValue
+    {
+        get => GetValue(MinValueProperty);
+        set => SetValue(MinValueProperty, value);
+    }
+
+    public string Label
+    {
+        get => GetValue(LabelProperty);
+        set => SetValue(LabelProperty, value);
+    }
+}

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -123,6 +123,7 @@ public static class Index
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
         "VisualTest/Tabs",
+        "VisualTest/Issue2008Repro",
 
         "Test/ChangeSeriesInstance",
         "Test/Dispose",

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -123,7 +123,6 @@ public static class Index
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
         "VisualTest/Tabs",
-        "VisualTest/Issue2008Repro",
 
         "Test/ChangeSeriesInstance",
         "Test/Dispose",

--- a/src/skiasharp/_Shared.Xaml/Series.cs
+++ b/src/skiasharp/_Shared.Xaml/Series.cs
@@ -167,6 +167,32 @@ public partial class XamlGaugeSeries<TVisual, TLabel> : XamlSeries, IPieSeries, 
         MapChangeToBaseType(change.Property.Name);
         OnXamlPropertyChanged(change);
     }
+
+    /// <inheritdoc />
+    public override void EndInit()
+    {
+        base.EndInit();
+
+        // Avalonia skips OnPropertyChanged when SetValue assigns a value equal to the
+        // property's default (e.g. CornerRadius="0" where the DP default is also 0).
+        // MapChangeToBaseType then never runs for that property, _userSets stays empty,
+        // and a theme rule (HasRuleForGaugeSeries setting CornerRadius=8) silently
+        // overrides the user's explicit value (issue #2008). Series controls don't
+        // get rooted in the visual tree (they're collected by Series, not Children),
+        // so OnInitialized never fires for them — but EndInit does, after the XAML
+        // parser has applied every value.
+        //
+        // Walk the registered DPs and sync any property whose value source isn't the
+        // default. MapChangeToBaseType pushes the value into the wrapped CorePieSeries
+        // and SetProperty there records the property in _userSets, blocking subsequent
+        // theme overrides. Properties at default source are skipped so theme defaults
+        // still apply for unspecified properties.
+        foreach (var prop in global::Avalonia.AvaloniaPropertyRegistry.Instance.GetRegistered(GetType()))
+        {
+            if (IsSet(prop))
+                MapChangeToBaseType(prop.Name);
+        }
+    }
 #endif
 }
 

--- a/tests/SharedUITests/PieChartTests.cs
+++ b/tests/SharedUITests/PieChartTests.cs
@@ -56,6 +56,29 @@ public class PieChartTests
     }
 #endif
 
+#if AVALONIA_UI_TESTING
+    // Regression for https://github.com/Live-Charts/LiveCharts2/issues/2008
+    //
+    // When XAML inside an Avalonia ControlTemplate sets a XamlGaugeSeries property
+    // to a value equal to its DP default (e.g. CornerRadius="0"), Avalonia skips
+    // OnPropertyChanged. Without the EndInit sync, MapChangeToBaseType never fires
+    // and _userSets stays empty, so the gauge theme rule (CornerRadius=8) silently
+    // overrides the user's explicit 0.
+
+    [AppTestMethod]
+    public async Task GaugeSeriesRespectsXamlCornerRadiusZero_Issue2008()
+    {
+        var sut = await App.NavigateTo<Samples.VisualTest.Issue2008Repro.View>();
+
+        // wait for the templated control to instantiate and the chart to measure.
+        await Task.Delay(1500);
+
+        var series = sut.FindTemplatedGaugeSeries();
+        Xunit.Assert.NotNull(series);
+        Xunit.Assert.Equal(0d, series!.CornerRadius);
+    }
+#endif
+
 #if (WPF_UI_TESTING && TEST_HA_VIEWS) || MAUI_UI_TESTING || WINUI_UI_TESTING || (UNO_UI_TESTING && HAS_OS_LVC)
     // native platforms where gpu is supported
 


### PR DESCRIPTION
## Summary

- Closes #2008 (the lingering CornerRadius concern; the original `GaugeValue` TemplateBinding bug was already fixed in main per [issue commenter](https://github.com/Live-Charts/LiveCharts2/issues/2008#issuecomment-2756651212))
- Adds an `EndInit()` override on the Avalonia `XamlGaugeSeries` that walks registered DPs and syncs any user-set property to the wrapped `CorePieSeries` so `_userSets` blocks subsequent theme overrides
- Adds a Factos regression test (`avalonia-desktop`) that templates a `Gauge` `TemplatedControl` with `<lvc:XamlGaugeSeries CornerRadius="0" GaugeValue="{TemplateBinding Value}" />` and asserts the templated series's `CornerRadius` ends up at 0, not 8

## Why

Avalonia skips `OnPropertyChanged` when `SetValue` assigns a value equal to the DP default. `XamlGaugeSeries` maps wrapped-property writes from `OnPropertyChanged`, so when XAML writes `CornerRadius="0"` (DP default = 0):

1. The shared `CorePieSeries.CornerRadius` setter never runs ⇒ `_userSets["CornerRadius"]` never gets recorded.
2. On first chart measure the theme rule (`HasRuleForGaugeSeries: gaugeSeries.CornerRadius = 8`) fires with `_isInternalSet = true`, sees no entry in `_userSets`, and overwrites 0 → 8.
3. The user's gauge renders rounded; toggling the value via code (any non-zero, then back to 0) fires real `OnPropertyChanged` events that finally push the value through, which is the workaround the issue commenter described.

`OnInitialized` would normally be the right hook, but series controls aren't rooted in the visual tree (they're collected by `PieChart.Series`, not added to `Children`), so `OnInitialized` never fires for them. `EndInit` does — the XAML parser calls it on every `ISupportInitialize` after applying values. Walking the DP registry with `IsSet()` lets us sync only properties the user actually wrote, leaving unspecified properties at their `Default` source so theme defaults still apply.

## Test plan

- [x] Build `samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop` and visually verify both gauges in `VisualTest/Issue2008Repro` render flat endcaps
- [x] Run the avalonia-desktop Factos suite: 15/15 pass with the fix
- [x] Revert the `EndInit` override and re-run: only the new test fails (`Actual: 8 / Expected: 0`) — confirms the test is gated on the fix
- [ ] Re-run the cross-platform Factos suite via CI to confirm no regressions on WPF/MAUI/WinUI/Uno (no code changes there, but the source-gen path is shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)