### PR TITLE
fix(chart-engines): respect user-pinned MinLimit/MaxLimit during zoom (#2159)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -85,6 +85,10 @@ runs:
       shell: bash
       run: |
         cat << 'EOF' > run_tests.sh
+        # reactivecircus/android-emulator-runner spawns a subshell that drops
+        # DOTNET_HOST_PATH set by setup-dotnet; SDK 10.0.300 ILLink hard-fails
+        # _ComputeManagedAssemblies (MSB4221) without it.
+        export DOTNET_HOST_PATH="$(command -v dotnet)"
         n=0
         while [ $n -lt 3 ]; do
           echo "Starting Attempt $((n+1))..."

--- a/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
+++ b/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
@@ -248,6 +248,15 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
                     var hasSetter = property.SetMethod is not null;
                     var isPublic = property.DeclaredAccessibility == Accessibility.Public;
 
+                    // An explicit interface implementation can only be hosted by the generated
+                    // XAML wrapper when the wrapper itself implements that interface. Members that
+                    // explicitly implement an interface the wrapper does not declare (e.g. an
+                    // internal LiveCharts contract such as IInternalCartesianAxis, which lives on
+                    // the wrapped core type only) would emit `Interface.Member` and not compile.
+                    if (!notExplicit &&
+                        !ImplementsInterface(symbol, property.ExplicitInterfaceImplementations[0].ContainingType))
+                        continue;
+
                     if (notExplicit && hasSetter && isPublic)
                     {
                         bindableProperties.Add(property);
@@ -273,7 +282,11 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
                     if (method.MethodKind == MethodKind.Ordinary && method.DeclaredAccessibility == Accessibility.Public)
                         methods[methodKey] = method;
 
-                    if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation)
+                    // see the property comment above: only host an explicit implementation
+                    // when the XAML wrapper actually implements the interface.
+                    if (method.MethodKind == MethodKind.ExplicitInterfaceImplementation &&
+                        method.ExplicitInterfaceImplementations.Length > 0 &&
+                        ImplementsInterface(symbol, method.ExplicitInterfaceImplementations[0].ContainingType))
                         explicitMethods[methodKey] = method;
                 }
 
@@ -462,6 +475,10 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
             _ => throw new NotSupportedException($"The consumer type '{consumerType}' is not supported.")
         };
     }
