### PR TITLE
fix(uno-winui): Uno-Skia Android/iOS BindableView typeref + blank render

### DIFF
--- a/.github/workflows/livecharts.yml
+++ b/.github/workflows/livecharts.yml
@@ -388,10 +388,9 @@ jobs:
           - id: maui
             tf: net10.0-android
             workloads: maui-android
-          # ToDo: find why not running.
-          # - id: uno
-          #   tf: net10.0-android
-          #   workloads: android
+          - id: uno
+            tf: net10.0-android
+            workloads: android
     needs: [pack, prepare]
     steps:
       - name: Checkout

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
     <UITesting>false</UITesting>
     <NoWarnUITests>$(NoWarn);NETSDK1198;NU1701;XC0022;XA0141;XAAADB0000;CS0067;CS0414;CS0108;CS0618;CS4014;CS8600;CS8601;CS8602;CS8603;CS8612;CS8618;CS8622;CS8625;CS8629;CS9264;</NoWarnUITests>
     <!-- Factos version https://github.com/beto-rodriguez/Factos -->
-    <FactosVersion>0.8.1</FactosVersion>
+    <FactosVersion>0.8.3</FactosVersion>
 
     <!-- Useful to toggle between using project references or nuget references -->
     <UseNuGetForSamples>false</UseNuGetForSamples>

--- a/samples/UnoPlatformSample/UnoPlatformSample/UnoPlatformSample.csproj
+++ b/samples/UnoPlatformSample/UnoPlatformSample/UnoPlatformSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk/6.5.31">
+﻿<Project Sdk="Uno.Sdk/6.5.33">
     <PropertyGroup>
         <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-windows10.0.19041.0;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/src/_Shared.Native/Platforms/Android/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/Android/NativeTicker.cs
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if ANDROID
+#if ANDROID && !LVC_UNO_SKIA
 
 // reachable on maui android or uno android (without skia renderer)
+// LVC_UNO_SKIA excludes the Uno-Skia chart library build.
 
 using System;
 using LiveChartsCore.Motion;

--- a/src/_Shared.Native/Platforms/Android/PointerController.cs
+++ b/src/_Shared.Native/Platforms/Android/PointerController.cs
@@ -20,9 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if ANDROID
+#if ANDROID && !LVC_UNO_SKIA
 
 // reachable on maui android or uno android (without skia renderer)
+// LVC_UNO_SKIA excludes the Uno-Skia chart library build (uses
+// _Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs instead).
 
 using System;
 using Android.Views;

--- a/src/_Shared.Native/Platforms/Mac/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/Mac/NativeTicker.cs
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if IOS || MACCATALYST
+#if (IOS || MACCATALYST) && !LVC_UNO_SKIA
 
 // reachable on maui ios/catalys or uno ios/catalyst (without skia renderer)
+// LVC_UNO_SKIA excludes the Uno-Skia chart library build.
 
 using CoreAnimation;
 using Foundation;

--- a/src/_Shared.Native/Platforms/Mac/PointerController.cs
+++ b/src/_Shared.Native/Platforms/Mac/PointerController.cs
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if MACCATALYST || IOS
+#if (MACCATALYST || IOS) && !LVC_UNO_SKIA
 
 // reachable on maui ios/catalys or uno ios/catalyst (without skia renderer)
+// LVC_UNO_SKIA excludes the Uno-Skia chart library build.
 
 using System;
 using CoreGraphics;

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if !HAS_OS_LVC && UNO_LVC
+#if (!HAS_OS_LVC && UNO_LVC) || LVC_UNO_SKIA
 
-// reachable on uno skia renderer
+// reachable on uno skia renderer (desktop and Uno.WinUI chart lib mobile)
 // HAS_OS_LVC is true when the target framework contains any of the following:
 // -windows, -android, -ios, -maccatalyst, -tizen
 // currently this is the the same file as WinUI, because uno makes this work across platforms

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/PointerController.cs
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if !HAS_OS_LVC && UNO_LVC
+#if (!HAS_OS_LVC && UNO_LVC) || LVC_UNO_SKIA
 
-// reachable on uno skia renderer
+// reachable on uno skia renderer (desktop and, for the Uno.WinUI chart lib,
+// mobile via the LVC_UNO_SKIA opt-in defined in that csproj)
 // HAS_OS_LVC is true when the target framework contains any of the following:
 // -windows, -android, -ios, -maccatalyst, -tizen
 // currently this is the the same file as WinUI, because uno makes this work across platforms

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -61,8 +61,18 @@
        Version="$(LatestSkiaSharpVersion)" />
   </ItemGroup>
 
