### PR TITLE
feat: LVC_SAMPLE auto-nav + repro-and-fix skill

### DIFF
--- a/.claude/scripts/capture-window-linux.sh
+++ b/.claude/scripts/capture-window-linux.sh
@@ -62,8 +62,10 @@ if [[ -z "$is_wayland" ]] && command -v xdotool >/dev/null && command -v import 
     exit 0
 fi
 
-if [[ -n "$is_wayland" ]] && command -v swaymsg >/dev/null && command -v grim >/dev/null; then
+if [[ -n "$is_wayland" ]] && command -v swaymsg >/dev/null && command -v grim >/dev/null && command -v jq >/dev/null; then
     # sway path: walk the tree, find the focused window matching the app_id.
+    # `jq` is required to query swaymsg JSON; if it's missing, fall through to
+    # gnome-screenshot (set -e would otherwise abort the whole script).
     deadline=$(( $(date +%s) + wait_seconds ))
     rect=""
     while [[ $(date +%s) -lt $deadline ]]; do

--- a/.claude/scripts/capture-window-linux.sh
+++ b/.claude/scripts/capture-window-linux.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Captures a top-level window of a running app to a PNG (Linux).
+#
+# Used by the repro-and-fix skill as a fallback when LVC_SCREENSHOT (in-app
+# RenderTargetBitmap) isn't available. Linux is fragmented across X11 and
+# Wayland with several compositors per session, so this script tries the
+# tools in priority order and uses the first one that's installed:
+#
+#   X11:     `xdotool` + `import` (ImageMagick)
+#   Wayland: `swaymsg` + `grim`   (sway)
+#            `gnome-screenshot`   (GNOME, captures focused window — needs
+#                                  the target window to be focused first)
+#
+# Usage:
+#   capture-window-linux.sh <ProcessName> <OutPath> [WaitSeconds]
+#
+# Example:
+#   capture-window-linux.sh AvaloniaSample.Desktop ./out.png
+#
+# If none of the supported tools are present, prints a hint with apt/dnf
+# install commands and exits 1. If your environment uses a different
+# compositor (Hyprland, KDE on Wayland, etc.) extend this script with the
+# matching capture command.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $(basename "$0") <ProcessName> <OutPath> [WaitSeconds]" >&2
+    exit 64
+fi
+
+proc_name="$1"
+out_path="$2"
+wait_seconds="${3:-10}"
+
+mkdir -p "$(dirname "$out_path")"
+
+is_wayland="${WAYLAND_DISPLAY:-}"
+
+if [[ -z "$is_wayland" ]] && command -v xdotool >/dev/null && command -v import >/dev/null; then
+    # X11 path: find a window owned by a process matching the name and capture it.
+    deadline=$(( $(date +%s) + wait_seconds ))
+    win=""
+    while [[ $(date +%s) -lt $deadline ]]; do
+        win=$(xdotool search --name "$proc_name" 2>/dev/null | head -1 || true)
+        if [[ -z "$win" ]]; then
+            # fall back to searching by class — many .NET apps don't set a
+            # window title that matches the process name.
+            win=$(xdotool search --class "$proc_name" 2>/dev/null | head -1 || true)
+        fi
+        if [[ -n "$win" ]]; then break; fi
+        sleep 0.25
+    done
+
+    if [[ -z "$win" ]]; then
+        echo "no X11 window matching '$proc_name' within ${wait_seconds}s" >&2
+        exit 1
+    fi
+
+    import -window "$win" "$out_path"
+    echo "captured X11 window $win of '$proc_name' to $out_path"
+    exit 0
+fi
+
+if [[ -n "$is_wayland" ]] && command -v swaymsg >/dev/null && command -v grim >/dev/null; then
+    # sway path: walk the tree, find the focused window matching the app_id.
+    deadline=$(( $(date +%s) + wait_seconds ))
+    rect=""
+    while [[ $(date +%s) -lt $deadline ]]; do
+        rect=$(swaymsg -t get_tree |
+            jq -r --arg name "$proc_name" \
+                '.. | objects | select(.app_id != null and (.app_id | contains($name))) |
+                "\(.rect.x),\(.rect.y) \(.rect.width)x\(.rect.height)"' |
+            head -1 || true)
+        if [[ -n "$rect" ]]; then break; fi
+        sleep 0.25
+    done
+
+    if [[ -z "$rect" ]]; then
+        echo "no sway window matching '$proc_name' within ${wait_seconds}s" >&2
+        exit 1
+    fi
+
+    grim -g "$rect" "$out_path"
+    echo "captured sway window of '$proc_name' to $out_path"
+    exit 0
+fi
+
+if command -v gnome-screenshot >/dev/null; then
+    echo "WARNING: falling back to gnome-screenshot --window — focus the target window manually" >&2
+    sleep "$wait_seconds"
+    gnome-screenshot --window --file="$out_path"
+    echo "captured focused window to $out_path"
+    exit 0
+fi
+
+cat >&2 <<EOF
+no supported screenshot tool found. install one of:
+  X11:     sudo apt install xdotool imagemagick
+  sway:    sudo apt install grim jq                       (jq required for tree query)
+  GNOME:   sudo apt install gnome-screenshot              (manual focus)
+EOF
+exit 1

--- a/.claude/scripts/capture-window-macos.sh
+++ b/.claude/scripts/capture-window-macos.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Captures a top-level window of a running app to a PNG (macOS).
+#
+# Used by the repro-and-fix skill as a fallback when LVC_SCREENSHOT (in-app
+# RenderTargetBitmap) isn't available — primarily for MAUI and Uno on macOS,
+# where the framework lacks a unified render-to-bitmap surface.
+#
+# Window selection is by process name (the same name shown in Activity
+# Monitor), looked up via System Events / osascript. The frontmost window of
+# the matching process is captured. If multiple windows are open, focus the
+# right one before running the script.
+#
+# Usage:
+#   capture-window-macos.sh <ProcessName> <OutPath> [WaitSeconds]
+#
+# Example:
+#   capture-window-macos.sh MauiSample ./.claude/screenshots/before.png
+#   capture-window-macos.sh "AvaloniaSample.Desktop" ./out.png 20
+#
+# Requires: macOS (uses `screencapture` and `osascript`, both shipped with
+# the OS). Will fail if the process isn't running or has no visible window
+# within the wait timeout.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $(basename "$0") <ProcessName> <OutPath> [WaitSeconds]" >&2
+    exit 64
+fi
+
+proc_name="$1"
+out_path="$2"
+wait_seconds="${3:-10}"
+
+mkdir -p "$(dirname "$out_path")"
+
+# Poll for the process' frontmost window ID. screencapture -l takes the
+# numeric window id, which we can fetch via System Events.
+deadline=$(( $(date +%s) + wait_seconds ))
+window_id=""
+while [[ $(date +%s) -lt $deadline ]]; do
+    set +e
+    window_id=$(osascript <<EOF 2>/dev/null
+tell application "System Events"
+    if exists application process "$proc_name" then
+        try
+            return id of front window of (first process whose name is "$proc_name")
+        end try
+    end if
+end tell
+EOF
+    )
+    set -e
+    if [[ -n "$window_id" && "$window_id" != "missing value" ]]; then
+        break
+    fi
+    sleep 0.25
+done
+
+if [[ -z "$window_id" || "$window_id" == "missing value" ]]; then
+    echo "no visible window for process '$proc_name' within ${wait_seconds}s" >&2
+    exit 1
+fi
+
+# -o omits the drop-shadow; -t png is explicit format; -l takes the window id.
+screencapture -o -t png -l "$window_id" "$out_path"
+echo "captured window $window_id of '$proc_name' to $out_path"

--- a/.claude/scripts/capture-window.ps1
+++ b/.claude/scripts/capture-window.ps1
@@ -1,7 +1,8 @@
 #requires -Version 5.1
 <#
 .SYNOPSIS
-    Captures the client area of a top-level window to a PNG.
+    Captures a top-level window (full window bounds, including non-client
+    chrome) to a PNG.
 
 .DESCRIPTION
     Used by the repro-and-fix skill to grab a snapshot of a running sample