+
+    private static bool ImplementsInterface(INamedTypeSymbol type, INamedTypeSymbol interfaceType) =>
+        type.AllInterfaces.Any(i =>
+            SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, interfaceType.OriginalDefinition));
 
     private static List<ISymbol> GetLiveChartsMembers(ITypeSymbol typeSymbol)
     {

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -1046,11 +1046,23 @@ public class CartesianChartEngine(
             var min = axis.MinLimit ?? limits.DataMin;
             var max = axis.MaxLimit ?? limits.DataMax;
 
-            if (min < limits.DataMin)
-                min = limits.DataMin - geometryOffset;
+            // The outer rail the post-zoom fit may grow back to is the user's
+            // pinning when wider than the data, otherwise the data bounds.
+            // Without this, a user-pinned view wider than the data was snapped
+            // to data bounds on every zoom and never returned to its initial
+            // state (#2159).
+            var outerMin = limits.UserSetMin.HasValue
+                ? Math.Min(limits.UserSetMin.Value, limits.DataMin)
+                : limits.DataMin;
+            var outerMax = limits.UserSetMax.HasValue
+                ? Math.Max(limits.UserSetMax.Value, limits.DataMax)
+                : limits.DataMax;
 
-            if (max > limits.DataMax)
-                max = limits.DataMax + geometryOffset;
+            if (min < outerMin)
+                min = outerMin - geometryOffset;
+
+            if (max > outerMax)
+                max = outerMax + geometryOffset;
 
             axis.SetLimits(min, max);
         }
@@ -1122,11 +1134,24 @@ public class CartesianChartEngine(
         {
             var threshold = GetThreshold(axis, scale);
 
-            if (fits && mint < limits.DataMin - threshold)
-                mint = limits.DataMin - threshold;
+            // Outer rail for zoom-out: when the user pinned MinLimit/MaxLimit
+            // wider than the data, those pinned values are the rail — not the
+            // data bounds. Clamping to data alone trapped the view at data
+            // bounds the first time a user with a wider pin zoomed out, and
+            // the subsequent "zoom-in does nothing / can only shrink" symptom
+            // had no path back to the user's original view (#2159).
+            var outerMin = limits.UserSetMin.HasValue
+                ? Math.Min(limits.UserSetMin.Value, limits.DataMin)
+                : limits.DataMin;
+            var outerMax = limits.UserSetMax.HasValue
+                ? Math.Max(limits.UserSetMax.Value, limits.DataMax)
+                : limits.DataMax;
 
-            if (fits && maxt > limits.DataMax + threshold)
-                maxt = limits.DataMax + threshold;
+            if (fits && mint < outerMin - threshold)
+                mint = outerMin - threshold;
+
+            if (fits && maxt > outerMax + threshold)
+                maxt = outerMax + threshold;
         }
 
         if (maxt < mint)

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -40,7 +40,7 @@ namespace LiveChartsCore;
 /// <typeparam name="TTextGeometry">The type of the text geometry.</typeparam>
 /// <typeparam name="TLineGeometry">The type of the line geometry.</typeparam>
 public abstract class CoreAxis<TTextGeometry, TLineGeometry>
-    : ChartElement, ICartesianAxis, IPlane
+    : ChartElement, ICartesianAxis, IInternalCartesianAxis, IPlane
         where TTextGeometry : BaseLabelGeometry, new()
         where TLineGeometry : BaseLineGeometry, new()
 {
@@ -313,8 +313,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     /// <inheritdoc cref="ICartesianAxis.SharedWith"/>
     public IEnumerable<ICartesianAxis>? SharedWith { get; set; }
 
-    double? ICartesianAxis.UserSetMinLimit => _userSetMinLimit;
-    double? ICartesianAxis.UserSetMaxLimit => _userSetMaxLimit;
+    double? IInternalCartesianAxis.UserSetMinLimit => _userSetMinLimit;
+    double? IInternalCartesianAxis.UserSetMaxLimit => _userSetMaxLimit;
 
     #endregion
 
@@ -941,10 +941,13 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             if (minDI < mind) mind = minDI;
 
             // widest pin wins: smallest non-null UserSetMin, largest non-null UserSetMax
-            if (axis.UserSetMinLimit is { } usMin && (userSetMin is null || usMin < userSetMin))
-                userSetMin = usMin;
-            if (axis.UserSetMaxLimit is { } usMax && (userSetMax is null || usMax > userSetMax))
-                userSetMax = usMax;
+            if (axis is IInternalCartesianAxis internalAxis)
+            {
+                if (internalAxis.UserSetMinLimit is { } usMin && (userSetMin is null || usMin < userSetMin))
+                    userSetMin = usMin;
+                if (internalAxis.UserSetMaxLimit is { } usMax && (userSetMax is null || usMax > userSetMax))
+                    userSetMax = usMax;
+            }
         }
 
         if (double.IsInfinity(minZoomDelta))

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -982,21 +982,15 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             // keeps the property setters from recording this engine-driven
             // view change as a user pin (#2159).
             _isEngineSettingLimits = true;
-            try
-            {
-                MinLimit = min;
-                MaxLimit = max;
+            MinLimit = min;
+            MaxLimit = max;
 
-                if (step > 0)
-                {
-                    ForceStepToMin = true;
-                    MinStep = step;
-                }
-            }
-            finally
+            if (step > 0)
             {
-                _isEngineSettingLimits = false;
+                ForceStepToMin = true;
+                MinStep = step;
             }
+            _isEngineSettingLimits = false;
         }
         else
         {

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -313,6 +313,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     /// <inheritdoc cref="ICartesianAxis.SharedWith"/>
     public IEnumerable<ICartesianAxis>? SharedWith { get; set; }
 
+    double? ICartesianAxis.UserSetMinLimit => _userSetMinLimit;
+    double? ICartesianAxis.UserSetMaxLimit => _userSetMaxLimit;
+
     #endregion
 
     /// <inheritdoc cref="ICartesianAxis.MeasureStarted"/>
@@ -917,6 +920,13 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         var mind = DataBounds.Min;
         var minZoomDelta = MinZoomDelta ?? DataBounds.MinDelta * 3;
 
+        // The user pin must be aggregated across the shared group the same way
+        // Min/Max/DataMin/DataMax are: a zoom started from an unpinned shared
+        // axis still has to honor a sibling's pin as the outer rail, otherwise
+        // SetLimits propagates a data-bounds collapse onto the pinned axis (#2159).
+        var userSetMin = _userSetMinLimit;
+        var userSetMax = _userSetMaxLimit;
+
         foreach (var axis in SharedWith ?? [])
         {
             var maxI = axis.MaxLimit is null ? axis.DataBounds.Max : axis.MaxLimit.Value;
@@ -929,6 +939,12 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             if (minI < min) min = minI;
             if (maxDI > maxd) maxd = maxDI;
             if (minDI < mind) mind = minDI;
+
+            // widest pin wins: smallest non-null UserSetMin, largest non-null UserSetMax
+            if (axis.UserSetMinLimit is { } usMin && (userSetMin is null || usMin < userSetMin))
+                userSetMin = usMin;
+            if (axis.UserSetMaxLimit is { } usMax && (userSetMax is null || usMax > userSetMax))
+                userSetMax = usMax;
         }
 
         if (double.IsInfinity(minZoomDelta))
@@ -943,8 +959,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
         return new(min, max, minZoomDelta, mind, maxd)
         {
-            UserSetMin = _userSetMinLimit,
-            UserSetMax = _userSetMaxLimit,
+            UserSetMin = userSetMin,
+            UserSetMax = userSetMax,
         };
     }
 

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -63,6 +63,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     private TTextGeometry? _nameGeometry;
     private double? _minLimit = null;
     private double? _maxLimit = null;
+    private double? _userSetMinLimit = null;
+    private double? _userSetMaxLimit = null;
+    private bool _isEngineSettingLimits;
     private BaseLineGeometry? _ticksPath;
     private BaseLineGeometry? _zeroLine;
     private BaseLineGeometry? _crosshairLine;
@@ -142,6 +145,15 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             if (filtered is not null && double.IsNaN(filtered.Value))
                 filtered = null;
 
+            // Track the user-set pinning separately from the view min/max.
+            // The chart engine's zoom/pan path also lands here (via
+            // SetLimits(notify: true)) — that path raises _isEngineSettingLimits
+            // so the engine's transient view is NOT mistaken for a user pin.
+            // Without this guard the outer rail collapses onto the zoomed-out
+            // view and the bounce-back-to-fit is lost (#2159).
+            if (!_isEngineSettingLimits)
+                _userSetMinLimit = filtered;
+
             SetProperty(ref _minLimit, filtered);
         }
     }
