### PR TITLE
fix(designer): skip Chart.Load when View.DesignerMode is true (#2182)

### DIFF
--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -346,6 +346,13 @@ public abstract class Chart
     /// </summary>
     public virtual void Load()
     {
+        // At design time GetTheme below would JIT-load SkiaSharp paint types via
+        // ThemesExtensions.AddDefaultTheme initializers, which crashes the .NET
+        // Framework WinForms designer host on strong-name binding (#2182).
+        // SkiaSharp's SKElement/SKControl already short-circuit paint at design
+        // time, so there's nothing to set up.
+        if (View.DesignerMode) return;
+
         IsLoaded = true;
         _isFirstDraw = true;
         var theme = GetTheme();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKChart.cs
@@ -58,7 +58,14 @@ public abstract partial class SourceGenSKChart : InMemorySkiaSharpChart
         CoreChart?.Load();
     }
 
-    bool IChartView.DesignerMode => false;
+    /// <summary>
+    /// Whether this in-memory chart reports itself as running in a designer
+    /// host. Always <c>false</c> in production; test fixtures override to
+    /// exercise the design-time short-circuit in <see cref="Chart.Load"/>.
+    /// </summary>
+    protected virtual bool IsDesignerMode => false;
+
+    bool IChartView.DesignerMode => IsDesignerMode;
     bool IChartView.IsDarkMode => false;
     LvcColor IChartView.BackColor => Background.AsLvcColor();
     LvcSize IDrawnView.ControlSize => new() { Width = Width, Height = Height };

--- a/tests/CoreTests/ChartTests/ChartTests.cs
+++ b/tests/CoreTests/ChartTests/ChartTests.cs
@@ -119,4 +119,24 @@ public class ChartTests
 
         Assert.IsTrue(image is not null);
     }
+
+    // https://github.com/Live-Charts/LiveCharts2/issues/2182
+    // Chart.Load() must short-circuit when the host reports designer mode,
+    // otherwise the theme initializer JIT-loads SkiaSharp paint types and the
+    // .NET Framework WinForms designer host crashes on strong-name binding.
+    [TestMethod]
+    public void DesignerModeShortCircuitsLoad()
+    {
+        var chart = new DesignerSKCartesianChart();
+
+        Assert.IsFalse(
+            chart.CoreChart.IsLoaded,
+            "Chart.Load() ran in designer mode — the theme initializer would " +
+            "JIT-load SkiaSharp and crash the WinForms designer host (#2182).");
+    }
+
+    private sealed class DesignerSKCartesianChart : SKCartesianChart
+    {
+        protected override bool IsDesignerMode => true;
+    }
 }


### PR DESCRIPTION
Closes #2182.

## Summary

- Adds a one-line guard at the top of `Chart.Load()` that returns when `View.DesignerMode` is true. Pre-fix the property was plumbed across every view assembly but only `GeoMapChart` consulted it — Cartesian/Pie/Polar inherited the unguarded base, so the WinForms designer host ran the full theme initializer.
- Adds a `protected virtual bool IsDesignerMode` hook on `SourceGenSKChart` so a test subclass can flip the explicit `IChartView.DesignerMode` impl, and a regression test that asserts `chart.CoreChart.IsLoaded` stays `false`. Test verified to fail on the parent commit.

## Why this stops the crash

WinForms designer host → `OnParentChanged` → `CoreChart.Load()` → `GetTheme()` → `theme.Setup(...)` runs the `OnInitialized` callbacks registered by `LiveChartsCore.SkiaSharpView.ThemesExtensions.AddDefaultTheme` → those construct `SolidColorPaint` etc. → JIT-load `SkiaSharp.dll`. Under .NET Framework strong-name binding the designer host demands exact-version `SkiaSharp, Version=2.88.0.0`, which the consumer's runtime asset graph does not satisfy → `FileNotFoundException`. Guarding `Load` short-circuits before any SkiaSharp type is touched.

## What this does NOT do

It does not produce a designer preview. SkiaSharp's `SKElement.OnRender` (WPF) and `SKControl.OnPaint` (WinForms) both `return` at the top when `DesignerProperties.GetIsInDesignMode(this)` / `DesignMode` is true (still the case on current `main` of mono/SkiaSharp). After this fix the WinForms designer stops throwing and shows an empty rectangle. Hot-reload remains the only path; Avalonia is still the only platform with a real preview because the Avalonia team ships its own design surface that loads SkiaSharp.

## Test plan

- [x] `dotnet test tests/CoreTests/CoreTests.csproj --framework net8.0` — 515/515 passed
- [x] New `ChartTests.DesignerModeShortCircuitsLoad` passes with fix, fails without (verified by `git checkout HEAD~1 -- src/LiveChartsCore/Chart.cs` then re-running)
- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/...csproj -f net8.0-windows` clean
- [ ] Manual confirmation in VS WinForms designer (cannot automate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)