### PR TITLE
fix(maui): drop Microsoft.Maui.Controls.Compatibility ref (#2185)

### DIFF
--- a/samples/MauiSample/MauiSample.csproj
+++ b/samples/MauiSample/MauiSample.csproj
@@ -68,7 +68,6 @@
   <ItemGroup>
     <ProjectReference Include="..\ViewModelsSamples\ViewModelsSamples.csproj" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <!--<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MauiVersion)" />-->
   </ItemGroup>
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj
@@ -65,7 +65,6 @@
 	  <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="$(LatestSkiaSharpVersion)" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="$(LatestSkiaSharpVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(LvcMauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(LvcMauiVersion)" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- `LiveChartsCore.SkiaSharpView.Maui` was leaking `Microsoft.Maui.Controls.Compatibility` (the Xamarin.Forms compat layer) into every consumer's dep graph (reported in #2185).
- The package is unused by LiveCharts2 source (zero `using Microsoft.Maui.Controls.Compatibility` hits) and is not a transitive of `SkiaSharp.Views.Maui.Controls` — it was a leftover top-level ref from early MAUI days.
- Keeps the `Microsoft.Maui.Controls` ref intact: it's still doing real work as the [dotnet/maui#26952](https://github.com/dotnet/maui/issues/26952) workaround that bumps SkiaSharp's `8.0.82` floor up to the consumer's MAUI major on net9/net10.
- Also drops the matching ref from `samples/MauiSample/MauiSample.csproj` for consistency.

## Verification

Before:
```
> Microsoft.Maui.Controls                    10.0.0
> Microsoft.Maui.Controls.Compatibility      10.0.0
> SkiaSharp.Views.Maui.Controls              3.119.1
…
```

After (`dotnet list package --include-transitive`): `Microsoft.Maui.Controls.Compatibility` no longer appears top-level or transitively across any TFM (net9/net10 × android/ios/maccatalyst/windows).

`dotnet build src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/LiveChartsCore.SkiaSharpView.Maui.csproj -f net10.0` → 0 errors.

## Test plan
- [x] Confirm no source file uses `Microsoft.Maui.Controls.Compatibility` namespace
- [x] Build `LiveChartsCore.SkiaSharpView.Maui` for `net10.0` — clean
- [x] `dotnet list package --include-transitive` shows Compatibility is gone
- [ ] Factos MAUI run (CI)

Closes #2185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)