@@ -156,6 +168,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
             if (filtered is not null && double.IsNaN(filtered.Value))
                 filtered = null;
+
+            if (!_isEngineSettingLimits)
+                _userSetMaxLimit = filtered;
 
             SetProperty(ref _maxLimit, filtered);
         }
@@ -926,7 +941,11 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             maxd = max;
         }
 
-        return new(min, max, minZoomDelta, mind, maxd);
+        return new(min, max, minZoomDelta, mind, maxd)
+        {
+            UserSetMin = _userSetMinLimit,
+            UserSetMax = _userSetMaxLimit,
+        };
     }
 
     /// <inheritdoc cref="ICartesianAxis.SetLimits(double, double, double, bool, bool)"/>
@@ -939,13 +958,25 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
         if (notify)
         {
-            MinLimit = min;
-            MaxLimit = max;
-
-            if (step > 0)
+            // notify: true still raises PropertyChanged so two-way MinLimit/
+            // MaxLimit bindings track zoom/pan — but _isEngineSettingLimits
+            // keeps the property setters from recording this engine-driven
+            // view change as a user pin (#2159).
+            _isEngineSettingLimits = true;
+            try
             {
-                ForceStepToMin = true;
-                MinStep = step;
+                MinLimit = min;
+                MaxLimit = max;
+
+                if (step > 0)
+                {
+                    ForceStepToMin = true;
+                    MinStep = step;
+                }
+            }
+            finally
+            {
+                _isEngineSettingLimits = false;
             }
         }
         else

--- a/src/LiveChartsCore/IInternalCartesianAxis.cs
+++ b/src/LiveChartsCore/IInternalCartesianAxis.cs
@@ -1,0 +1,44 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Defines internal members of a cartesian axis that are not part of the public
+/// <see cref="ICartesianAxis"/> contract.
+/// </summary>
+internal interface IInternalCartesianAxis
+{
+    /// <summary>
+    /// Gets the user-pinned <see cref="IPlane.MinLimit"/>, independent of the current view min the chart
+    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a min.
+    /// </summary>
+    double? UserSetMinLimit { get; }
+
+    /// <summary>
+    /// Gets the user-pinned <see cref="IPlane.MaxLimit"/>, independent of the current view max the chart
+    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a max.
+    /// </summary>
+    double? UserSetMaxLimit { get; }
+}

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -239,7 +239,10 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     AxisLimit GetLimits();
 
     /// <summary>
-    /// Sets the axis limits (own and shared).
+    /// Sets the current view limits (own and shared). This is the engine/runtime path used by zoom
+    /// and pan; it does <b>not</b> record a user pin. To pin a range that zoom-out and post-zoom fit
+    /// must respect as the outer rail, set <see cref="IPlane.MinLimit"/> / <see cref="IPlane.MaxLimit"/>
+    /// instead.
     /// </summary>
     /// <param name="min">The min limit.</param>
     /// <param name="max">The max limit.</param>

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -145,18 +145,6 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     IEnumerable<ICartesianAxis>? SharedWith { get; set; }
 
     /// <summary>
-    /// Gets the user-pinned <see cref="IPlane.MinLimit"/>, independent of the current view min the chart
-    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a min.
-    /// </summary>
-    double? UserSetMinLimit { get; }
-
-    /// <summary>
-    /// Gets the user-pinned <see cref="IPlane.MaxLimit"/>, independent of the current view max the chart
-    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a max.
-    /// </summary>
-    double? UserSetMaxLimit { get; }
-
-    /// <summary>
     /// Gets or sets the sub-separators paint.
     /// </summary>
     /// <value>

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -145,6 +145,18 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     IEnumerable<ICartesianAxis>? SharedWith { get; set; }
 
     /// <summary>
+    /// Gets the user-pinned <see cref="IPlane.MinLimit"/>, independent of the current view min the chart
+    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a min.
+    /// </summary>
+    double? UserSetMinLimit { get; }
+
+    /// <summary>
+    /// Gets the user-pinned <see cref="IPlane.MaxLimit"/>, independent of the current view max the chart
+    /// engine mutates via SetLimits during zoom/pan. <c>null</c> when the user never pinned a max.
+    /// </summary>
+    double? UserSetMaxLimit { get; }
+
+    /// <summary>
     /// Gets or sets the sub-separators paint.
     /// </summary>
     /// <value>

