### PR TITLE
fix(motion-composer): close #2029 scale-doubling on WPF tab-switch

### DIFF
--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -123,7 +123,6 @@ public static class Index
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
         "VisualTest/Tabs",
-        "VisualTest/Issue2029Repro",
 
         "Test/ChangeSeriesInstance",
         "Test/Dispose",

--- a/samples/ViewModelsSamples/Index.cs
+++ b/samples/ViewModelsSamples/Index.cs
@@ -123,6 +123,7 @@ public static class Index
         "VisualTest/ReattachVisual",
         "VisualTest/DataTemplate",
         "VisualTest/Tabs",
+        "VisualTest/Issue2029Repro",
 
         "Test/ChangeSeriesInstance",
         "Test/Dispose",

--- a/samples/WPFSample/VisualTest/Issue2029Repro/View.xaml
+++ b/samples/WPFSample/VisualTest/Issue2029Repro/View.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="WPFSample.VisualTest.Issue2029Repro.View"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF">
+    <Grid>
+        <TabControl x:Name="tabControl" Margin="20,20,20,20">
+            <TabItem Header="TabItem1">
+                <Grid>
+                    <lvc:CartesianChart x:Name="chart1" x:FieldModifier="public"/>
+                </Grid>
+            </TabItem>
+            <TabItem Header="TabItem2">
+                <Grid>
+                    <lvc:CartesianChart x:Name="chart2" x:FieldModifier="public"/>
+                </Grid>
+            </TabItem>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/samples/WPFSample/VisualTest/Issue2029Repro/View.xaml.cs
+++ b/samples/WPFSample/VisualTest/Issue2029Repro/View.xaml.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Windows.Controls;
+using System.Windows.Threading;
+
+namespace WPFSample.VisualTest.Issue2029Repro;
+
+public partial class View : UserControl
+{
+    public View()
+    {
+        InitializeComponent();
+
+        // Drive the repro automatically: TabItem1 → TabItem2 → TabItem1.
+        // Reporter's full flow on 2.0.0-rc6.1 (closed as dup of #2049):
+        //   * step 1 — TabItem2 reveals an abnormally large/blurry chart
+        //     because the not-yet-selected MotionCanvas got Loaded at
+        //     size 0 and then Loaded again with no Unloaded in between,
+        //     so the WPF render-mode paint handler ended up subscribed
+        //     twice and Canvas.Scale(DPI) was applied twice per frame
+        //     (fixed by #2070 was only the NRE — this is the scale bug
+        //     #2029 keeps complaining about).
+        //   * step 2 — switching back to TabItem1 used to NRE inside
+        //     CompositionTargetTicker.OnCompositonTargetRendering
+        //     (fixed by #2070).
+        Loaded += (_, _) =>
+        {
+            _ = Dispatcher.BeginInvoke(
+                DispatcherPriority.Background,
+                new Action(() => tabControl.SelectedIndex = 1));
+            _ = Dispatcher.BeginInvoke(
+                DispatcherPriority.Background,
+                new Action(() => tabControl.SelectedIndex = 0));
+        };
+    }
+}

--- a/src/LiveChartsCore/Motion/MotionCanvasComposer.cs
+++ b/src/LiveChartsCore/Motion/MotionCanvasComposer.cs
@@ -46,12 +46,25 @@ public class MotionCanvasComposer(IRenderMode renderMode, IFrameTicker ticker)
     /// </summary>
     public IFrameTicker Ticker { get; } = ticker;
 