-  <!-- Include Uno skia renderer if needed -->
-  <PropertyGroup Condition="'$(HasOS)' != 'true'">
+  <!--
+    Enable SkiaRenderer for every non-Windows TFM. This makes the chart library
+    compile against the Skia variant of Uno.UI (UIElement → DependencyObject) on
+    Android/iOS/macCatalyst, matching what apps using <UnoFeatures>SkiaRenderer
+    </UnoFeatures> ship at runtime. The prior condition '$(HasOS)' != 'true'
+    excluded -android / -ios, so the library compiled against the Native Android
+    Uno.UI (UIElement → BindableView) and ended up with typerefs to
+    Uno.UI.Controls.BindableView in every GetValue/SetValue call. Loading any
+    chart-hosting UserControl under an Uno-Skia Android app then threw
+    TypeLoadException because the Skia Uno.UI assembly has no BindableView.
+  -->
+  <PropertyGroup Condition="!$(TargetFramework.Contains('-windows'))">
     <UnoFeatures>$(UnoFeatures);SkiaRenderer</UnoFeatures>
   </PropertyGroup>
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -76,6 +76,23 @@
     <UnoFeatures>$(UnoFeatures);SkiaRenderer</UnoFeatures>
   </PropertyGroup>
 
+  <!--
+    On -android / -ios / -maccatalyst we ship Uno-Skia, not Uno-Native, so the
+    rendering must go through SkiaRenderMode2 (SKCanvasElement) and the
+    Uno-Skia pointer/ticker code. LVC_UNO_SKIA is the toggle: shared code that
+    guards `#if ANDROID` / `#if IOS || MACCATALYST` (the Maui+Uno-Native Android
+    paths) excludes itself when LVC_UNO_SKIA is set, and the Uno-Skia
+    pointer/ticker partials accept LVC_UNO_SKIA as an opt-in alongside their
+    desktop `!HAS_OS_LVC && UNO_LVC` condition. Same for MotionCanvas's
+    `#if !HAS_OS_LVC` render-mode factory.
+  -->
+  <PropertyGroup Condition="
+      $(TargetFramework.Contains('-android'))    or
+      $(TargetFramework.Contains('-ios'))        or
+      $(TargetFramework.Contains('-maccatalyst'))">
+    <DefineConstants>$(DefineConstants);LVC_UNO_SKIA</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="../../../generators/LiveChartsGenerators/LiveChartsGenerators.csproj">
       <OutputItemType>Analyzer</OutputItemType>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk/6.3.28">
+﻿<Project Sdk="Uno.Sdk/6.5.33">
   
   <PropertyGroup>
     <UnoSingleProject>true</UnoSingleProject>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if !HAS_OS_LVC
+#if !HAS_OS_LVC || LVC_UNO_SKIA
 
 using System.Diagnostics;
 using LiveChartsCore.Kernel.Sketches;
@@ -92,11 +92,9 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
         public void InvalidateRenderer() =>
             Invalidate();
 
-        protected override void RenderOverride(SKCanvas canvas, Size area)
-        {
+        protected override void RenderOverride(SKCanvas canvas, Size area) =>
             FrameRequest?.Invoke(
                 new SkiaSharpDrawingContext(_canvas, canvas, GetBackground()));
-        }
 
         private SKColor GetBackground() =>
             ((Parent as FrameworkElement)?.Parent as IChartView)?.BackColor.AsSKColor() ?? SKColor.Empty;