--- a/src/LiveChartsCore/Measure/AxisLimit.cs
+++ b/src/LiveChartsCore/Measure/AxisLimit.cs
@@ -62,6 +62,20 @@ public struct AxisLimit(double min, double max, double minDelta, double dataMin,
     public double MinDelta { get; set; } = minDelta;
 
     /// <summary>
+    /// Gets or sets the user-set <see cref="LiveChartsCore.Kernel.Sketches.IPlane.MinLimit"/>
+    /// pinning, independent of the current view min the chart engine may have mutated via
+    /// SetLimits during zoom/pan. <c>null</c> when the user never pinned a min.
+    /// </summary>
+    public double? UserSetMin { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user-set <see cref="LiveChartsCore.Kernel.Sketches.IPlane.MaxLimit"/>
+    /// pinning, independent of the current view max the chart engine may have mutated via
+    /// SetLimits during zoom/pan. <c>null</c> when the user never pinned a max.
+    /// </summary>
+    public double? UserSetMax { get; set; }
+
+    /// <summary>
     /// Validates the limits of the axis, if the limits are not defined.
     /// </summary>
     /// <param name="min">The possible min value.</param>

--- a/tests/CoreTests/OtherTests/Issue2159ZoomLimitsTests.cs
+++ b/tests/CoreTests/OtherTests/Issue2159ZoomLimitsTests.cs
@@ -1,0 +1,283 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class Issue2159ZoomLimitsTests
+{
+    // Issue #2159: user pins XAxis MinLimit=0, MaxLimit=180 on a 10-point
+    // series (X data ≈ [0, 9]). Before the fix, the zoom-out clamp + the
+    // debounced post-zoom Fit both used DataMin/DataMax as the outer rail,
+    // so on the first wheel zoom-out the view collapsed to the data bounds
+    // and the user's pinned [0, 180] was permanently lost. From then on
+    // every further wheel zoom looked like "can only shrink / zoom-in does
+    // nothing" because the view was trapped at data scale.
+
+    private static (Axis xAxis, CartesianChartEngine core) CreateReporterChart()
+    {
+        var xAxis = new Axis { MinLimit = 0, MaxLimit = 180, MinStep = 10 };
+        var yAxis = new Axis { MinLimit = -10, MaxLimit = 110, MinStep = 10 };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [xAxis],
+            YAxes = [yAxis],
+            Series =
+            [
+                new LineSeries<double>
+                {
+                    Values = [10d, 50d, 30d, 80d, 20d, 60d, 40d, 70d, 35d, 55d]
+                }
+            ]
+        };
+        _ = chart.GetImage();
+        var core = (CartesianChartEngine)chart.CoreChart;
+        return (xAxis, core);
+    }
+
+    // Same data and viewport as the reporter chart, but with NO pinned
+    // MinLimit/MaxLimit. This is the "bounce" baseline: the engine is free
+    // to fit the view to the data, and zoom-out must overshoot then snap
+    // back. The #2159 fix must not break this for unpinned axes.
+    private static (Axis xAxis, CartesianChartEngine core) CreateUnpinnedChart()
+    {
+        var xAxis = new Axis();
+        var yAxis = new Axis();
+
+        var chart = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [xAxis],
+            YAxes = [yAxis],
+            Series =
+            [
+                new LineSeries<double>
+                {
+                    Values = [10d, 50d, 30d, 80d, 20d, 60d, 40d, 70d, 35d, 55d]
+                }
+            ]
+        };
+        _ = chart.GetImage();
+        var core = (CartesianChartEngine)chart.CoreChart;
+        return (xAxis, core);
+    }
+
+    [TestMethod]
+    public void ZoomOut_OnAxisPinnedWiderThanData_GrowsTheView()
+    {
+        // From a pinned [0, 180] view the natural expectation is "zoom-out
+        // makes the visible range larger." Pre-fix, the outer rail was the
+        // data bounds (~[0, 9]) plus BouncingDistance threshold, so a single
+        // zoom-out actually SHRANK the visible range — the user's pinned
+        // [0, 180] was lost on the first wheel tick.
+        var (xAxis, core) = CreateReporterChart();
+        var pivot = new LvcPoint(400, 200);
+
+        var rangeBefore = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+        core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+        var rangeAfter = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        Assert.IsTrue(rangeAfter > rangeBefore,
+            $"ZoomOut must grow the visible range from a user-pinned view; before={rangeBefore}, after={rangeAfter}.");
+    }
+
+    [TestMethod]
+    public void ZoomIn_ThenZoomOut_RestoresViewToOrBeyondUserPinning()
+    {
+        // The basic reversibility users expect: zooming in then zooming out
+        // by the same amount should return to (or wider than) the original
+        // pinned view. Pre-fix this never came back because zoom-out was
+        // trapped at data bounds.
+        var (xAxis, core) = CreateReporterChart();
+        var pivot = new LvcPoint(400, 200);
+
+        core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomIn);
+        var inMax = xAxis.MaxLimit!.Value;
+        Assert.IsTrue(inMax < 180,
+            $"ZoomIn from [0, 180] should narrow MaxLimit below 180; got {inMax}.");
+
+        for (var i = 0; i < 6; i++)
+            core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+
+        var finalMin = xAxis.MinLimit!.Value;
+        var finalMax = xAxis.MaxLimit!.Value;
+
+        Assert.IsTrue(finalMin <= 0 + 1e-6,
+            $"Repeated ZoomOut must allow the view to return to the user-pinned MinLimit=0; got Min={finalMin}.");
+        Assert.IsTrue(finalMax >= 180 - 1e-6,
+            $"Repeated ZoomOut must allow the view to return to the user-pinned MaxLimit=180; got Max={finalMax}.");
+    }
+
+    [TestMethod]
+    public async Task FitAfterZoom_DoesNotSnapPinnedWiderViewToDataBounds()
+    {
+        // The post-zoom FitAllOnZoom (300 ms debounced) was the second half
+        // of the bug: even when a single ZoomAxis call left the view
+        // reasonable, the deferred Fit then snapped MinLimit/MaxLimit down
+        // to DataMin/DataMax (the source-of-truth for the second symptom in
+        // the report: "MinLimit/MaxLimit have no effect").
+        var (xAxis, core) = CreateReporterChart();
+        var pivot = new LvcPoint(400, 200);
+
+        core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomIn);
+        await Task.Delay(450); // past the 300 ms zoom-fit debounce
+
+        var minAfter = xAxis.MinLimit!.Value;
+        var maxAfter = xAxis.MaxLimit!.Value;
+
+        Assert.IsTrue(maxAfter > minAfter,
+            $"FitAllOnZoom must not produce a degenerate range; got X=[{minAfter}, {maxAfter}].");
+        // Data X data range is [0, 9]; if Fit snapped to data bounds we'd
+        // see MaxLimit ≤ ~10 here. Anything meaningfully wider proves the
+        // pinned-outer-rail path is engaged.
+        Assert.IsTrue(maxAfter > 20,
+            $"FitAllOnZoom must not snap a pinned-wider view to data bounds; got X=[{minAfter}, {maxAfter}].");
+    }
+
+    // ----------------------------------------------------------------------
+    // Bounce-back regression coverage.
+    //
+    // PR #2240's first attempt recorded the user pin inside the
+    // MinLimit/MaxLimit property setter. But the chart engine's own zoom and
+    // pan writes land in that same setter (via SetLimits(notify: true)), so
+    // every interaction was misrecorded as a "user pin". For an UNPINNED
+    // chart that silently turned the engine's zoomed-out / panned view into
+    // the outer rail, and the bounce-back-to-fit stopped working. These tests
+    // pin that behaviour down for both zoom and pan.
+    // ----------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task ZoomOut_OnUnpinnedChart_BouncesBackToFitDataBounds()
+    {
+        // Unpinned chart: a wheel zoom-out is allowed to overshoot the data
+        // bounds by BouncingDistance, then the 300 ms debounced FitAllOnZoom
+        // must snap the view back so it fits the data again.
+        var (xAxis, core) = CreateUnpinnedChart();
+        var pivot = new LvcPoint(400, 200);
+
+        core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+
+        // Right after the zoom (before the debounce) the view has overshot.
+        var overshootRange = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        await Task.Delay(450); // past the 300 ms FitAllOnZoom debounce
+
+        var fittedRange = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        Assert.IsTrue(fittedRange < overshootRange,
+            $"FitAllOnZoom must shrink the overshot view back toward the data " +
+            $"bounds; overshoot range={overshootRange}, fitted range={fittedRange}.");
+
+        // Data X spans indices [0, 9] (range 9). After the bounce the view
+        // must land near that, not stay stuck at the zoomed-out overshoot.
+        Assert.IsTrue(fittedRange < 9 * 1.5,
+            $"FitAllOnZoom must land near the ~9 data range, not the zoomed-out " +
+            $"range; got fitted range={fittedRange}.");
+    }
+
+    [TestMethod]
+    public async Task RepeatedZoomOut_OnUnpinnedChart_KeepsBouncingBack()
+    {
+        // The first attempt's pollution compounded: every wheel tick widened
+        // the misrecorded "pin", so the view ran away. Repeated zoom-out on an
+        // unpinned chart must keep settling back to the data fit.
+        var (xAxis, core) = CreateUnpinnedChart();
+        var pivot = new LvcPoint(400, 200);
+
+        for (var i = 0; i < 5; i++)
+        {
+            core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+            await Task.Delay(450);
+        }
+
+        var fittedRange = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        Assert.IsTrue(fittedRange < 9 * 1.5,
+            $"Repeated zoom-out must keep bouncing back to the ~9 data range; " +
+            $"got fitted range={fittedRange} after 5 ticks.");
+    }
+
+    [TestMethod]
+    public async Task PanThenZoomOut_OnUnpinnedChart_StillBouncesBack()
+    {
+        // A pan also writes the axis limits through SetLimits(notify: true).
+        // The first attempt let that pan write masquerade as a user pin, so a
+        // zoom-out *after* a pan had its bounce-back rail collapsed onto the
+        // panned view.
+        var (xAxis, core) = CreateUnpinnedChart();
+        var pivot = new LvcPoint(400, 200);
+
+        core.Pan(ZoomAndPanMode.Both, new LvcPoint(40, 0));
+        core.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+
+        var overshootRange = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        await Task.Delay(450);
+
+        var fittedRange = xAxis.MaxLimit!.Value - xAxis.MinLimit!.Value;
+
+        Assert.IsTrue(fittedRange < overshootRange,
+            $"After a pan, zoom-out must still bounce back; overshoot " +
+            $"range={overshootRange}, fitted range={fittedRange}.");
+        Assert.IsTrue(fittedRange < 9 * 1.5,
+            $"After a pan, zoom-out must still fit the ~9 data range; got " +
+            $"fitted range={fittedRange}.");
+    }
+
+    [TestMethod]
+    public void Pan_OnUnpinnedChart_CannotEscapeDataBoundsRail()
+    {
+        // Panning hard past the data must clamp: the visible window stays
+        // anchored within BouncingDistance of the data bounds instead of
+        // scrolling into empty space forever.
+        var (xAxis, core) = CreateUnpinnedChart();
+
+        for (var i = 0; i < 20; i++)
+            core.Pan(ZoomAndPanMode.Both, new LvcPoint(200, 0));
+
+        var min = xAxis.MinLimit!.Value;
+        var max = xAxis.MaxLimit!.Value;
+
+        // Data X spans [0, 9]. The clamp keeps the window overlapping the data
+        // and no more than one BouncingDistance past DataMax — without it,
+        // 20 pans of 200 px would scroll the view far into empty space.
+        Assert.IsTrue(min <= 9 && max >= 0,
+            $"Pan must keep the data within view; got X=[{min}, {max}].");
+        Assert.IsTrue(max < 20,
+            $"Pan must clamp to the data-bounds rail; a runaway pan would put " +
+            $"MaxLimit far past the ~9 data max, got {max}.");
+    }
+}