@@ -89,7 +90,11 @@ function Resolve-WindowHandle {
     param([string]$Title, [string]$Process)
 
     if ($Title) {
-        $found = [IntPtr]::Zero
+        # The EnumWindows callback runs in the script scope, so use a single
+        # script-scoped slot to communicate the result. Reset on every call so
+        # we never return $null on a no-match or a stale handle from a prior
+        # invocation — the polling loop relies on Zero meaning "not yet".
+        $script:found = [IntPtr]::Zero
         $cb = [WinApi+EnumWindowsProc] {
             param($hWnd, $lParam)
             if (-not [WinApi]::IsWindowVisible($hWnd)) { return $true }

--- a/.claude/scripts/capture-window.ps1
+++ b/.claude/scripts/capture-window.ps1
@@ -1,0 +1,166 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Captures the client area of a top-level window to a PNG.
+
+.DESCRIPTION
+    Used by the repro-and-fix skill to grab a snapshot of a running sample
+    app (Avalonia/WPF/WinUI) so an agent can analyze the chart visually
+    without a human in the loop.
+
+    Window selection (in priority order):
+      1. -WindowTitle <substring>  — first window whose title contains the substring
+      2. -ProcessName <name>       — first MainWindow of a process matching the name
+                                    (e.g. AvaloniaSample.Desktop, WPFSample, WinUISample)
+
+    Captures the window's full bounds (including title bar) using PrintWindow,
+    which works even when the window is occluded or off-screen — important
+    because the agent may not have control over window stacking.
+
+.PARAMETER WindowTitle
+    Substring of the target window's title. Case-insensitive. First match wins.
+
+.PARAMETER ProcessName
+    Process name (without .exe). The MainWindowHandle of the first process
+    matching is used.
+
+.PARAMETER OutPath
+    Destination PNG path. Parent directory must exist.
+
+.PARAMETER WaitSeconds
+    Optional seconds to wait for the window to appear before failing. Default 10.
+
+.EXAMPLE
+    .\capture-window.ps1 -ProcessName AvaloniaSample.Desktop -OutPath .\repro.png
+
+.EXAMPLE
+    .\capture-window.ps1 -WindowTitle "AvaloniaSample" -OutPath .\repro.png -WaitSeconds 20
+#>
+[CmdletBinding(DefaultParameterSetName = 'ByProcess')]
+param(
+    [Parameter(ParameterSetName = 'ByTitle',   Mandatory)] [string] $WindowTitle,
+    [Parameter(ParameterSetName = 'ByProcess', Mandatory)] [string] $ProcessName,
+    [Parameter(Mandatory)] [string] $OutPath,
+    [int] $WaitSeconds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+
+# PrintWindow + GetWindowRect are the right primitives — they work for occluded
+# or background windows, which CopyFromScreen cannot.
+$signature = @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class WinApi
+{
+    [DllImport("user32.dll")]
+    public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left, Top, Right, Bottom; }
+
+    [DllImport("user32.dll")]
+    public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll")]
+    public static extern bool IsWindowVisible(IntPtr hWnd);
+
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowTextLength(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern int GetWindowText(IntPtr hWnd, System.Text.StringBuilder lpString, int nMaxCount);
+}
+'@
+if (-not ([System.Management.Automation.PSTypeName]'WinApi').Type) {
+    Add-Type -TypeDefinition $signature -Language CSharp
+}
+
+function Resolve-WindowHandle {
+    param([string]$Title, [string]$Process)
+
+    if ($Title) {
+        $found = [IntPtr]::Zero
+        $cb = [WinApi+EnumWindowsProc] {
+            param($hWnd, $lParam)
+            if (-not [WinApi]::IsWindowVisible($hWnd)) { return $true }
+            $len = [WinApi]::GetWindowTextLength($hWnd)
+            if ($len -le 0) { return $true }
+            $sb = New-Object System.Text.StringBuilder ($len + 1)
+            [void][WinApi]::GetWindowText($hWnd, $sb, $sb.Capacity)
+            if ($sb.ToString() -like "*$Title*") {
+                $script:found = $hWnd
+                return $false
+            }
+            return $true
+        }
+        [void][WinApi]::EnumWindows($cb, [IntPtr]::Zero)
+        return $script:found
+    }
+
+    if ($Process) {
+        $p = Get-Process -Name $Process -ErrorAction SilentlyContinue |
+             Where-Object { $_.MainWindowHandle -ne 0 } |
+             Select-Object -First 1
+        if ($p) { return $p.MainWindowHandle }
+    }
+
+    return [IntPtr]::Zero
+}
+
+# poll until the window appears.
+$deadline = (Get-Date).AddSeconds($WaitSeconds)
+$hWnd = [IntPtr]::Zero
+while ((Get-Date) -lt $deadline) {
+    $hWnd = Resolve-WindowHandle -Title $WindowTitle -Process $ProcessName
+    if ($hWnd -ne [IntPtr]::Zero) { break }
+    Start-Sleep -Milliseconds 250
+}
+
+if ($hWnd -eq [IntPtr]::Zero) {
+    if ($WindowTitle) {
+        Write-Error "No visible window with title containing '$WindowTitle' found within $WaitSeconds s."
+    } else {
+        Write-Error "No visible window for process '$ProcessName' found within $WaitSeconds s."
+    }
+    exit 1
+}
+
+$rect = New-Object WinApi+RECT
+[void][WinApi]::GetWindowRect($hWnd, [ref]$rect)
+$w = $rect.Right - $rect.Left
+$h = $rect.Bottom - $rect.Top
+if ($w -le 0 -or $h -le 0) {
+    Write-Error "Window has zero dimensions ($w x $h); is it minimized?"
+    exit 1
+}
+
+$bmp = New-Object System.Drawing.Bitmap $w, $h
+$gfx = [System.Drawing.Graphics]::FromImage($bmp)
+$hdc = $gfx.GetHdc()
+try {
+    # PW_RENDERFULLCONTENT = 0x00000002 — needed for DirectComposition / WinUI
+    $ok = [WinApi]::PrintWindow($hWnd, $hdc, 0x2)
+    if (-not $ok) {
+        Write-Error "PrintWindow returned false for HWND $hWnd."
+        exit 1
+    }
+}
+finally {
+    $gfx.ReleaseHdc($hdc)
+    $gfx.Dispose()
+}
+
+$bmp.Save($OutPath, [System.Drawing.Imaging.ImageFormat]::Png)
+$bmp.Dispose()
+
+Write-Output "Captured $w x $h to $OutPath"

--- a/.claude/scripts/capture-window.ps1
+++ b/.claude/scripts/capture-window.ps1
@@ -165,6 +165,10 @@ finally {
     $gfx.Dispose()
 }
 
+$outDir = Split-Path -Parent $OutPath
+if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
 $bmp.Save($OutPath, [System.Drawing.Imaging.ImageFormat]::Png)
 $bmp.Dispose()
 

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -11,6 +11,11 @@ you build the repro, launch the sample at that repro automatically, verify the
 bug yourself (screenshot or logs), fix it, verify the fix, and commit. Don't
 ask the user for visual confirmations you can get yourself.
 
+> **Shared with Copilot Coding Agent.** `.github/copilot-instructions.md` links
+> here as the canonical issue → reproduce → fix → PR workflow. Edit this file
+> when changing the workflow; keep the Copilot doc as a thin pointer to avoid
+> drift.
+
 ## When this skill applies
 
 - "Let's work on https://github.com/Live-Charts/LiveCharts2/issues/N"

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: repro-and-fix
+description: Use when the user asks to investigate, reproduce, or fix a GitHub issue (e.g. "let's work on issue #1234", a github.com/Live-Charts/LiveCharts2/issues/N URL, or "reproduce and propose a fix"). Implements the LiveCharts workflow end-to-end — worktree, in-sample repro view, auto-launched sample, screenshot/log verification, diagnosis, fix, separate regression-test commit, and PR — with minimal user interaction.
+---
+
+# repro-and-fix
+
+A user pointed you at a GitHub issue and asked you to reproduce + fix it. Run
+the workflow below. The whole point is that the dev loop is *self-contained*:
+you build the repro, launch the sample at that repro automatically, verify the
+bug yourself (screenshot or logs), fix it, verify the fix, and commit. Don't
+ask the user for visual confirmations you can get yourself.
+
+## When this skill applies
+
+- "Let's work on https://github.com/Live-Charts/LiveCharts2/issues/N"
+- "Reproduce issue #N and propose a fix"
+- "Investigate this bug report: <URL>"
+- A user paste of an issue URL with no other instruction
+
+If the user is asking about *theory* ("why does the gauge use a doughnut
+geometry?") or a *non-issue* task (refactor, doc update, perf), this skill is
+not the right tool — fall back to general workflow.
+
+## Project conventions you must follow
+
+These are durable rules from `~/.claude/projects/.../memory/MEMORY.md`. Re-read
+the relevant memory file if uncertain — these are not optional:
+
+- **Worktree per issue.** Create `../LiveCharts2-fix-<issue>-<slug>` first
+  (`feedback_worktree_per_issue`). Don't work in the primary tree.
+- **One concept per commit.** Fix and regression test go in *separate* commits.
+  The regression-test commit must fail when the fix is reverted — verify this
+  before pushing (`feedback_commit_separation`).
+- **Snapshot tests for render-path changes.** If your fix touches paint, layout,
+  z-index, or draw order, run `tests/SnapshotTests/` before claiming done — unit
+  tests have missed catastrophic regressions
+  (`feedback_run_snapshots_for_render_changes`).
+- **Update docs when public API changes** in the same change set as a separate
+  commit (`feedback_update_docs_for_api`).
+- Released version is **2.0.0** — never tell reporters "rc6 is latest" in
+  user-facing text (`project_current_version`).
+
+## Workflow
+
+### 1. Read the issue and decide if it still reproduces
+
+```bash
+gh issue view <N> --repo Live-Charts/LiveCharts2 --json title,body,labels,state,comments
+```
+
+Pay attention to **comments**, not just the body. Issues commonly evolve:
+
+- The original symptom may already be fixed in main (commenter says "newer
+  releases fixed this") and the *current* bug is a downstream observation.
+  This is exactly what happened with #2008 — the `GaugeValue` TemplateBinding
+  bug in the title was already resolved; the live bug was a `CornerRadius=0`
+  override in the comments.
+- Multiple users may report different things in the same thread. Identify the
+  most recent reporter's actual symptom.
+
+If you suspect the title bug is already fixed: build the original repro
+verbatim and verify *first*, before doing diagnosis. Cite the commenter who
+said it's fixed in your PR description.
+
+### 2. Set up the worktree
+
+```bash
+git worktree add ../LiveCharts2-fix-<issue>-<short-slug> -b fix/issue-<N>-<short-slug>
+```
+
+All edits, builds, and runs happen in the worktree. The primary tree stays
+clean for other work.
+
+### 3. Build the repro view (XAML platforms)
+
+The repro convention is a **sample view inside the platform sample app**:
+
+```
+samples/AvaloniaSample/VisualTest/Issue<N>Repro/View.axaml
+samples/AvaloniaSample/VisualTest/Issue<N>Repro/View.axaml.cs
+```
+
+Match the issue's repro setup as closely as you can — same `ControlTemplate`
+shape, same property values, same paints. *Don't simplify* until you've
+confirmed the bug fires; over-minimization can accidentally avoid the trigger.
+
+Existing repros to use as templates:
+
+- `samples/AvaloniaSample/VisualTest/Issue1986Repro/` — TabControl + ScrollViewer
+- `samples/AvaloniaSample/VisualTest/Issue1417Repro/` — GeoMap reattach
+- `samples/AvaloniaSample/VisualTest/Issue2008Repro/` — Gauge ControlTemplate
+
+The View's code-behind should expose helpers that a Factos test can call
+(e.g. `FindTemplatedGaugeSeries()`). This is how the regression test hooks in
+without going through the visual tree.
+
+Add the new path to the sample selector:
+
+```csharp
+// samples/ViewModelsSamples/Index.cs
+"VisualTest/Issue<N>Repro",
+```
+
+### 4. Auto-launch the sample at your repro
+
+The platform sample apps read `LVC_SAMPLE` from the environment and load that
+sample on startup. Set it before launching:
+
+```bash
+LVC_SAMPLE=VisualTest/Issue<N>Repro \
+  ./samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/bin/Debug/net10.0/AvaloniaSample.Desktop.exe
+```
+
+Or for cross-platform:
+
+```bash
+# WPF
+$env:LVC_SAMPLE = "VisualTest/Issue<N>Repro"
+./samples/WPFSample/bin/Debug/net10.0-windows/WPFSample.exe
+
+# WinUI / MAUI / Uno: same pattern, env var set before launch
+```
+
+Build first if needed: `dotnet build samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop -c Debug`.
+
+### 5. Verify the bug yourself
+
+Two paths — pick based on the bug type:
+
+**A. Screenshot for visual bugs** (color, shape, position, rendering artifacts):
+
+```powershell
+# Run the app in background first (ensure it's the only AvaloniaSample.Desktop instance)
+.\.claude\scripts\capture-window.ps1 `
+    -ProcessName AvaloniaSample.Desktop `
+    -OutPath .\.claude\screenshots\<issue>-before.png `
+    -WaitSeconds 15
+```
+
+Then `Read` the PNG. You're multimodal — describe what you see, compare to a
+control sample (often `Pies/Gauge1` or `General/FirstChart` for "what should
+this look like"). If the bug is subtle (a few pixels), make the repro larger
+(`Width=380`, `Height=380`) so it's clearly visible.
+
+**B. Console logs for state/dataflow bugs** (binding doesn't fire, value
+doesn't propagate, event order is wrong):
+
+Add temporary `Console.WriteLine` calls along the suspected path:
+
+```csharp
+Console.WriteLine($"[issue<N>] OnPropertyChanged: {change.Property.Name} old={change.OldValue} new={change.NewValue}");
+```
+
+The platform sample writes to stdout when launched from the terminal. Run via
+the bash tool with `run_in_background=true`, wait for the user to navigate (or
+your env var to land you on the repro), kill the app, then `grep` the
+captured output file. **Remove the diagnostics before committing.**
+
+If neither approach decisively confirms the bug, escalate to the user:
+
+> "I can see X, but I'm not certain whether that matches the symptom you're
+> reporting. Can you confirm <specific question>?"
+
+Don't loop screenshot questions on the user — capture once, analyze, then
+proceed.
+
+### 6. Diagnose the root cause
+
+Trace from symptom backward through the rendering/data pipeline. Cross-check
+against `MEMORY.md` — many bugs in this repo have related ancestors
+(z-index issues, theme overrides, motion-property defaults, source-gen
+behavior). If you find a matching memory note, use its diagnosis as a starting
+point but verify against current code; memories go stale.
+
+Common gotchas in this codebase:
+
+- **Theme overrides user-set values** when the user's value equals the DP
+  default — Avalonia skips `OnPropertyChanged` and `_userSets` never gets
+  populated. `XamlGaugeSeries.EndInit` syncs IsSet DPs as a remediation; if
+  you see this pattern in another wrapper, the same fix shape applies.
+- **Series controls aren't in the visual tree.** `OnInitialized` and
+  `TemplatedParent` may not fire/be set the way you'd expect. Use `EndInit`
+  instead.
+- **Theme rules run from the chart engine measure pass**, not at construction.
+  `_isInternalSet` + `_userSets` is the existing precedence mechanism — don't
+  reinvent it.
+- **Motion properties animate from a stale "from" value.** A value flip from
+  N→0 may render N for one frame.
+
+### 7. Apply the fix
+
+Smallest possible change. Don't refactor surrounding code. Don't add
+comments unless the WHY is non-obvious — but if the bug is a subtle
+interaction (Avalonia behavior, theme precedence, source-gen quirk), a comment
+explaining *why this fix is necessary* is warranted because future readers
+won't reconstruct it from memory.
+
+### 8. Verify the fix
+
+Re-run step 5 with the fix in place. Capture an "after" screenshot at the
+same path:
+
+```powershell
+.\.claude\scripts\capture-window.ps1 `
+    -ProcessName AvaloniaSample.Desktop `
+    -OutPath .\.claude\screenshots\<issue>-after.png
+```
+
+Read both images and confirm the symptom is gone. Don't claim the fix works
+without comparing.
+
+### 9. Write the regression test
+
+Test choice depends on the bug nature:
+
+- **Programmatic state assertion** (the bug is in state propagation, not
+  pixels): Factos test in `tests/SharedUITests/`. Navigate to the repro,
+  query a helper method on the View that exposes the state under test,
+  assert. Gate by `#if AVALONIA_UI_TESTING` if Avalonia-specific (most
+  XAML-platform-quirk bugs are).
+- **Pixel-perfect rendering**: snapshot test in `tests/SnapshotTests/`.
+- **Pure C# logic** (chart engine, motion, math): MSTest in
+  `tests/CoreTests/`.
+
+**Verify the test fails without the fix.** Comment out your fix, rebuild,
+re-run the test. Expect it to fail with a meaningful error. Restore the fix
+before committing.
+
+To run a single Factos UI test:
+
+```bash
+# In tests/UITests/Program.cs, set: var appToRun = "avalonia-desktop";
+dotnet build tests/UITests/UITests.csproj -c Debug
+cd tests/UITests/bin/Debug/net10.0 && dotnet UITests.dll
+# Revert the appToRun change before committing — it's a local dev-loop tweak.
+```
+
+### 10. Commit and PR
+
+Two commits, in this order:
+
+1. `fix(<scope>): <one-line summary> (#<N>)` — only the fix.
+2. `test(<scope>): regression for <symptom> (#<N>)` — only the test +
+   repro view + index entry.
+
+Commit message style follows recent history (`git log --oneline -10`).
+Body: imperative, mention the root-cause mechanism, why the test catches it.
+End with the standard `Co-Authored-By` line.
+
+Push and open the PR with `gh pr create`. The PR body should include:
+
+- **Summary** bullet list (what changed, what it closes)
+- **Why** section (root cause walkthrough — the most valuable part)
+- **Test plan** checklist with what you actually verified locally
+
+### 11. Update memory
+
+After the PR is open, write a `project_issue_<N>.md` memory and add a one-line
+entry to `MEMORY.md`. Capture: **what was non-obvious** about the bug, what
+diagnosis steps led to the fix, and what conventions/files the next person
+needs. Don't re-document the code — just the insights.
+
+## Anti-patterns to avoid
+
+- **Asking the user "is the bug visible now?" repeatedly.** Capture a
+  screenshot or read logs. If you can't decide from one capture + one
+  question, you haven't framed the question precisely enough.
+- **Simplifying the repro before confirming.** A "minimal" repro that doesn't
+  trigger the bug is worse than a verbose one that does.
+- **Skipping the test-fails-without-fix verification.** A passing test that
+  also passes when reverted proves nothing.
+- **Mixing fix + test + cleanup in one commit.** Project policy is strict
+  here — every fix needs a separately revertible test commit.
+- **Force-pushing for "cleanliness".** Never. Stack new commits.
+- **Trusting memory over code.** Memory files name specific functions and
+  files; verify they still exist before recommending — projects refactor.
+
+## Tooling reference
+
+- Issue triage: `gh issue view <N> --repo Live-Charts/LiveCharts2`
+- Screenshot: `.claude/scripts/capture-window.ps1` (Windows; `-ProcessName`
+  or `-WindowTitle`, `-OutPath`)
+- Auto-launch sample: `LVC_SAMPLE=<path>` env var, supported by Avalonia,
+  WPF, WinUI, MAUI, Uno
+- Factos UI tests: `tests/UITests/`, set `appToRun` in `Program.cs` for
+  local runs
+- Build per-platform: `LiveCharts.<Platform>.slnx` solutions

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -22,6 +22,22 @@ If the user is asking about *theory* ("why does the gauge use a doughnut
 geometry?") or a *non-issue* task (refactor, doc update, perf), this skill is
 not the right tool — fall back to general workflow.
 
+## Pick the platform that matches the issue
+
+Read the issue's **labels** and **repro snippet** to choose. The workflow is
+the same on every XAML platform — only paths and launch commands change.
+
+| Platform | Sample dir                    | Launch project (Debug build)                                                | In-app screenshot |
+| -------- | ----------------------------- | --------------------------------------------------------------------------- | ----------------- |
+| Avalonia | `samples/AvaloniaSample/`     | `samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/.../*.Desktop.exe` | ✅ supported       |
+| WPF      | `samples/WPFSample/`          | `samples/WPFSample/.../WPFSample.exe`                                       | ✅ supported       |
+| WinUI    | `samples/WinUISample/WinUISample/` | `samples/WinUISample/WinUISample/.../WinUISample.exe`                  | ✅ supported       |
+| MAUI     | `samples/MauiSample/`         | per-platform; `dotnet build -t:Run -f net10.0-windows10.0.19041.0`          | ❌ use OS tool     |
+| Uno      | `samples/UnoPlatformSample/UnoPlatformSample/` | per-platform                                              | ❌ use OS tool     |
+
+If the issue is platform-agnostic (a core engine bug), prefer Avalonia for the
+fastest dev loop on Windows (no WindowsAppSDK / packaged-build overhead).
+
 ## Project conventions you must follow
 
 These are durable rules from `~/.claude/projects/.../memory/MEMORY.md`. Re-read
@@ -77,15 +93,15 @@ clean for other work.
 The repro convention is a **sample view inside the platform sample app**:
 
 ```
-samples/AvaloniaSample/VisualTest/Issue<N>Repro/View.axaml
-samples/AvaloniaSample/VisualTest/Issue<N>Repro/View.axaml.cs
+samples/<Platform>Sample/VisualTest/Issue<N>Repro/View.<axaml|xaml>
+samples/<Platform>Sample/VisualTest/Issue<N>Repro/View.<axaml|xaml>.cs
 ```
 
 Match the issue's repro setup as closely as you can — same `ControlTemplate`
 shape, same property values, same paints. *Don't simplify* until you've
 confirmed the bug fires; over-minimization can accidentally avoid the trigger.
 
-Existing repros to use as templates:
+Existing repros to mirror:
 
 - `samples/AvaloniaSample/VisualTest/Issue1986Repro/` — TabControl + ScrollViewer
 - `samples/AvaloniaSample/VisualTest/Issue1417Repro/` — GeoMap reattach
@@ -104,44 +120,56 @@ Add the new path to the sample selector:
 
 ### 4. Auto-launch the sample at your repro
 
-The platform sample apps read `LVC_SAMPLE` from the environment and load that
-sample on startup. Set it before launching:
+All XAML platform samples read `LVC_SAMPLE` at startup and load that sample
+instead of the default landing screen. Set it before launching:
 
 ```bash
+# bash / WSL
 LVC_SAMPLE=VisualTest/Issue<N>Repro \
   ./samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/bin/Debug/net10.0/AvaloniaSample.Desktop.exe
 ```
 
-Or for cross-platform:
-
-```bash
-# WPF
+```powershell
+# PowerShell
 $env:LVC_SAMPLE = "VisualTest/Issue<N>Repro"
-./samples/WPFSample/bin/Debug/net10.0-windows/WPFSample.exe
-
-# WinUI / MAUI / Uno: same pattern, env var set before launch
+.\samples\WPFSample\bin\Debug\net10.0-windows\WPFSample.exe
 ```
 
-Build first if needed: `dotnet build samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop -c Debug`.
+Build first if needed: `dotnet build samples/<Platform>Sample/... -c Debug`.
 
 ### 5. Verify the bug yourself
 
 Two paths — pick based on the bug type:
 
-**A. Screenshot for visual bugs** (color, shape, position, rendering artifacts):
+**A. In-app screenshot for visual bugs** (color, shape, position, rendering
+artifacts). All XAML platform samples support `LVC_SCREENSHOT`: when set, the
+sample renders its main window via the framework's native `RenderTargetBitmap`
+~2 s after open and exits. No external tooling, no DPI-scaling surprises, and
+no race against the screenshot tool launching too early:
 
-```powershell
-# Run the app in background first (ensure it's the only AvaloniaSample.Desktop instance)
-.\.claude\scripts\capture-window.ps1 `
-    -ProcessName AvaloniaSample.Desktop `
-    -OutPath .\.claude\screenshots\<issue>-before.png `
-    -WaitSeconds 15
+```bash
+LVC_SAMPLE=VisualTest/Issue<N>Repro \
+LVC_SCREENSHOT=$(pwd)/.claude/screenshots/<N>-before.png \
+  ./samples/AvaloniaSample/Platforms/AvaloniaSample.Desktop/bin/Debug/net10.0/AvaloniaSample.Desktop.exe
 ```
 
-Then `Read` the PNG. You're multimodal — describe what you see, compare to a
-control sample (often `Pies/Gauge1` or `General/FirstChart` for "what should
-this look like"). If the bug is subtle (a few pixels), make the repro larger
-(`Width=380`, `Height=380`) so it's clearly visible.
+```powershell
+# PowerShell
+$env:LVC_SAMPLE = "VisualTest/Issue<N>Repro"
+$env:LVC_SCREENSHOT = "$pwd\.claude\screenshots\<N>-before.png"
+.\samples\WPFSample\bin\Debug\net10.0-windows\WPFSample.exe
+```
+
+After it exits, `Read` the PNG. You're multimodal — describe what you see,
+compare to a control sample (often `Pies/Gauge1` or `General/FirstChart` for
+"what should this look like"). If the bug is subtle (a few pixels), make the
+repro larger (`Width=380`, `Height=380`) so it's clearly visible.
+
+**Fallback for MAUI/Uno or other-OS edge cases:** the Windows-only PrintWindow
+helper at `.claude/scripts/capture-window.ps1` captures any visible top-level
+window. macOS users can substitute `screencapture -l <window-id>`. Linux users
+have `grim` (Wayland) or `import` (ImageMagick on X11). Use these only when
+`LVC_SCREENSHOT` isn't supported on the target platform.
 
 **B. Console logs for state/dataflow bugs** (binding doesn't fire, value
 doesn't propagate, event order is wrong):
@@ -153,17 +181,16 @@ Console.WriteLine($"[issue<N>] OnPropertyChanged: {change.Property.Name} old={ch
 ```
 
 The platform sample writes to stdout when launched from the terminal. Run via
-the bash tool with `run_in_background=true`, wait for the user to navigate (or
-your env var to land you on the repro), kill the app, then `grep` the
-captured output file. **Remove the diagnostics before committing.**
+the bash tool with `run_in_background=true` (no `LVC_SCREENSHOT` so the app
+stays open), wait a few seconds, kill the app, then `grep` the captured output
+file. **Remove the diagnostics before committing.**
 
-If neither approach decisively confirms the bug, escalate to the user:
+If neither approach decisively confirms the bug, escalate to the user with
+**one** well-framed question, not a chain of polling questions. Example:
 
-> "I can see X, but I'm not certain whether that matches the symptom you're
-> reporting. Can you confirm <specific question>?"
-
-Don't loop screenshot questions on the user — capture once, analyze, then
-proceed.
+> "The before-fix capture shows the gauge endcaps as flat, contrary to the
+> issue's screenshot. Did you toggle CornerRadius after the screenshot was
+> taken in the original report?"
 
 ### 6. Diagnose the root cause
 
@@ -198,17 +225,16 @@ won't reconstruct it from memory.
 
 ### 8. Verify the fix
 
-Re-run step 5 with the fix in place. Capture an "after" screenshot at the
-same path:
+Re-run step 5 with the fix in place. Capture an "after" screenshot at a
+sibling path and compare:
 
-```powershell
-.\.claude\scripts\capture-window.ps1 `
-    -ProcessName AvaloniaSample.Desktop `
-    -OutPath .\.claude\screenshots\<issue>-after.png
+```bash
+LVC_SAMPLE=VisualTest/Issue<N>Repro \
+LVC_SCREENSHOT=$(pwd)/.claude/screenshots/<N>-after.png \
+  ./samples/<Platform>Sample/.../<Platform>Sample.exe
 ```
 
-Read both images and confirm the symptom is gone. Don't claim the fix works
-without comparing.
+`Read` both images. Don't claim the fix works without comparing.
 
 ### 9. Write the regression test
 
@@ -217,7 +243,7 @@ Test choice depends on the bug nature:
 - **Programmatic state assertion** (the bug is in state propagation, not
   pixels): Factos test in `tests/SharedUITests/`. Navigate to the repro,
   query a helper method on the View that exposes the state under test,
-  assert. Gate by `#if AVALONIA_UI_TESTING` if Avalonia-specific (most
+  assert. Gate by `#if <PLATFORM>_UI_TESTING` if platform-specific (most
   XAML-platform-quirk bugs are).
 - **Pixel-perfect rendering**: snapshot test in `tests/SnapshotTests/`.
 - **Pure C# logic** (chart engine, motion, math): MSTest in
@@ -230,7 +256,8 @@ before committing.
 To run a single Factos UI test:
 
 ```bash
-# In tests/UITests/Program.cs, set: var appToRun = "avalonia-desktop";
+# In tests/UITests/Program.cs, set: var appToRun = "<platform>-desktop"
+# (avalonia-desktop / wpf-net10 / winui / maui / uno).
 dotnet build tests/UITests/UITests.csproj -c Debug
 cd tests/UITests/bin/Debug/net10.0 && dotnet UITests.dll
 # Revert the appToRun change before committing — it's a local dev-loop tweak.
@@ -279,10 +306,19 @@ needs. Don't re-document the code — just the insights.
 ## Tooling reference
 
 - Issue triage: `gh issue view <N> --repo Live-Charts/LiveCharts2`
-- Screenshot: `.claude/scripts/capture-window.ps1` (Windows; `-ProcessName`
-  or `-WindowTitle`, `-OutPath`)
-- Auto-launch sample: `LVC_SAMPLE=<path>` env var, supported by Avalonia,
-  WPF, WinUI, MAUI, Uno
+- **Auto-launch sample**: `LVC_SAMPLE=<path>` env var (Avalonia, WPF, WinUI,
+  MAUI, Uno).
+- **In-app screenshot**: `LVC_SCREENSHOT=<path>` env var (Avalonia, WPF,
+  WinUI). Sample renders to PNG ~2 s after open and exits.
+- **External screenshot fallback** (Windows): `.claude/scripts/capture-window.ps1`
+  with `-ProcessName <name>` or `-WindowTitle <substring>`, `-OutPath <png>`.
+  Uses `PrintWindow`, so it works on occluded windows.
+- **macOS screenshot**: `screencapture -l $(/usr/sbin/screencapture -l? lookup
+  by app)`; or use `osascript` to bring window to front first then
+  `screencapture -o -t png -R<x,y,w,h> path`. Document the exact incantation
+  in a per-OS memory if you discover one that works reliably.
+- **Linux screenshot**: `grim -g "$(slurp)" out.png` (Wayland) or
+  `import -window <id> out.png` (X11).
 - Factos UI tests: `tests/UITests/`, set `appToRun` in `Program.cs` for
-  local runs
-- Build per-platform: `LiveCharts.<Platform>.slnx` solutions
+  local runs.
+- Build per-platform: `LiveCharts.<Platform>.slnx` solutions.

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -145,8 +145,11 @@ Two paths — pick based on the bug type:
 artifacts). Avalonia/WPF/WinUI samples support `LVC_SCREENSHOT`: when set,
 the sample renders its main window via the framework's native
 `RenderTargetBitmap` after a short delay (default 3 s, override with
-`LVC_SCREENSHOT_DELAY_MS`) and exits. No external tooling, no DPI-scaling
-surprises, no race against the screenshot tool launching too early:
+`LVC_SCREENSHOT_DELAY_MS`) and exits. No external tooling, no race against
+a screenshot tool launching too early. The capture is scaled to the
+window's physical pixels (`RenderScaling` on Avalonia,
+`VisualTreeHelper.GetDpi` on WPF) so HiDPI displays produce a sharp PNG
+that matches what's on screen:
 
 ```bash
 LVC_SAMPLE=VisualTest/Issue<N>Repro \

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -38,7 +38,7 @@ the relevant memory file if uncertain — these are not optional:
   (`feedback_run_snapshots_for_render_changes`).
 - **Update docs when public API changes** in the same change set as a separate
   commit (`feedback_update_docs_for_api`).
-- Released version is **2.0.0** — never tell reporters "rc6 is latest" in
+- Check `Directory.Build.props` for `<LiveChartsVersion>` and use that value in
   user-facing text (`project_current_version`).
 
 ## Workflow

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -142,10 +142,11 @@ Build first if needed: `dotnet build samples/<Platform>Sample/... -c Debug`.
 Two paths — pick based on the bug type:
 
 **A. In-app screenshot for visual bugs** (color, shape, position, rendering
-artifacts). All XAML platform samples support `LVC_SCREENSHOT`: when set, the
-sample renders its main window via the framework's native `RenderTargetBitmap`
-~2 s after open and exits. No external tooling, no DPI-scaling surprises, and
-no race against the screenshot tool launching too early:
+artifacts). Avalonia/WPF/WinUI samples support `LVC_SCREENSHOT`: when set,
+the sample renders its main window via the framework's native
+`RenderTargetBitmap` after a short delay (default 3 s, override with
+`LVC_SCREENSHOT_DELAY_MS`) and exits. No external tooling, no DPI-scaling
+surprises, no race against the screenshot tool launching too early:
 
 ```bash
 LVC_SAMPLE=VisualTest/Issue<N>Repro \
@@ -165,11 +166,20 @@ compare to a control sample (often `Pies/Gauge1` or `General/FirstChart` for
 "what should this look like"). If the bug is subtle (a few pixels), make the
 repro larger (`Width=380`, `Height=380`) so it's clearly visible.
 
-**Fallback for MAUI/Uno or other-OS edge cases:** the Windows-only PrintWindow
-helper at `.claude/scripts/capture-window.ps1` captures any visible top-level
-window. macOS users can substitute `screencapture -l <window-id>`. Linux users
-have `grim` (Wayland) or `import` (ImageMagick on X11). Use these only when
-`LVC_SCREENSHOT` isn't supported on the target platform.
+**Fallback for MAUI/Uno or other-OS edge cases:** use the OS-appropriate
+helper script. They all take `<ProcessName> <OutPath> [WaitSeconds]` and
+poll for the target window before capturing:
+
+| OS      | Script                                       | Underlying tool                            |
+| ------- | -------------------------------------------- | ------------------------------------------ |
+| Windows | `.claude/scripts/capture-window.ps1`         | `PrintWindow` via Win32 (works occluded)   |
+| macOS   | `.claude/scripts/capture-window-macos.sh`    | `osascript` + `screencapture -l <id>`      |
+| Linux   | `.claude/scripts/capture-window-linux.sh`    | `xdotool`+`import` / `swaymsg`+`grim` / `gnome-screenshot` |
+
+The Linux script tries X11 → sway → GNOME in priority order; install the
+matching package if none are present (the script prints the apt/dnf hint).
+Use these only when `LVC_SCREENSHOT` isn't supported on the target platform
+(MAUI, Uno) — for Avalonia/WPF/WinUI prefer in-app capture.
 
 **B. Console logs for state/dataflow bugs** (binding doesn't fire, value
 doesn't propagate, event order is wrong):
@@ -309,16 +319,14 @@ needs. Don't re-document the code — just the insights.
 - **Auto-launch sample**: `LVC_SAMPLE=<path>` env var (Avalonia, WPF, WinUI,
   MAUI, Uno).
 - **In-app screenshot**: `LVC_SCREENSHOT=<path>` env var (Avalonia, WPF,
-  WinUI). Sample renders to PNG ~2 s after open and exits.
-- **External screenshot fallback** (Windows): `.claude/scripts/capture-window.ps1`
-  with `-ProcessName <name>` or `-WindowTitle <substring>`, `-OutPath <png>`.
-  Uses `PrintWindow`, so it works on occluded windows.
-- **macOS screenshot**: `screencapture -l $(/usr/sbin/screencapture -l? lookup
-  by app)`; or use `osascript` to bring window to front first then
-  `screencapture -o -t png -R<x,y,w,h> path`. Document the exact incantation
-  in a per-OS memory if you discover one that works reliably.
-- **Linux screenshot**: `grim -g "$(slurp)" out.png` (Wayland) or
-  `import -window <id> out.png` (X11).
+  WinUI). Sample renders to PNG after `LVC_SCREENSHOT_DELAY_MS` (default
+  3000) and exits.
+- **External screenshot fallback** — one script per OS, all take the same
+  `<ProcessName> <OutPath> [WaitSeconds]` shape:
+  - Windows: `.claude/scripts/capture-window.ps1` (also accepts
+    `-WindowTitle <substring>` instead of `-ProcessName`)
+  - macOS:   `.claude/scripts/capture-window-macos.sh`
+  - Linux:   `.claude/scripts/capture-window-linux.sh` (X11 / sway / GNOME)
 - Factos UI tests: `tests/UITests/`, set `appToRun` in `Program.cs` for
   local runs.
 - Build per-platform: `LiveCharts.<Platform>.slnx` solutions.

--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -105,7 +105,6 @@ Existing repros to mirror:
 
 - `samples/AvaloniaSample/VisualTest/Issue1986Repro/` — TabControl + ScrollViewer
 - `samples/AvaloniaSample/VisualTest/Issue1417Repro/` — GeoMap reattach
-- `samples/AvaloniaSample/VisualTest/Issue2008Repro/` — Gauge ControlTemplate
 
 The View's code-behind should expose helpers that a Factos test can call
 (e.g. `FindTemplatedGaugeSeries()`). This is how the regression test hooks in

--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,7 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Always use LF for shell scripts so they remain executable on macOS/Linux
+# even when checked out on Windows.
+*.sh text eol=lf

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -699,6 +699,24 @@ MSBuildArg isTest = new("IsTestBuild", "true");
 ### Problem: Generator errors
 **Solution**: Check `UseNuGetForGenerator` setting and ensure LiveChartsGenerators package/project is available
 
+## Issue Reproduction & Fix Workflow
+
+When picking up a GitHub issue (reproduce → diagnose → fix → regression test → PR),
+follow the canonical workflow at [`.claude/skills/repro-and-fix/SKILL.md`](../.claude/skills/repro-and-fix/SKILL.md).
+That doc is the single source of truth for both Claude Code and Copilot Coding Agent —
+keep edits there, not duplicated here.
+
+Quick reference for the dev-loop hooks the workflow relies on:
+
+- **`LVC_SAMPLE=<sample-path>`** — XAML samples (Avalonia / WPF / WinUI / MAUI / Uno) auto-navigate to the named sample on launch, e.g. `LVC_SAMPLE=VisualTest/Issue1986Repro`. Skips manual UI navigation for repros.
+- **`LVC_SCREENSHOT=<png-path>`** — Avalonia / WPF / WinUI samples render the main window to PNG via `RenderTargetBitmap` shortly after activation and exit. Captures scale to physical pixels on HiDPI.
+- **`LVC_SCREENSHOT_DELAY_MS=<ms>`** — overrides the 3 s default settle delay before the in-app screenshot is taken (use on slower CI hosts).
+- **`.claude/scripts/capture-window.{ps1,-macos.sh,-linux.sh}`** — per-OS PrintWindow / `screencapture` / `grim` fallbacks for platforms without an in-app capture path (MAUI, Uno).
+
+Repro views live under `samples/AvaloniaSample/VisualTest/Issue<N>Repro/` and are
+registered in `samples/ViewModelsSamples/Index.cs`. Their code-behind exposes
+helpers (e.g. `FindTemplatedGaugeSeries()`) that Factos UI tests call directly.
+
 ## Resources
 
 - **Main Documentation**: https://livecharts.dev

--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,5 @@ samples/XamarinSample/XamarinSample/XamarinSample.Android/XamarinSample.Android.
 samples/XamarinSample/XamarinSample/XamarinSample.Android/Resources/Resource.designer.cs
 nuget.exe
 /.claude/settings.local.json
+/.claude/screenshots/
+/.claude/worktrees/

--- a/samples/AvaloniaSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaSample/MainWindow.axaml.cs
@@ -1,5 +1,11 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 
 namespace AvaloniaSample;
 
@@ -8,6 +14,42 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        // Dev-loop hook: when LVC_SCREENSHOT is set, render the window to PNG
+        // shortly after open and exit. Lets agents/scripts capture the rendered
+        // sample without external screenshot tooling. Pair with LVC_SAMPLE to
+        // land on a specific repro view.
+        var screenshotPath = Environment.GetEnvironmentVariable("LVC_SCREENSHOT");
+        if (!string.IsNullOrWhiteSpace(screenshotPath))
+            Opened += async (_, _) => await CaptureAndExitAsync(screenshotPath);
+    }
+
+    private async Task CaptureAndExitAsync(string path)
+    {
+        // Allow the chart's measure + initial animation frames to settle before
+        // capture. 2s is conservative — sample animations are typically ~700 ms.
+        await Task.Delay(2000);
+
+        try
+        {
+            var size = new PixelSize(
+                Math.Max(1, (int)Bounds.Width),
+                Math.Max(1, (int)Bounds.Height));
+            var rtb = new RenderTargetBitmap(size);
+            rtb.Render(this);
+
+            var fullPath = Path.GetFullPath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            rtb.Save(fullPath);
+            Console.WriteLine($"[LVC_SCREENSHOT] saved {size.Width}x{size.Height} to {fullPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(Close);
     }
 
     private void InitializeComponent()

--- a/samples/AvaloniaSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaSample/MainWindow.axaml.cs
@@ -26,9 +26,12 @@ public partial class MainWindow : Window
 
     private async Task CaptureAndExitAsync(string path)
     {
-        // Allow the chart's measure + initial animation frames to settle before
-        // capture. 2s is conservative — sample animations are typically ~700 ms.
-        await Task.Delay(2000);
+        // Wait for the chart's measure + initial animation frames to settle.
+        // The default series animation is 800 ms; some samples kick off async
+        // data loads (~1 s) before animating. 3 s leaves a margin for both,
+        // overridable via LVC_SCREENSHOT_DELAY_MS for slower machines or
+        // longer-loading samples.
+        await Task.Delay(GetDelayMs());
 
         try
         {
@@ -50,6 +53,12 @@ public partial class MainWindow : Window
         }
 
         await Dispatcher.UIThread.InvokeAsync(Close);
+    }
+
+    private static int GetDelayMs()
+    {
+        var raw = Environment.GetEnvironmentVariable("LVC_SCREENSHOT_DELAY_MS");
+        return int.TryParse(raw, out var ms) && ms > 0 ? ms : 3000;
     }
 
     private void InitializeComponent()

--- a/samples/AvaloniaSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaSample/MainWindow.axaml.cs
@@ -35,10 +35,18 @@ public partial class MainWindow : Window
 
         try
         {
+            // Bounds is in DIPs; scale by RenderScaling so the captured PNG
+            // matches on-screen pixels on HiDPI displays. Pass the same DPI to
+            // RenderTargetBitmap so its rendering uses the correct sub-pixel
+            // grid instead of producing a stretched/blurry capture. Window
+            // inherits TopLevel.RenderScaling, which reflects the active
+            // platform impl's scale.
+            var scaling = RenderScaling > 0 ? RenderScaling : 1.0;
             var size = new PixelSize(
-                Math.Max(1, (int)Bounds.Width),
-                Math.Max(1, (int)Bounds.Height));
-            var rtb = new RenderTargetBitmap(size);
+                Math.Max(1, (int)(Bounds.Width * scaling)),
+                Math.Max(1, (int)(Bounds.Height * scaling)));
+            var dpi = new Vector(96 * scaling, 96 * scaling);
+            using var rtb = new RenderTargetBitmap(size, dpi);
             rtb.Render(this);
 
             var fullPath = Path.GetFullPath(path);

--- a/samples/AvaloniaSample/MainWindow.axaml.cs
+++ b/samples/AvaloniaSample/MainWindow.axaml.cs
@@ -54,7 +54,16 @@ public partial class MainWindow : Window
             rtb.Save(fullPath);
             Console.WriteLine($"[LVC_SCREENSHOT] saved {size.Width}x{size.Height} to {fullPath}");
         }
-        catch (Exception ex)
+        // Catch only the *expected* capture failure modes — file/path I/O,
+        // permission, invalid arguments, encoder state — and let truly
+        // unexpected exceptions (OOM, chart-engine bugs, etc.) propagate so
+        // CI sees a real stack trace instead of a quiet exit 1.
+        catch (Exception ex) when (
+            ex is IOException                  // also covers DirectoryNotFound, PathTooLong, FileNotFound
+            or UnauthorizedAccessException
+            or ArgumentException               // also covers ArgumentNullException
+            or NotSupportedException
+            or InvalidOperationException)
         {
             Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
             Environment.ExitCode = 1;

--- a/samples/AvaloniaSample/MainWindowViewModel.cs
+++ b/samples/AvaloniaSample/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace AvaloniaSample;
 
@@ -10,6 +11,13 @@ public class MainWindowViewModel : INotifyPropertyChanged
             ViewModelsSamples.Index.Samples,
             "VisualTest/Issue1986Repro"
         ];
+
+        // Dev-loop hook: LVC_SAMPLE selects an initial sample by path
+        // (e.g. LVC_SAMPLE=VisualTest/Issue1986Repro). Lets agents/scripts
+        // launch the app pointed at a specific repro without UI navigation.
+        var initial = Environment.GetEnvironmentVariable("LVC_SAMPLE");
+        if (!string.IsNullOrWhiteSpace(initial) && Array.IndexOf(Samples, initial) >= 0)
+            SelectedSample = initial;
     }
 
     public string[] Samples { get; set; }

--- a/samples/MauiSample/AppShell.xaml.cs
+++ b/samples/MauiSample/AppShell.xaml.cs
@@ -18,7 +18,15 @@ public partial class AppShell : Shell
 
         var samples = ViewModelsSamples.Index.Samples;
 
-        var i = 0;
+        // Dev-loop hook: LVC_SAMPLE selects an initial sample by path
+        // (e.g. LVC_SAMPLE=Bars/Basic). Lets agents/scripts launch the app
+        // pointed at a specific repro. Falls back to the first sample if
+        // the env var is unset or the path isn't in the index.
+        var initial = Environment.GetEnvironmentVariable("LVC_SAMPLE");
+        var initialIndex = string.IsNullOrWhiteSpace(initial)
+            ? 0
+            : Math.Max(0, Array.IndexOf(samples, initial));
+
         for (var i1 = 0; i1 < samples.Length; i1++)
         {
             var item = samples[i1];
@@ -34,7 +42,7 @@ public partial class AppShell : Shell
             {
                 content = new ShellContent()
                 {
-                    Content = i == 0 ? Activator.CreateInstance(t) : null
+                    Content = i1 == initialIndex ? Activator.CreateInstance(t) : null
                 };
             }
             catch (Exception)
@@ -46,10 +54,11 @@ public partial class AppShell : Shell
 
             Items.Add(shell_section);
             _routesSamples.Add("//" + content.Route, item);
-            i++;
 
             //if (i > 4) break;
         }
+
+        if (initialIndex > 0) CurrentItem = Items[initialIndex];
 
         Navigating += AppShell_Navigating;
     }

--- a/samples/UnoPlatformSample/UnoPlatformSample/Presentation/MainModel.cs
+++ b/samples/UnoPlatformSample/UnoPlatformSample/Presentation/MainModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using Uno.Extensions;
 using Uno.Extensions.Reactive;
@@ -18,6 +19,13 @@ public partial record MainModel : INotifyPropertyChanged
         INavigator navigator)
     {
         _navigator = navigator;
+
+        // Dev-loop hook: LVC_SAMPLE selects an initial sample by path
+        // (e.g. LVC_SAMPLE=Bars/Basic). Lets agents/scripts launch the app
+        // pointed at a specific repro without UI navigation.
+        var initial = Environment.GetEnvironmentVariable("LVC_SAMPLE");
+        if (!string.IsNullOrWhiteSpace(initial) && Array.IndexOf(Samples, initial) >= 0)
+            SelectedSample = initial;
     }
 
     public string[] Samples { get; } = ViewModelsSamples.Index.Samples;

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -47,9 +47,10 @@ public partial class MainWindow : Window
 
     private async Task CaptureAndExitAsync(string path)
     {
-        // Allow the chart's measure + initial animation frames to settle before
-        // capture. 2s is conservative — sample animations are typically ~700 ms.
-        await Task.Delay(2000);
+        // Wait for the chart's measure + initial animation frames to settle.
+        // See AvaloniaSample/MainWindow.axaml.cs for rationale (default 3s,
+        // override via LVC_SCREENSHOT_DELAY_MS for slower hosts).
+        await Task.Delay(GetDelayMs());
 
         try
         {
@@ -73,5 +74,11 @@ public partial class MainWindow : Window
         }
 
         Close();
+    }
+
+    private static int GetDelayMs()
+    {
+        var raw = Environment.GetEnvironmentVariable("LVC_SCREENSHOT_DELAY_MS");
+        return int.TryParse(raw, out var ms) && ms > 0 ? ms : 3000;
     }
 }

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -54,9 +54,14 @@ public partial class MainWindow : Window
 
         try
         {
-            var w = (int)Math.Max(1, ActualWidth);
-            var h = (int)Math.Max(1, ActualHeight);
-            var rtb = new RenderTargetBitmap(w, h, 96, 96, PixelFormats.Pbgra32);
+            // ActualWidth/ActualHeight are in DIPs. Scale to physical pixels
+            // and pass the matching DPI to RenderTargetBitmap so the capture
+            // matches on-screen pixels on HiDPI displays instead of being
+            // stretched/blurry.
+            var dpi = VisualTreeHelper.GetDpi(this);
+            var w = (int)Math.Max(1, ActualWidth * dpi.DpiScaleX);
+            var h = (int)Math.Max(1, ActualHeight * dpi.DpiScaleY);
+            var rtb = new RenderTargetBitmap(w, h, dpi.PixelsPerInchX, dpi.PixelsPerInchY, PixelFormats.Pbgra32);
             rtb.Render(this);
 
             var fullPath = Path.GetFullPath(path);

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 
@@ -14,6 +15,15 @@ public partial class MainWindow : Window
         InitializeComponent();
         Samples = ViewModelsSamples.Index.Samples;
         DataContext = this;
+
+        // Dev-loop hook: LVC_SAMPLE selects an initial sample by path
+        // (e.g. LVC_SAMPLE=Bars/Basic). Lets agents/scripts launch the app
+        // pointed at a specific repro without UI navigation.
+        var initial = Environment.GetEnvironmentVariable("LVC_SAMPLE");
+        if (!string.IsNullOrWhiteSpace(initial) && Samples.Contains(initial))
+            content.Content = Activator
+                .CreateInstance(null, $"WPFSample.{initial.Replace('/', '.')}.View")?
+                .Unwrap();
     }
 
     public string[] Samples { get; set; }

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -72,7 +72,17 @@ public partial class MainWindow : Window
             encoder.Save(fs);
             Console.WriteLine($"[LVC_SCREENSHOT] saved {w}x{h} to {fullPath}");
         }
-        catch (Exception ex)
+        // Catch only the *expected* capture failure modes — file/path I/O,
+        // permission, invalid arguments, encoder state, native-side errors
+        // — and let truly unexpected exceptions (OOM, chart-engine bugs,
+        // etc.) propagate so CI sees a real stack trace.
+        catch (Exception ex) when (
+            ex is IOException                  // also covers DirectoryNotFound, PathTooLong, FileNotFound
+            or UnauthorizedAccessException
+            or ArgumentException               // also covers ArgumentNullException
+            or NotSupportedException
+            or InvalidOperationException
+            or System.Runtime.InteropServices.COMException)
         {
             Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
             Environment.ExitCode = 1;

--- a/samples/WPFSample/MainWindow.xaml.cs
+++ b/samples/WPFSample/MainWindow.xaml.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace WPFSample;
 
@@ -24,6 +28,13 @@ public partial class MainWindow : Window
             content.Content = Activator
                 .CreateInstance(null, $"WPFSample.{initial.Replace('/', '.')}.View")?
                 .Unwrap();
+
+        // Dev-loop hook: when LVC_SCREENSHOT is set, render the window to PNG
+        // shortly after load and exit. Lets agents/scripts capture the rendered
+        // sample without external screenshot tooling.
+        var screenshotPath = Environment.GetEnvironmentVariable("LVC_SCREENSHOT");
+        if (!string.IsNullOrWhiteSpace(screenshotPath))
+            Loaded += async (_, _) => await CaptureAndExitAsync(screenshotPath);
     }
 
     public string[] Samples { get; set; }
@@ -32,5 +43,35 @@ public partial class MainWindow : Window
     {
         if ((sender as FrameworkElement).DataContext is not string ctx) throw new Exception("Sample not found");
         content.Content = Activator.CreateInstance(null, $"WPFSample.{ctx.Replace('/', '.')}.View").Unwrap();
+    }
+
+    private async Task CaptureAndExitAsync(string path)
+    {
+        // Allow the chart's measure + initial animation frames to settle before
+        // capture. 2s is conservative — sample animations are typically ~700 ms.
+        await Task.Delay(2000);
+
+        try
+        {
+            var w = (int)Math.Max(1, ActualWidth);
+            var h = (int)Math.Max(1, ActualHeight);
+            var rtb = new RenderTargetBitmap(w, h, 96, 96, PixelFormats.Pbgra32);
+            rtb.Render(this);
+
+            var fullPath = Path.GetFullPath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            using var fs = File.Create(fullPath);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(rtb));
+            encoder.Save(fs);
+            Console.WriteLine($"[LVC_SCREENSHOT] saved {w}x{h} to {fullPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+
+        Close();
     }
 }

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -78,7 +78,17 @@ public sealed partial class MainWindow : Window
             await encoder.FlushAsync();
             Console.WriteLine($"[LVC_SCREENSHOT] saved {rtb.PixelWidth}x{rtb.PixelHeight} to {fullPath}");
         }
-        catch (Exception ex)
+        // Catch only the *expected* capture failure modes — file/path I/O,
+        // permission, invalid arguments, encoder state, WinRT-side errors
+        // — and let truly unexpected exceptions (OOM, chart-engine bugs,
+        // etc.) propagate so CI sees a real stack trace.
+        catch (Exception ex) when (
+            ex is IOException                  // also covers DirectoryNotFound, PathTooLong, FileNotFound
+            or UnauthorizedAccessException
+            or ArgumentException               // also covers ArgumentNullException
+            or NotSupportedException
+            or InvalidOperationException
+            or System.Runtime.InteropServices.COMException)
         {
             Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
             Environment.ExitCode = 1;

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 
@@ -11,6 +12,15 @@ public sealed partial class MainWindow : Window
         InitializeComponent();
         Samples = ViewModelsSamples.Index.Samples;
         grid.DataContext = this;
+
+        // Dev-loop hook: LVC_SAMPLE selects an initial sample by path
+        // (e.g. LVC_SAMPLE=Bars/Basic). Lets agents/scripts launch the app
+        // pointed at a specific repro without UI navigation.
+        var initial = Environment.GetEnvironmentVariable("LVC_SAMPLE");
+        if (!string.IsNullOrWhiteSpace(initial) && Samples.Contains(initial))
+            content.Content = Activator
+                .CreateInstance(null, $"WinUISample.{initial.Replace('/', '.')}.View")?
+                .Unwrap();
     }
 
     public string[] Samples { get; set; }

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -59,7 +59,7 @@ public sealed partial class MainWindow : Window
 
         try
         {
-            using var rtb = new RenderTargetBitmap();
+            var rtb = new RenderTargetBitmap();
             await rtb.RenderAsync(grid);
             var pixels = await rtb.GetPixelsAsync();
 

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
-using Windows.Storage.Streams;
 
 namespace WinUISample;
 

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -64,9 +64,11 @@ public sealed partial class MainWindow : Window
             var pixels = await rtb.GetPixelsAsync();
 
             var fullPath = Path.GetFullPath(path);
-            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            var dir = Path.GetDirectoryName(fullPath)
+                ?? throw new ArgumentException($"LVC_SCREENSHOT path has no parent directory: {path}", nameof(path));
+            Directory.CreateDirectory(dir);
 
-            var folder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(fullPath));
+            var folder = await StorageFolder.GetFolderFromPathAsync(dir);
             var file = await folder.CreateFileAsync(Path.GetFileName(fullPath), CreationCollisionOption.ReplaceExisting);
             using var stream = await file.OpenAsync(FileAccessMode.ReadWrite);
             var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+using Windows.Storage.Streams;
 
 namespace WinUISample;
 
@@ -21,6 +27,13 @@ public sealed partial class MainWindow : Window
             content.Content = Activator
                 .CreateInstance(null, $"WinUISample.{initial.Replace('/', '.')}.View")?
                 .Unwrap();
+
+        // Dev-loop hook: when LVC_SCREENSHOT is set, render the window to PNG
+        // shortly after activation and exit. Lets agents/scripts capture the
+        // rendered sample without external screenshot tooling.
+        var screenshotPath = Environment.GetEnvironmentVariable("LVC_SCREENSHOT");
+        if (!string.IsNullOrWhiteSpace(screenshotPath))
+            Activated += async (_, _) => await CaptureAndExitAsync(screenshotPath);
     }
 
     public string[] Samples { get; set; }
@@ -30,5 +43,47 @@ public sealed partial class MainWindow : Window
         if ((sender as FrameworkElement).DataContext is not string ctx) throw new Exception("Sample not found");
 
         content.Content = Activator.CreateInstance(null, $"WinUISample.{ctx.Replace('/', '.')}.View").Unwrap();
+    }
+
+    private bool _captured;
+    private async Task CaptureAndExitAsync(string path)
+    {
+        // Activated fires multiple times; only run once.
+        if (_captured) return;
+        _captured = true;
+
+        // Allow the chart's measure + initial animation frames to settle before
+        // capture. 2s is conservative — sample animations are typically ~700 ms.
+        await Task.Delay(2000);
+
+        try
+        {
+            var rtb = new RenderTargetBitmap();
+            await rtb.RenderAsync(grid);
+            var pixels = await rtb.GetPixelsAsync();
+
+            var fullPath = Path.GetFullPath(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+
+            var folder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(fullPath));
+            var file = await folder.CreateFileAsync(Path.GetFileName(fullPath), CreationCollisionOption.ReplaceExisting);
+            using var stream = await file.OpenAsync(FileAccessMode.ReadWrite);
+            var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
+            encoder.SetPixelData(
+                BitmapPixelFormat.Bgra8,
+                BitmapAlphaMode.Premultiplied,
+                (uint)rtb.PixelWidth, (uint)rtb.PixelHeight,
+                96, 96,
+                pixels.ToArray());
+            await encoder.FlushAsync();
+            Console.WriteLine($"[LVC_SCREENSHOT] saved {rtb.PixelWidth}x{rtb.PixelHeight} to {fullPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[LVC_SCREENSHOT] capture failed: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+
+        Close();
     }
 }

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -52,9 +52,10 @@ public sealed partial class MainWindow : Window
         if (_captured) return;
         _captured = true;
 
-        // Allow the chart's measure + initial animation frames to settle before
-        // capture. 2s is conservative — sample animations are typically ~700 ms.
-        await Task.Delay(2000);
+        // Wait for the chart's measure + initial animation frames to settle.
+        // See AvaloniaSample/MainWindow.axaml.cs for rationale (default 3s,
+        // override via LVC_SCREENSHOT_DELAY_MS for slower hosts).
+        await Task.Delay(GetDelayMs());
 
         try
         {
@@ -85,5 +86,11 @@ public sealed partial class MainWindow : Window
         }
 
         Close();
+    }
+
+    private static int GetDelayMs()
+    {
+        var raw = Environment.GetEnvironmentVariable("LVC_SCREENSHOT_DELAY_MS");
+        return int.TryParse(raw, out var ms) && ms > 0 ? ms : 3000;
     }
 }

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -59,7 +59,7 @@ public sealed partial class MainWindow : Window
 
         try
         {
-            var rtb = new RenderTargetBitmap();
+            using var rtb = new RenderTargetBitmap();
             await rtb.RenderAsync(grid);
             var pixels = await rtb.GetPixelsAsync();
 

--- a/samples/WinUISample/WinUISample/MainWindow.xaml.cs
+++ b/samples/WinUISample/WinUISample/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;


### PR DESCRIPTION
## Summary

- Adds `LVC_SAMPLE` env var hook to Avalonia, WPF, WinUI, MAUI and Uno samples so the app starts on a specific sample path without UI navigation
- Adds `.claude/skills/repro-and-fix/SKILL.md` documenting the end-to-end "reproduce GitHub issue → diagnose → fix → regression test → PR" workflow
- Adds `.claude/scripts/capture-window.ps1` (Windows) for PrintWindow-based screenshot capture so the agent can self-verify visual bugs

## Why

After working through #2008 with a human in the loop for every visual confirmation, the dev loop kept stalling on three repeated questions:

1. "Please open the app and navigate to ..." — solved by `LVC_SAMPLE`.
2. "Is the bug visible now?" — solved by capturing a window screenshot and reading the PNG (multimodal). Reserved for visual bugs; logs + Factos test cover state/dataflow bugs.
3. "Did the fix work?" — same screenshot pattern, captured before/after.

The skill itself encodes the conventions already in the user's auto-memory (worktree-per-issue, separately-revertible regression-test commit, snapshot tests for render-path changes, etc.) so a future session can run end-to-end without rediscovering them.

## Test plan

- [x] `LVC_SAMPLE=VisualTest/DataTemplate ./AvaloniaSample.Desktop.exe` lands on the DataTemplate sample (verified via screenshot)
- [x] `LVC_SAMPLE=VisualTest/Issue1986Repro` lands on the Issue1986Repro view
- [x] Unset `LVC_SAMPLE` ⇒ default landing behavior unchanged
- [x] `capture-window.ps1 -ProcessName AvaloniaSample.Desktop` captures the window correctly (1646x870 PNG written)
- [ ] Sanity-check the WPF / WinUI / MAUI / Uno builds in CI (no behavior change when env var unset, so risk is low)

🤖 Generated with [Claude Code](https://claude.com/claude-code)