--- a/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
+++ b/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
@@ -46,7 +46,7 @@ public partial class MotionCanvas : Canvas
                 {
                     IFrameTicker ticker;
 
-#if !HAS_OS_LVC
+#if !HAS_OS_LVC || LVC_UNO_SKIA
                     var renderMode = new SkiaRenderMode();
 
                     ticker = settings.TryUseVSync


### PR DESCRIPTION
## Summary

Fixes the long-running blank-chart on Uno-Skia Android sample (`samples/UnoPlatformSample` running on `net10.0-android`). Sample now paints every chart end-to-end on a Pixel 5 API 35 emulator (Apple Silicon, Uno.Sdk 6.5.33). Same fix applies to `net10.0-ios` and `net10.0-maccatalyst`, though only Android was verified visually for this PR.

## Root cause (one mistake, two symptoms)

The chart library csproj gated `<UnoFeatures>SkiaRenderer</UnoFeatures>` behind `Condition="'$(HasOS)' != 'true'"`. `HasOS` is set by any `-android`/`-ios`/`-windows`/`-maccatalyst` TFM, so the SkiaRenderer feature was applied **only** on Uno-Native desktop/wasm builds. `-android` / `-ios` builds of the chart lib therefore compiled against the **Native Android variant** of `Uno.UI` (where `UIElement` derives from `Uno.UI.Controls.BindableView`). The source-generated DP code embeds typerefs to `BindableView` via every base-method call resolved against that compile-time hierarchy.

At runtime the sample ships Uno-Skia `Uno.UI` (no `BindableView`) — the JIT raises `TypeLoadException: Could not resolve type 'Uno.UI.Controls.BindableView'` the first time it walks any chart control's vtable. In the sample's `IndexToContentConverter`, that throw is swallowed by the binding pipeline, leaving the chart subtree silently unconstructed (the prior diagnosis of "Uno-Skia Android skips measure on UserControls" was incorrect — UserControls and Grids measure fine on Uno-Skia Android; the chart was being abandoned mid-construction).

Even with the type-load fix in isolation, `MotionCanvas`'s render-mode factory was gated `#if !HAS_OS_LVC` and so picked `CPURenderMode` on `-android`, which uses `SKXamlCanvas` — a Windows-only WinUI API absent on Uno-Skia mobile. Nothing would draw.

Both symptoms fall out from the same root: target the right `Uno.UI` variant at compile time, and route the rendering path that matches it.

## What changed

* **Commit 1** — `src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj`: replace `Condition="'$(HasOS)' != 'true'"` on the `SkiaRenderer` UnoFeature with `Condition="!$(TargetFramework.Contains('-windows'))"`. `-windows10.x` still compiles against the real WinUI (no Uno overlay); every other TFM lines up with the Uno-Skia runtime variant.

* **Commit 2** — adds an `LVC_UNO_SKIA` define in the same csproj for `-android`/`-ios`/`-maccatalyst` and updates `#if` guards in 8 files so the Uno-Skia render path (SkiaRenderMode2 via SKCanvasElement, Uno-Skia pointer/ticker) compiles on mobile while the Native-Android (Choreographer / MotionEvent / BindableView) and iOS-Native (CADisplayLink / UIKit gesture recognizers) partials are excluded — those continue to compile only under MAUI (LVC_UNO_SKIA is not defined on MAUI csprojs, so MAUI Android/iOS are unaffected).

* **Commits 3 + 4** — `.github/workflows/livecharts.yml`: re-enable Factos `uno / net10.0-android` in `test-android` and `uno / net10.0-ios` in `test-ios`. Both were commented in `a275efe0` because the Uno-Skia mobile sample crashed on launch; the fixes in this PR unblock them. The Android job catches future Uno-Native/Uno-Skia split regressions at PR time; the iOS job also lets us measure whether the previously-cited 3× slowdown still applies on the current Uno SDK.

## Sibling-platform builds verified clean

* Uno.WinUI chart lib `-windows10.0.19041.0`, `-desktop`, `-browserwasm` (Windows side); `-android` on Mac
* MAUI chart lib `-android`

## Test plan

- [ ] CI `test-android / uno` runs cleanly (regression guard for this exact bug)
- [ ] CI `test-ios / uno` runs cleanly (verifies Apple variant of the same fix)
- [ ] All existing Factos jobs (avalonia-*, maui, winui, wpf, winforms, blazor, eto, uno-desktop, uno-windows) stay green
- [x] Visual: `samples/UnoPlatformSample` on net10.0-android renders every Lines/Basic, Bars/Basic, and Pies/Basic sample correctly on a Pixel 5 API 35 emulator (LVC_SAMPLE=Lines/Basic shown in PR screenshot below)
- [ ] Visual: same sample on `net10.0-ios` simulator (deferred — needs a Mac runner; CI `test-ios / uno` covers this)

## Screenshot

`samples/UnoPlatformSample` on `net10.0-android`, LVC_SAMPLE=Lines/Basic, after the fix — title + two LineSeries with star/circle geometries + axes all paint:

![Lines/Basic on Uno-Skia Android](https://github.com/Live-Charts/LiveCharts2/blob/fix/uno-android-blank-render/.claude-android/final-fix.png)

(The screenshot is not committed; it lives under `.claude-android/` locally. Happy to attach via a comment if the linked path doesn't resolve.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)