--- a/tests/CoreTests/OtherTests/Issue2159ZoomLimitsTests.cs
+++ b/tests/CoreTests/OtherTests/Issue2159ZoomLimitsTests.cs
@@ -280,4 +280,93 @@ public class Issue2159ZoomLimitsTests
             $"Pan must clamp to the data-bounds rail; a runaway pan would put " +
             $"MaxLimit far past the ~9 data max, got {max}.");
     }
+
+    // ----------------------------------------------------------------------
+    // Shared-axes coverage (PR #2240 review).
+    //
+    // SharedAxes.Set keeps a group of axes' view limits in sync, and
+    // CoreAxis.GetLimits() already aggregates Min/Max/DataMin/DataMax across
+    // the SharedWith group. The user pin (UserSetMin/UserSetMax) must be
+    // aggregated the same way — otherwise a zoom started from an UNPINNED
+    // shared axis falls back to the ~data range as its outer rail, and
+    // SetLimits then propagates that collapse onto a pinned sibling.
+    // ----------------------------------------------------------------------
+
+    // Two charts whose X axes are a shared group: chart 1's X is pinned
+    // wider than the data ([0, 180]), chart 2's X is unpinned. Both charts
+    // carry the same 10-point series (X data ≈ [0, 9]).
+    private static (Axis pinnedX, CartesianChartEngine unpinnedCore) CreateSharedPinnedAndUnpinnedCharts()
+    {
+        var pinnedX = new Axis { MinLimit = 0, MaxLimit = 180, MinStep = 10 };
+        var unpinnedX = new Axis();
+
+        SharedAxes.Set(pinnedX, unpinnedX);
+
+        var pinnedChart = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [pinnedX],
+            YAxes = [new Axis()],
+            Series =
+            [
+                new LineSeries<double>
+                {
+                    Values = [10d, 50d, 30d, 80d, 20d, 60d, 40d, 70d, 35d, 55d]
+                }
+            ]
+        };
+        var unpinnedChart = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [unpinnedX],
+            YAxes = [new Axis()],
+            Series =
+            [
+                new LineSeries<double>
+                {
+                    Values = [10d, 50d, 30d, 80d, 20d, 60d, 40d, 70d, 35d, 55d]
+                }
+            ]
+        };
+
+        _ = pinnedChart.GetImage();
+        _ = unpinnedChart.GetImage();
+
+        return (pinnedX, (CartesianChartEngine)unpinnedChart.CoreChart);
+    }
+
+    [TestMethod]
+    public void ZoomFromUnpinnedSharedAxis_DoesNotCollapsePinnedSibling()
+    {
+        // The wheel zoom-out happens on the chart whose shared axis is NOT
+        // pinned. GetLimits() must still surface the sibling's pin as the
+        // outer rail; before the fix it aggregated Min/Max/DataMin/DataMax
+        // across SharedWith but not UserSetMin/UserSetMax, so the unpinned
+        // axis fell back to the ~9 data range and SetLimits propagated that
+        // collapse back onto the pinned sibling.
+        var (pinnedX, unpinnedCore) = CreateSharedPinnedAndUnpinnedCharts();
+        var pivot = new LvcPoint(400, 200);
+
+        var rangeBefore = pinnedX.MaxLimit!.Value - pinnedX.MinLimit!.Value; // 180
+
+        unpinnedCore.Zoom(ZoomAndPanMode.Both, pivot, ZoomDirection.ZoomOut);
+
+        var minAfter = pinnedX.MinLimit!.Value;
+        var maxAfter = pinnedX.MaxLimit!.Value;
+        var rangeAfter = maxAfter - minAfter;
+
+        Assert.IsTrue(rangeAfter > rangeBefore,
+            $"Zoom-out from an unpinned shared axis must grow — not collapse — the " +
+            $"pinned sibling's view; before={rangeBefore}, after={rangeAfter}.");
+        // The pin [0, 180] must stay within view: a zoom-out only grows it.
+        // Pre-fix the sibling collapsed toward the ~9 data range, leaving
+        // MaxLimit far below 180.
+        Assert.IsTrue(maxAfter >= 180 - 1e-6 && minAfter <= 0 + 1e-6,
+            $"Zoom-out from an unpinned shared axis must keep the pinned sibling's " +
+            $"[0, 180] pin within view; got X=[{minAfter}, {maxAfter}].");
+    }
 }

