### PR TITLE
fix(wpf): null-guard CompositionTargetTicker.DisposeTicker (#2216)

### DIFF
--- a/src/LiveChartsCore/Motion/AsyncLoopTicker.cs
+++ b/src/LiveChartsCore/Motion/AsyncLoopTicker.cs
@@ -58,7 +58,10 @@ internal class AsyncLoopTicker : IFrameTicker
 
     public void DisposeTicker()
     {
-        _canvas.Invalidated -= OnCoreInvalidated;
+        // _canvas can be null when DisposeTicker is called without a prior
+        // InitializeTicker, or twice in a row. The WPF sibling
+        // CompositionTargetTicker hits this in #2216; same shape applies here.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;

--- a/src/_Shared.Native/Platforms/Android/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/Android/NativeTicker.cs
@@ -58,11 +58,14 @@ internal partial class NativeFrameTicker : IFrameTicker
 
     public void DisposeTicker()
     {
-        _canvas.Invalidated -= OnCoreInvalidated;
+        // _canvas / _vsyncTicker can be null when DisposeTicker is called
+        // without a prior InitializeTicker, or twice in a row — same #2216
+        // contract violation guarded in the WPF CompositionTargetTicker.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;
-        _vsyncTicker.Stop();
+        _vsyncTicker?.Stop();
         _vsyncTicker = null!;
     }
 

--- a/src/_Shared.Native/Platforms/Mac/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/Mac/NativeTicker.cs
@@ -59,12 +59,15 @@ internal partial class NativeFrameTicker : IFrameTicker
 
     public void DisposeTicker()
     {
-        _canvas.Invalidated -= OnCoreInvalidated;
+        // _canvas / _displayLink can be null when DisposeTicker is called
+        // without a prior InitializeTicker, or twice in a row — same #2216
+        // contract violation guarded in the WPF CompositionTargetTicker.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;
-        _displayLink.Invalidate();
-        _displayLink.Dispose();
+        _displayLink?.Invalidate();
+        _displayLink?.Dispose();
         _displayLink = null!;
     }
 }

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
@@ -61,7 +61,11 @@ internal partial class NativeFrameTicker : IFrameTicker
     public void DisposeTicker()
     {
         CompositionTarget.Rendering -= OnCompositonTargetRendering;
-        _canvas?.Invalidated -= OnCoreInvalidated;
+
+        // _canvas can be null when DisposeTicker is called without a prior
+        // InitializeTicker, or twice in a row — same #2216 contract violation
+        // guarded in the WPF CompositionTargetTicker.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;

--- a/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
@@ -57,7 +57,11 @@ internal partial class NativeFrameTicker : IFrameTicker
     public void DisposeTicker()
     {
         CompositionTarget.Rendering -= OnCompositonTargetRendering;
-        _canvas?.Invalidated -= OnCoreInvalidated;
+
+        // _canvas can be null when DisposeTicker is called without a prior
+        // InitializeTicker, or twice in a row — same #2216 contract violation
+        // guarded in the WPF CompositionTargetTicker.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/CompositionTargetTicker.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/Rendering/CompositionTargetTicker.cs
@@ -54,7 +54,12 @@ internal class CompositionTargetTicker : IFrameTicker
     public void DisposeTicker()
     {
         CompositionTarget.Rendering -= OnCompositonTargetRendering;
-        _canvas.Invalidated -= OnCoreInvalidated;
+
+        // _canvas can be null if Unloaded fires on a MotionCanvas whose Loaded
+        // never ran (Prism-style ContentControl swaps where a TabControl
+        // hosting the chart is removed while a different tab is active) or
+        // if Dispose runs twice — both seen in #2216.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Rendering/ApplicationIdleTicker.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/Rendering/ApplicationIdleTicker.cs
@@ -52,7 +52,11 @@ internal class ApplicationIdleTicker : IFrameTicker
     public void DisposeTicker()
     {
         Application.Idle -= OnApplicationIdle;
-        _canvas.Invalidated -= OnCoreInvalidated;
+
+        // _canvas can be null when DisposeTicker is called without a prior
+        // InitializeTicker, or twice in a row — same #2216 contract violation
+        // guarded in the WPF CompositionTargetTicker.
+        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
 
         _canvas = null!;
         _renderMode = null!;

--- a/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
+++ b/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
@@ -1,0 +1,52 @@
+using LiveChartsCore.Motion;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+[TestClass]
+public class FrameTickerTesting
+{
+    // Regression for #2216. The reporter sees an NRE in
+    // CompositionTargetTicker.DisposeTicker on WPF when a Prism-style
+    // ContentControl swap unloads a TabControl that hosts a chart while the
+    // chart tab is not the active one — Unloaded fires on the MotionCanvas
+    // without the ticker ever having been initialized (or with a previous
+    // DisposeTicker already having nulled _canvas), and the unsubscribe of
+    // _canvas.Invalidated dereferences null.
+    //
+    // The fix is a defensive null guard on the ticker's DisposeTicker(). The
+    // contract is: it must be safe to call DisposeTicker even when
+    // InitializeTicker was never called, or when DisposeTicker was already
+    // called. CompositionTargetTicker is WPF-internal and not reachable from
+    // CoreTests, but AsyncLoopTicker is the parallel core-side implementation
+    // and shares the same null-deref shape — fixing one without the other
+    // would just relocate the bug.
+    [TestMethod]
+    public void AsyncLoopTicker_DisposeWithoutInitialize_DoesNotThrow()
+    {
+        var ticker = new AsyncLoopTicker();
+
+        ticker.DisposeTicker();
+    }
+
+    [TestMethod]
+    public void AsyncLoopTicker_DoubleDispose_DoesNotThrow()
+    {
+        var ticker = new AsyncLoopTicker();
+        var canvas = new CoreMotionCanvas();
+        var renderMode = new NoopRenderMode();
+
+        ticker.InitializeTicker(canvas, renderMode);
+        ticker.DisposeTicker();
+        ticker.DisposeTicker();
+    }
+
+    private sealed class NoopRenderMode : IRenderMode
+    {
+        public event CoreMotionCanvas.FrameRequestHandler FrameRequest { add { } remove { } }
+
+        public void InitializeRenderMode(CoreMotionCanvas canvas) { }
+        public void DisposeRenderMode() { }
+        public void InvalidateRenderer() { }
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
+++ b/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
@@ -21,6 +21,16 @@ public class FrameTickerTesting
     // CoreTests, but AsyncLoopTicker is the parallel core-side implementation
     // and shares the same null-deref shape — fixing one without the other
     // would just relocate the bug.
+    //
+    // Every IFrameTicker implementation was audited for the same shape:
+    // ApplicationIdleTicker (WinForms) and the Android / iOS-MacCatalyst
+    // NativeFrameTicker partials had the unguarded _canvas.Invalidated -=
+    // (Android / Mac also dereferenced _vsyncTicker / _displayLink) and were
+    // guarded the same way. The WinUI and Uno-Skia NativeFrameTicker partials
+    // were already null-safe and were normalized to the identical idiom. The
+    // NoOS NativeFrameTicker delegates to AsyncLoopTicker. None of those
+    // tickers are reachable from CoreTests (platform TFMs / project refs), so
+    // this test pins the contract for the whole family via AsyncLoopTicker.
     [TestMethod]
     public void AsyncLoopTicker_DisposeWithoutInitialize_DoesNotThrow()
     {


### PR DESCRIPTION
## Summary
- Null-guard `_canvas.Invalidated -= OnCoreInvalidated` in `CompositionTargetTicker.DisposeTicker()` so MotionCanvas teardown survives the contract violation reported in #2216.
- Apply the same defensive guard to the core-side `AsyncLoopTicker.DisposeTicker()` — same null-deref shape, would otherwise just relocate the bug for hosts that opt out of VSync.
- Add `FrameTickerTesting` (CoreTests) locking in the `IFrameTicker` contract: `DisposeTicker` is safe to call without `InitializeTicker`, and idempotent.

Closes #2216.

## Why
The reporter sees an NRE in `MotionCanvas.OnUnloaded` → `MotionCanvasComposer.Dispose` → `Ticker.DisposeTicker` when a Prism-style `ContentControl` swaps the view that hosts a `TabControl` containing a chart while the chart tab is *not* the active one. A second commenter sees the same NRE when a modal dialog hosting a chart closes. The teardown reaches `DisposeTicker` with `_canvas == null` — because `InitializeTicker` was never called (Unloaded without a preceding Loaded), or because a previous `DisposeTicker` already nulled it — and `_canvas.Invalidated -= ...` dereferences null.

The composer-level `_isInitialized` guard added for #2029 masks the most common path on `master`, but the ticker's `DisposeTicker` contract should be safe on its own. Among other reasons: if `Initialize` throws between `_isInitialized = true` and `Ticker.InitializeTicker(...)` (e.g. a render-mode constructor failure), a later `Dispose` still re-enters `DisposeTicker` with `_canvas` null. And the small defensive guard is much safer to backport to `release/v2.0.x` than #2233's broader composer rework — the two reporters are both on 2.0.2.

The guard does not change the happy-path subscription/unsubscription semantics; it only prevents the dereference when the ticker was never initialized or has already been disposed.

## Test plan
- [x] `dotnet test tests/CoreTests/ --framework net8.0` — 522/522 pass (was 520/522 with both new tests NRE-ing before the fix).
- [x] `dotnet test tests/CoreTests/ --framework net462` — 519/519 pass.
- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharp.WPF/LiveChartsCore.SkiaSharpView.Wpf.csproj -f net8.0-windows` — clean.
- [x] Reverted the fix in `CompositionTargetTicker` + `AsyncLoopTicker` alone (test commit kept) and re-ran CoreTests; both new tests fail with `System.NullReferenceException` in `DisposeTicker`, confirming the test pins the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)