+    private bool _isInitialized;
+
     /// <summary>
     /// Initializes the composer.
     /// </summary>
     /// <param name="canvas"></param>
     public void Initialize(CoreMotionCanvas canvas)
     {
+        // Guard against repeated Initialize without an intervening Dispose.
+        // WPF's TabControl raises Loaded on a chart that lives in a not-yet-
+        // selected tab (size 0), then raises Loaded again — with no Unloaded
+        // in between — when the tab is reparented into the active content
+        // host. Without this guard the render-mode paint event and the
+        // FrameRequest → DrawFrame handler would be subscribed twice, so
+        // every paint applies the HiDPI Canvas.Scale twice (e.g. 1.75² ≈ 3)
+        // and the chart renders at multiple-times the intended scale (#2029).
+        if (_isInitialized) return;
+        _isInitialized = true;
+
         RenderMode.InitializeRenderMode(canvas);
         Ticker.InitializeTicker(canvas, RenderMode);
         RenderMode.FrameRequest += canvas.DrawFrame;
@@ -63,6 +76,9 @@ public class MotionCanvasComposer(IRenderMode renderMode, IFrameTicker ticker)
     /// <param name="canvas"></param>
     public void Dispose(CoreMotionCanvas canvas)
     {
+        if (!_isInitialized) return;
+        _isInitialized = false;
+
         RenderMode.DisposeRenderMode();
         Ticker.DisposeTicker();
         RenderMode.FrameRequest -= canvas.DrawFrame;

--- a/tests/CoreTests/CoreObjectsTests/MotionCanvasComposerTesting.cs
+++ b/tests/CoreTests/CoreObjectsTests/MotionCanvasComposerTesting.cs
@@ -1,0 +1,84 @@
+using LiveChartsCore.Motion;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+[TestClass]
+public class MotionCanvasComposerTesting
+{
+    // Regression for #2029. WPF's TabControl raises Loaded on a chart that lives
+    // in a not-yet-selected tab (size 0), then raises Loaded *again* — with no
+    // Unloaded between them — once the tab is reparented into the active content
+    // host. Without an idempotency guard the composer's Initialize re-subscribed
+    // OnPaintSurface and FrameRequest → DrawFrame, so every paint applied the
+    // HiDPI Canvas.Scale twice (e.g. 1.75² ≈ 3) and the chart rendered at
+    // multiple-times the intended scale.
+    [TestMethod]
+    public void Initialize_IsIdempotent_WithoutInterveningDispose()
+    {
+        var renderMode = new SpyRenderMode();
+        var ticker = new SpyFrameTicker();
+        var composer = new MotionCanvasComposer(renderMode, ticker);
+        var canvas = new CoreMotionCanvas();
+
+        composer.Initialize(canvas);
+        composer.Initialize(canvas);
+
+        Assert.AreEqual(1, renderMode.InitializeCount, "InitializeRenderMode must run once.");
+        Assert.AreEqual(1, ticker.InitializeCount, "InitializeTicker must run once.");
+        Assert.AreEqual(1, renderMode.FrameRequestSubscriberCount, "FrameRequest must have a single subscriber.");
+    }
+
+    [TestMethod]
+    public void Dispose_AfterDoubleInitialize_RestoresCleanState()
+    {
+        var renderMode = new SpyRenderMode();
+        var ticker = new SpyFrameTicker();
+        var composer = new MotionCanvasComposer(renderMode, ticker);
+        var canvas = new CoreMotionCanvas();
+
+        composer.Initialize(canvas);
+        composer.Initialize(canvas);
+        composer.Dispose(canvas);
+
+        Assert.AreEqual(0, renderMode.FrameRequestSubscriberCount, "Dispose must unsubscribe FrameRequest.");
+        Assert.AreEqual(1, renderMode.DisposeCount, "DisposeRenderMode must run once.");
+        Assert.AreEqual(1, ticker.DisposeCount, "DisposeTicker must run once.");
+
+        // After a full Dispose, Initialize must work again (re-entering the
+        // Initialize → Dispose → Initialize cycle on a future tab switch).
+        composer.Initialize(canvas);
+
+        Assert.AreEqual(2, renderMode.InitializeCount);
+        Assert.AreEqual(1, renderMode.FrameRequestSubscriberCount);
+    }
+
+    private sealed class SpyRenderMode : IRenderMode
+    {
+        private CoreMotionCanvas.FrameRequestHandler? _frameRequest;
+
+        public int InitializeCount { get; private set; }
+        public int DisposeCount { get; private set; }
+        public int FrameRequestSubscriberCount =>
+            _frameRequest?.GetInvocationList().Length ?? 0;
+
+        public event CoreMotionCanvas.FrameRequestHandler FrameRequest
+        {
+            add => _frameRequest += value;
+            remove => _frameRequest -= value;
+        }
+
+        public void InitializeRenderMode(CoreMotionCanvas canvas) => InitializeCount++;
+        public void DisposeRenderMode() => DisposeCount++;
+        public void InvalidateRenderer() { }
+    }
+
+    private sealed class SpyFrameTicker : IFrameTicker
+    {
+        public int InitializeCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public void InitializeTicker(CoreMotionCanvas canvas, IRenderMode renderMode) => InitializeCount++;
+        public void DisposeTicker() => DisposeCount++;
+    }
+}


### PR DESCRIPTION
## Summary
- Guards `MotionCanvasComposer.Initialize`/`Dispose` against repeated calls without an intervening Dispose/Initialize.
- Adds a CoreTests regression that fails when the guard is reverted.
- Adds a `VisualTest/Issue2029Repro` WPF sample (two empty `CartesianChart`s in a `TabControl` with auto tab-switch) covering the original report's flow end-to-end.

Closes #2029.

## Why the bug only showed up under WPF + TabControl
WPF realizes every `TabItem`'s content at load time, but the unselected tab's content sits unattached to the active `ContentPresenter`. The chart in the unselected tab fires `Loaded` at `ActualWidth=0`, and fires `Loaded` *again* — with no `Unloaded` between — once the tab is reparented into the active host.

`Initialize` re-subscribed `OnPaintSurface` on the render mode and `FrameRequest → DrawFrame` on the canvas without unsubscribing, so by the time the tab became visible every paint ran those handlers **twice** and applied the HiDPI `Canvas.Scale(dpi)` twice: a `1.75² ≈ 3` effective scale, with only the top-left quadrant visible. The reporter rightly complained that the post-#2070 build still showed the "abnormally large/blurry" first-display symptom — that was the lingering bit; this PR closes it.

Tracking a single `_isInitialized` flag inside the composer fixes it without touching any platform view's `OnLoaded`/`OnUnloaded` ordering. The flag flips back on `Dispose`, so the normal `Init → Dispose → Init` cycle other platforms use on tab switch is unchanged.

## Before / after (WPF, `VisualTest/Issue2029Repro`, screenshot at TabItem2)

| Before | After |
| --- | --- |
| Y-axis labels at ~2× size, 0–5 cropped, no X-axis visible | Full 0–10 Y and 0–10 X axes at normal label size |

## Test plan
- [x] `dotnet bin/Debug/net8.0/CoreTests.dll` — 511 / 511 pass
- [x] `dotnet bin/Debug/net10.0/SnapshotTests.dll` — 132 / 132 pass
- [x] New `MotionCanvasComposerTesting` regression: passes with fix, fails when the guard is reverted (verified)
- [x] `LVC_SAMPLE=VisualTest/Issue2029Repro LVC_SCREENSHOT=…` on WPF — chart renders correctly on the previously-hidden tab and on switch-back, no NRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)