--- a/tests/CoreTests/OtherTests/SharedAxesTests.cs
+++ b/tests/CoreTests/OtherTests/SharedAxesTests.cs
@@ -1,0 +1,167 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Linq;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class SharedAxesTests
+{
+    // SharedAxes.Set links a group of axes so they zoom/pan together and a
+    // measure on one chart contributes its data bounds to the others. The
+    // feature had no dedicated coverage; these tests pin down the contract
+    // (group wiring, SetLimits propagation, GetLimits aggregation, zoom
+    // propagation). #2159's shared-axes regression lives separately in
+    // Issue2159ZoomLimitsTests.
+
+    // Two charts whose X axes are a shared group, each carrying its own
+    // line series so the axes get real data bounds after a measure.
+    private static (Axis ax1, Axis ax2, CartesianChartEngine core1, CartesianChartEngine core2)
+        CreateSharedCharts(double[] data1, double[] data2)
+    {
+        var ax1 = new Axis();
+        var ax2 = new Axis();
+
+        SharedAxes.Set(ax1, ax2);
+
+        var chart1 = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [ax1],
+            YAxes = [new Axis()],
+            Series = [new LineSeries<double> { Values = data1 }]
+        };
+        var chart2 = new SKCartesianChart
+        {
+            Width = 800,
+            Height = 400,
+            ZoomMode = ZoomAndPanMode.Both,
+            XAxes = [ax2],
+            YAxes = [new Axis()],
+            Series = [new LineSeries<double> { Values = data2 }]
+        };
+
+        _ = chart1.GetImage();
+        _ = chart2.GetImage();
+
+        return (ax1, ax2, (CartesianChartEngine)chart1.CoreChart, (CartesianChartEngine)chart2.CoreChart);
+    }
+
+    [TestMethod]
+    public void Set_WiresSharedWithBothWays_AndExcludesSelf()
+    {
+        var a = new Axis();
+        var b = new Axis();
+        var c = new Axis();
+
+        SharedAxes.Set(a, b, c);
+
+        var aShared = a.SharedWith!.ToList();
+        var bShared = b.SharedWith!.ToList();
+        var cShared = c.SharedWith!.ToList();
+
+        // each axis is shared with every OTHER axis in the group, never itself
+        CollectionAssert.AreEquivalent(new ICartesianAxis[] { b, c }, aShared);
+        CollectionAssert.AreEquivalent(new ICartesianAxis[] { a, c }, bShared);
+        CollectionAssert.AreEquivalent(new ICartesianAxis[] { a, b }, cShared);
+    }
+
+    [TestMethod]
+    public void SetLimits_PropagatesAcrossTheSharedGroup()
+    {
+        var a = new Axis();
+        var b = new Axis();
+        var c = new Axis();
+        SharedAxes.Set(a, b, c);
+
+        ((ICartesianAxis)a).SetLimits(5, 25);
+
+        // the limits set on one axis must land on every sibling
+        Assert.AreEqual(5, b.MinLimit);
+        Assert.AreEqual(25, b.MaxLimit);
+        Assert.AreEqual(5, c.MinLimit);
+        Assert.AreEqual(25, c.MaxLimit);
+    }
+
+    [TestMethod]
+    public void SetLimits_WithPropagateSharedFalse_StaysLocal()
+    {
+        var a = new Axis();
+        var b = new Axis();
+        SharedAxes.Set(a, b);
+
+        ((ICartesianAxis)a).SetLimits(5, 25, propagateShared: false);
+
+        Assert.AreEqual(5, a.MinLimit);
+        Assert.IsNull(b.MinLimit,
+            "propagateShared: false must keep the change off the shared siblings.");
+        Assert.IsNull(b.MaxLimit,
+            "propagateShared: false must keep the change off the shared siblings.");
+    }
+
+    [TestMethod]
+    public void GetLimits_UnionsViewAndDataBoundsAcrossSharedGroup()
+    {
+        // chart1 X data spans indices [0, 9], chart2 X data spans [0, 4].
+        var (ax1, ax2, _, _) = CreateSharedCharts(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [1, 2, 3, 4, 5]);
+
+        // a pin on one axis must surface as the view max of the whole group
+        ax1.MaxLimit = 100;
+
+        var limits = ((ICartesianAxis)ax2).GetLimits();
+
+        Assert.AreEqual(100, limits.Max,
+            "GetLimits() must surface a sibling's pinned MaxLimit as the group view max.");
+        // ax2's own series only reaches X index 4; seeing 9 proves the wider
+        // sibling's data bounds were unioned in (via AppendLimits + GetLimits).
+        Assert.IsTrue(limits.DataMax >= 9 - 1e-6,
+            $"GetLimits() must union DataMax across the shared group; got {limits.DataMax}.");
+    }
+
+    [TestMethod]
+    public void Zoom_OnOneChart_PropagatesLimitsToSharedSibling()
+    {
+        var (ax1, ax2, core1, _) = CreateSharedCharts(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [1, 2, 3, 4, 5]);
+
+        core1.Zoom(ZoomAndPanMode.Both, new LvcPoint(400, 200), ZoomDirection.ZoomIn);
+
+        Assert.IsNotNull(ax1.MinLimit, "ZoomIn must assign the zoomed axis a concrete MinLimit.");
+        Assert.AreEqual(ax1.MinLimit, ax2.MinLimit,
+            "A zoom on one chart must propagate the new MinLimit to its shared sibling.");
+        Assert.AreEqual(ax1.MaxLimit, ax2.MaxLimit,
+            "A zoom on one chart must propagate the new MaxLimit to its shared sibling.");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #2159
- Zoom-out + post-zoom Fit no longer destroy a user-pinned `MinLimit`/`MaxLimit` wider than the data range.
- New `AxisLimit.UserSetMin` / `UserSetMax` surface the user-pinned values (independent of the engine's view-side mutations) so the zoom math can use them as the outer rail.
- The user pin is recorded **only** on a genuine user/binding assignment — the engine's own zoom/pan writes are no longer mistaken for pins.

## Why

The reporter pinned `XAxes: { MinLimit = 0, MaxLimit = 180, MinStep = 10 }` on a 10-point series (X data ≈ `[0, 9]`). On the first wheel zoom-out the visible range *shrank*; on the next it degenerated.

Root cause: both `CartesianChartEngine.ZoomAxis` (zoom-out branch) and `FitAllOnZoom.Fit` used `DataMin` / `DataMax` as the outer rail. When the user's pinning extended past the data, the rail was *narrower* than the pin, so the first wheel zoom-out snapped the view down to data scale and `_minLimit` / `_maxLimit` were overwritten to that narrower range. From then on every wheel tick worked off the collapsed view.

The fix surfaces the user's pin as the outer rail:

- `CoreAxis` tracks `_userSetMinLimit` / `_userSetMaxLimit`.
- `GetLimits()` surfaces them on `AxisLimit.UserSetMin` / `UserSetMax`.
- `ZoomAxis` zoom-out and `FitAllOnZoom.Fit` use `Math.Min(UserSetMin, DataMin)` / `Math.Max(UserSetMax, DataMax)` for the outer rail — whichever is wider. Unpinned axes fall back to data bounds (previous behaviour).

## What changed since the first push

The first attempt recorded the user pin **unconditionally inside the `MinLimit`/`MaxLimit` property setters**. But the chart engine's own zoom/pan writes also land in those setters (via `SetLimits(notify: true)` — the `ICartesianAxis` interface default). So every wheel tick / pan was misrecorded as a "user pin": the outer rail collapsed onto the engine's zoomed-out view, and **the bounce-back-to-fit stopped working for every chart, pinned or not** — zoom-out overshot and never snapped back.

The corrected approach: `SetLimits` raises a new `_isEngineSettingLimits` guard around its `notify` path. `PropertyChanged` still fires (two-way `MinLimit`/`MaxLimit` bindings keep tracking zoom/pan), but the property setters skip recording the engine-driven view change as a user pin. Only genuine user/binding assignments mark a pin.

## Test plan

- [x] `dotnet test tests/CoreTests/CoreTests.csproj --framework net8.0` — 521/521 passing
- [x] `Issue2159ZoomLimitsTests` — 7 assertions, each fails when the fix is reverted (verified by stashing only the `CoreAxis` guard between runs: 3 of the unpinned bounce tests fail without it):
  - **Pinned wider than data:** `ZoomOut_OnAxisPinnedWiderThanData_GrowsTheView`, `ZoomIn_ThenZoomOut_RestoresViewToOrBeyondUserPinning`, `FitAfterZoom_DoesNotSnapPinnedWiderViewToDataBounds`
  - **Unpinned bounce-back (the regression the first attempt introduced):** `ZoomOut_OnUnpinnedChart_BouncesBackToFitDataBounds`, `RepeatedZoomOut_OnUnpinnedChart_KeepsBouncingBack`, `PanThenZoomOut_OnUnpinnedChart_StillBouncesBack`, `Pan_OnUnpinnedChart_CannotEscapeDataBoundsRail`
- [x] `ChartInteractiveApiTests` (26 tests) unchanged

Note: the third symptom the reporter described — right-drag becoming a pan instead of a zoom-to-rectangle — is `ZoomAndPanMode.InvertPanningPointerTrigger` working as documented; explained inline on the issue, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)