### PR TITLE
fix: invisible series + Top legend ArgumentNullException (#2054)

### DIFF
--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -413,7 +413,10 @@ public class CartesianChartEngine(
         var areAllColumns = true;
         var columnsFlags = SeriesProperties.Bar | SeriesProperties.PrimaryAxisVerticalOrientation;
 
-        foreach (var series in VisibleSeries.Cast<ICartesianSeries>())
+        // iterate Series (not VisibleSeries) so invisible series still get their theme
+        // applied; the legend can still request their miniature when IsVisibleAtLegend is
+        // true (its default), and a missing paint would otherwise crash on draw.
+        foreach (var series in Series.Cast<ICartesianSeries>())
         {
             if (series.SeriesId == -1) series.SeriesId = GetNextSeriesId();
 
@@ -423,6 +426,12 @@ public class CartesianChartEngine(
             {
                 theme.ApplyStyleToSeries(series);
                 ce._theme = themeId;
+            }
+
+            if (!series.IsVisible)
+            {
+                ce._isInternalSet = false;
+                continue;
             }
 
             var xAxis = GetXAxis(series);

--- a/src/LiveChartsCore/PieChartEngine.cs
+++ b/src/LiveChartsCore/PieChartEngine.cs
@@ -153,7 +153,10 @@ public class PieChartEngine(
         IndexBounds = new Bounds();
         PushoutBounds = new Bounds();
 
-        foreach (var series in VisibleSeries.Cast<IPieSeries>())
+        // iterate Series (not VisibleSeries) so invisible series still get their theme
+        // applied; the legend can still request their miniature when IsVisibleAtLegend is
+        // true (its default), and a missing paint would otherwise crash on draw.
+        foreach (var series in Series.Cast<IPieSeries>())
         {
             if (series.SeriesId == -1) series.SeriesId = GetNextSeriesId();
 
@@ -163,6 +166,12 @@ public class PieChartEngine(
             {
                 theme.ApplyStyleToSeries(series);
                 ce._theme = themeId;
+            }
+
+            if (!series.IsVisible)
+            {
+                ce._isInternalSet = false;
+                continue;
             }
 
             var seriesBounds = series.GetBounds(this);

--- a/src/LiveChartsCore/PolarChartEngine.cs
+++ b/src/LiveChartsCore/PolarChartEngine.cs
@@ -245,7 +245,10 @@ public class PolarChartEngine(
 
         // get seriesBounds
         SetDrawMargin(ControlSize, new Margin());
-        foreach (var series in VisibleSeries.Cast<IPolarSeries>())
+        // iterate Series (not VisibleSeries) so invisible series still get their theme
+        // applied; the legend can still request their miniature when IsVisibleAtLegend is
+        // true (its default), and a missing paint would otherwise crash on draw.
+        foreach (var series in Series.Cast<IPolarSeries>())
         {
             if (series.SeriesId == -1) series.SeriesId = GetNextSeriesId();
 
@@ -255,6 +258,12 @@ public class PolarChartEngine(
             {
                 theme.ApplyStyleToSeries(series);
                 ce._theme = themeId;
+            }
+
+            if (!series.IsVisible)
+            {
+                ce._isInternalSet = false;
+                continue;
             }
 
             var secondaryAxis = GetAngleAxis(series);

--- a/tests/CoreTests/SeriesTests/VisibilityTests.cs
+++ b/tests/CoreTests/SeriesTests/VisibilityTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Linq;
 using CoreTests.CoreObjectsTests;
 using LiveChartsCore;
+using LiveChartsCore.Measure;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
@@ -15,6 +16,44 @@ namespace CoreTests.SeriesTests;
 [TestClass]
 public class VisibilityTests
 {
+    // Issue #2054: a series declared with IsVisible=false never reached the theme-application
+    // loop (which iterated VisibleSeries), leaving its paints null. The legend still listed it
+    // (IsVisibleAtLegend defaults to true) and the miniature crashed in SkiaSharp with
+    // "Value cannot be null. (Parameter 'paint')" at the first draw.
+    [TestMethod]
+    public void InvisibleSeriesWithLegend_DoesNotCrash_Issue2054()
+    {
+        var cartesian = new SKCartesianChart
+        {
+            Width = 500,
+            Height = 500,
+            LegendPosition = LegendPosition.Top,
+            Series = [new LineSeries<double> { IsVisible = false }],
+            ExplicitDisposing = true
+        };
+        _ = cartesian.GetImage();
+
+        var pie = new SKPieChart
+        {
+            Width = 500,
+            Height = 500,
+            LegendPosition = LegendPosition.Top,
+            Series = [new PieSeries<double> { IsVisible = false, Values = [1] }],
+            ExplicitDisposing = true
+        };
+        _ = pie.GetImage();
+
+        var polar = new SKPolarChart
+        {
+            Width = 500,
+            Height = 500,
+            LegendPosition = LegendPosition.Top,
+            Series = [new PolarLineSeries<double> { IsVisible = false }],
+            ExplicitDisposing = true
+        };
+        _ = polar.GetImage();
+    }
+
     [TestMethod]
     public void VisibilityChangingTest()
     {


### PR DESCRIPTION
## Summary

Closes #2054.

A chart declared with `IsVisible="false"` on a series **and** `LegendPosition` set crashes with `System.ArgumentNullException: Value cannot be null. (Parameter 'paint')` from `SKCanvas.DrawCircle` on first frame.

**Root cause**: `Chart.Measure` in all three engines (`CartesianChartEngine`, `PolarChartEngine`, `PieChartEngine`) iterated `VisibleSeries` when applying the theme, so a series with `IsVisible=false` kept null `Stroke` / `Fill` / `GeometryStroke` / `GeometryFill`. The legend still lists it (`IsVisibleAtLegend` defaults to `true`) and `SKDefaultLegend.GetLayout` calls `series.GetMiniatureGeometry(null)` — which constructs a `CircleGeometry` with null paints — and `SKCanvas` throws.

The legend deliberately surfaces invisible-but-legend-visible series, and an existing comment in `CartesianChartEngine.Measure` even says *"we draw all the series even invisible because it animates the series when hidden"* — so the theme-loop skip was an unintentional inconsistency rather than a guarded design choice.

**Fix**: iterate `Series` instead of `VisibleSeries` in the theme-application loop of each engine, and add `if (!series.IsVisible) continue;` **after** the theme call but **before** `GetBounds` so axis bounds remain clean.

Why fix in the engine and not in `SKDefaultLegend`: filtering invisible series out of the legend would silently change semantics for callers who want a hidden series's swatch to remain visible (the documented purpose of `IsVisibleAtLegend`).

## Test plan

- [x] New `VisibilityTests.InvisibleSeriesWithLegend_DoesNotCrash_Issue2054` exercises all three chart engines; verified to fail without the engine commit with the exact `ArgumentNullException: paint` from the issue.
- [x] Full CoreTests suite: 482/482 pass.
- [x] Full SnapshotTests suite: 124/124 pass — no rendering regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)