### PR TITLE
fix(visual-elements): expose LabelGeometry on DrawnLabelVisual (#2124)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
@@ -57,6 +57,16 @@ public class DrawnLabelVisual : Visual
         _drawnElement = labelGeometry;
     }
 
+    /// <summary>
+    /// Gets the underlying <see cref="LabelGeometry"/>. Use this to read or
+    /// mutate label properties such as
+    /// <see cref="BaseLabelGeometry.Text"/>,
+    /// <see cref="BaseLabelGeometry.TextSize"/>,
+    /// <see cref="BaseLabelGeometry.Paint"/> or
+    /// <see cref="BaseLabelGeometry.Padding"/> after construction.
+    /// </summary>
+    public LabelGeometry Label => _drawnElement;
+
     /// <inheritdoc cref="Visual.DrawnElement"/>
     protected internal override IDrawnElement? DrawnElement => _drawnElement;
 

--- a/tests/CoreTests/OtherTests/DrawnLabelVisualLabelAccessTests.cs
+++ b/tests/CoreTests/OtherTests/DrawnLabelVisualLabelAccessTests.cs
@@ -1,0 +1,78 @@
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using LiveChartsCore.VisualElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+// Regression for #2124: DrawnLabelVisual hid its underlying LabelGeometry
+// behind a protected internal DrawnElement, so callers that received a
+// DrawnLabelVisual (e.g. chart.Title) had no way to read Text / TextSize /
+// Paint / Padding back without reflection.
+[TestClass]
+public class DrawnLabelVisualLabelAccessTests
+{
+    [TestMethod]
+    public void Label_Exposes_Default_Geometry_For_Parameterless_Ctor()
+    {
+        var visual = new DrawnLabelVisual();
+
+        Assert.IsNotNull(visual.Label);
+        Assert.AreEqual(string.Empty, visual.Label.Text);
+    }
+
+    [TestMethod]
+    public void Label_Returns_The_LabelGeometry_Passed_To_The_Ctor()
+    {
+        var geometry = new LabelGeometry { Text = "Hello" };
+        var visual = new DrawnLabelVisual(geometry);
+
+        Assert.AreSame(geometry, visual.Label);
+    }
+
+    [TestMethod]
+    public void Label_Mutations_Are_Visible_Through_The_Property()
+    {
+        var visual = new DrawnLabelVisual();
+        var padding = new Padding(4f);
+        Paint paint = new SolidColorPaint(SKColors.Red);
+
+        visual.Label.Text = "Revenue";
+        visual.Label.TextSize = 16f;
+        visual.Label.Padding = padding;
+        visual.Label.Paint = paint;
+
+        Assert.AreEqual("Revenue", visual.Label.Text);
+        Assert.AreEqual(16f, visual.Label.TextSize);
+        Assert.AreSame(padding, visual.Label.Padding);
+        Assert.AreSame(paint, visual.Label.Paint);
+    }
+
+    [TestMethod]
+    public void Label_Roundtrips_Through_Untyped_Reference()
+    {
+        // Models the user's reported use case: setting chart.Title (typed as
+        // Visual?), then reading it back later through a pattern match.
+        var padding = new Padding(2f);
+        var paint = new SolidColorPaint(SKColors.Black);
+        Visual title = new DrawnLabelVisual(new LabelGeometry
+        {
+            Text = "Revenue",
+            TextSize = 16f,
+            Paint = paint,
+            Padding = padding
+        });
+
+        Assert.IsInstanceOfType(title, typeof(DrawnLabelVisual));
+        var label = ((DrawnLabelVisual)title).Label;
+
+        Assert.AreEqual("Revenue", label.Text);
+        Assert.AreEqual(16f, label.TextSize);
+        Assert.AreSame(paint, label.Paint);
+        Assert.AreSame(padding, label.Padding);
+    }
+}


### PR DESCRIPTION
Closes #2124.

## Summary
- Adds a public `Label` property on `DrawnLabelVisual` that returns the underlying `LabelGeometry`.
- Adds CoreTests regression covering read-back, mutation, and the `chart.Title is DrawnLabelVisual` pattern-match flow.

## Why
The deprecation message on `LabelVisual` (*"Use `DrawnLabelVisual` instead."*) was unactionable for the read-back use case: `DrawnLabelVisual.DrawnElement` is `protected internal`, so a consumer who set `chart.Title = new DrawnLabelVisual(...)` had no public path to read `Text`, `TextSize`, `Paint`, or `Padding` later (e.g. for export, accessibility, or expanded-view rendering) without reflection.

`Label` is the smallest viable surface: it's a single readonly getter that returns the existing `LabelGeometry`, so callers get the full label API back (including the four properties named in the report, plus `MaxWidth`, `Background`, transforms, alignment). It also enables the C# nested-initializer pattern that mirrors the old `LabelVisual` ergonomics:

```csharp
chart.Title = new DrawnLabelVisual
{
    Label = { Text = "Revenue", TextSize = 16, Paint = paint }
};
```

I considered adding `Text` / `TextSize` / `Paint` / `Padding` pass-throughs directly on `DrawnLabelVisual` to fully match the deprecated `LabelVisual` API, but the XAML wrapper (`XamlDrawnLabelVisual`) already emits DPs for those same names via `Map = typeof(LabelGeometry), MapPath = "DrawnLabel"` — same-named pass-throughs would collide in the generator. `Label` is a read-only property, so the generator routes it through `notBindableProperties` (no DP), and Avalonia + WPF wrapper builds remain clean.

## Test plan
- [x] `dotnet test tests/CoreTests/ --framework net8.0` — 518/518 pass.
- [x] Reverting just the `Label` getter makes `DrawnLabelVisualLabelAccessTests` fail to compile (`'DrawnLabelVisual' does not contain a definition for 'Label'`), proving the test guards the new API.
- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/...` — wrapper builds clean (DP collision check).
- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharp.WPF/...` — same.
- [x] `dotnet build samples/ConsoleSample/...` — existing constructor pattern unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)