### PR TITLE
docs(repro-and-fix): don't commit Index.cs changes for repro views

### DIFF
--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -115,12 +115,19 @@ The View's code-behind should expose helpers that a Factos test can call
 (e.g. `FindTemplatedGaugeSeries()`). This is how the regression test hooks in
 without going through the visual tree.
 
-Add the new path to the sample selector:
+**Do not commit changes to `samples/ViewModelsSamples/Index.cs` for repro
+views.** Factos navigates to a sample by path via `LVC_SAMPLE` regardless of
+whether the path is listed in the index, and the index is shared across every
+platform sample. If you add `VisualTest/Issue<N>Repro` there and the view only
+exists in `samples/AvaloniaSample/`, every other platform sample (WPF, MAUI,
+WinUI, Uno) will throw when it loads the index. Leave the file untouched on
+your branch.
 
-```csharp
-// samples/ViewModelsSamples/Index.cs
-"VisualTest/Issue<N>Repro",
-```
+If it's genuinely easier for your *local* dev loop to pick the repro from the
+sample selector dropdown rather than via `LVC_SAMPLE`, edit `Index.cs`
+temporarily — but revert it before committing. `git restore
+samples/ViewModelsSamples/Index.cs` before each commit, or just don't stage
+the file.
 
 ### 4. Auto-launch the sample at your repro
 
@@ -286,7 +293,8 @@ Two commits, in this order:
 
 1. `fix(<scope>): <one-line summary> (#<N>)` — only the fix.
 2. `test(<scope>): regression for <symptom> (#<N>)` — only the test +
-   repro view + index entry.
+   repro view. Do not stage `samples/ViewModelsSamples/Index.cs`; see step 3
+   for why.
 
 Commit message style follows recent history (`git log --oneline -10`).
 Body: imperative, mention the root-cause mechanism, why the test catches it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -713,9 +713,13 @@ Quick reference for the dev-loop hooks the workflow relies on:
 - **`LVC_SCREENSHOT_DELAY_MS=<ms>`** — overrides the 3 s default settle delay before the in-app screenshot is taken (use on slower CI hosts).
 - **`.claude/scripts/capture-window.{ps1,-macos.sh,-linux.sh}`** — per-OS PrintWindow / `screencapture` / `grim` fallbacks for platforms without an in-app capture path (MAUI, Uno).
 
-Repro views live under `samples/AvaloniaSample/VisualTest/Issue<N>Repro/` and are
-registered in `samples/ViewModelsSamples/Index.cs`. Their code-behind exposes
-helpers (e.g. `FindTemplatedGaugeSeries()`) that Factos UI tests call directly.
+Repro views live under `samples/AvaloniaSample/VisualTest/Issue<N>Repro/` (or
+the equivalent under whichever platform sample fits the bug). Their code-behind
+exposes helpers (e.g. `FindTemplatedGaugeSeries()`) that Factos UI tests call
+directly. Factos and `LVC_SAMPLE` navigate by path and don't need the repro
+registered in `samples/ViewModelsSamples/Index.cs` — **do not commit changes
+to that file for a repro view.** It's shared across every platform sample,
+so a single-platform repro entry will crash the load on the other platforms.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Update the `repro-and-fix` skill (and its pointer in `.github/copilot-instructions.md`) so contributors **don't** stage `samples/ViewModelsSamples/Index.cs` when committing a bug-repro view.
- Explain *why* in both files: the index is shared across every platform sample, so a single-platform repro entry breaks the load on every other platform. Factos + `LVC_SAMPLE` navigate by path and don't need the entry.
- Still allows touching `Index.cs` locally if it speeds up the dev loop (picking from the sample dropdown), with an explicit revert-before-commit reminder.

## Why

Recent repro PRs (e.g. #2238) have been committing `Index.cs` changes by reflex because the skill told them to. That entry isn't needed — Factos navigates to the sample by path regardless of whether it's in the index — and it actively hurts the other platform samples that don't have a matching view.

The Copilot pointer doc (`.github/copilot-instructions.md`) also explicitly said repro views *are* registered in `Index.cs`. Fixed that line too so both sources of truth agree.

## Test plan

- [x] `grep` for `Index.cs` / `ViewModelsSamples/Index` in `.claude/` and `.github/` to confirm no stale "add to index" instructions remain in the repro-workflow paths
- [x] General `Adding New Samples` and `Adding a New Series Type` sections in `copilot-instructions.md` (which legitimately need `Index.cs`) left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)