### PR TITLE
fix(blazor): turn 'Module is not defined' into a build-time error (#2229)

### DIFF
--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -14,6 +14,23 @@ If you need more help to install a package from NuGet, please follow
 {{ $"LiveChartsCore.SkiaSharpView.{platform_display_name}@{version}" | from_nuget }}
 
 
+{{~ if blazor ~}}
+:::tip
+LiveCharts on Blazor WebAssembly needs the `.NET WebAssembly build tools` workload
+so SkiaSharp's native libs can be linked into your app's WASM bundle. Without it,
+the build fails with `error LVC0001` and the runtime would otherwise crash with
+`ReferenceError: Module is not defined` on the first chart render
+([#2229](https://github.com/Live-Charts/LiveCharts2/issues/2229)).
+
+Install it once per machine:
+
+```bash
+dotnet workload install wasm-tools
+```
+:::
+{{~ end ~}}
+
+
 {{~ if winforms || wpf ~}}
 :::tip
 By default wpf and winforms projects target `netx.0-windows` but SkiaSharp 3 does not provide a build

--- a/docs/overview/1.2.install.md
+++ b/docs/overview/1.2.install.md
@@ -22,11 +22,16 @@ the build fails with `error LVC0001` and the runtime would otherwise crash with
 `ReferenceError: Module is not defined` on the first chart render
 ([#2229](https://github.com/Live-Charts/LiveCharts2/issues/2229)).
 
-Install it once per machine:
+Install it:
 
 ```bash
 dotnet workload install wasm-tools
 ```
+
+Workloads are scoped to the SDK feature band, so a .NET SDK update — even a minor
+one that bumps the feature band (e.g. `10.0.1xx` → `10.0.2xx`) — can leave the
+workload missing again and re-trigger `LVC0001`. After updating the SDK, re-run
+the command above or `dotnet workload update`.
 :::
 {{~ end ~}}
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/LiveChartsCore.SkiaSharpView.Blazor.csproj
@@ -38,6 +38,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="build\LiveChartsCore.SkiaSharpView.Blazor.targets"
+          Pack="true"
+          PackagePath="buildTransitive\$(AssemblyName).targets" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Blazor" Version="$(LatestSkiaSharpVersion)" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="$(HarfBuzzWASMVersion)" />
   </ItemGroup>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/build/LiveChartsCore.SkiaSharpView.Blazor.targets
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/build/LiveChartsCore.SkiaSharpView.Blazor.targets
@@ -17,7 +17,7 @@
             and '$(WasmNativeWorkloadAvailable)' != 'true'">
 
     <Error Code="LVC0001"
-           Text="LiveChartsCore.SkiaSharpView.Blazor needs the .NET WebAssembly build tools workload, because SkiaSharp.Views.Blazor must be linked into your app's WebAssembly bundle. Without it, the first chart render throws 'ReferenceError: Module is not defined' (https://github.com/Live-Charts/LiveCharts2/issues/2229). Install the workload by running: dotnet workload install wasm-tools. See https://aka.ms/dotnet/wasm-build-tools for details." />
+           Text="LiveChartsCore.SkiaSharpView.Blazor needs the .NET WebAssembly build tools workload, because SkiaSharp.Views.Blazor must be linked into your app's WebAssembly bundle. Without it, the first chart render throws 'ReferenceError: Module is not defined' (https://github.com/Live-Charts/LiveCharts2/issues/2229). Install the workload by running: dotnet workload install wasm-tools. Workloads are scoped to the SDK feature band, so if a .NET SDK update triggered this error, re-run that command or 'dotnet workload update'. See https://aka.ms/dotnet/wasm-build-tools for details." />
 
   </Target>
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/build/LiveChartsCore.SkiaSharpView.Blazor.targets
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/build/LiveChartsCore.SkiaSharpView.Blazor.targets
@@ -1,0 +1,24 @@
+<Project>
+
+  <!--
+    SkiaSharp.Views.Blazor must be relinked into the consumer's WebAssembly
+    bundle so its emscripten Module is exposed as globalThis.SkiaSharpModule
+    via SkiaSharpInterop.js. Relinking requires the .NET WebAssembly build
+    tools workload. Without it, SDK silently skips the link step (buried
+    warning only), and SKHtmlCanvas.js then throws
+    'ReferenceError: Module is not defined' on first paint. Promote that
+    silent runtime failure to an actionable build error.
+  -->
+  <Target Name="_LiveChartsBlazorEnsureWasmTools"
+          BeforeTargets="Build"
+          Condition="
+            '$(RuntimeIdentifier)' == 'browser-wasm'
+            and '$(_BrowserWorkloadDisabled)' != 'true'
+            and '$(WasmNativeWorkloadAvailable)' != 'true'">
+
+    <Error Code="LVC0001"
+           Text="LiveChartsCore.SkiaSharpView.Blazor needs the .NET WebAssembly build tools workload, because SkiaSharp.Views.Blazor must be linked into your app's WebAssembly bundle. Without it, the first chart render throws 'ReferenceError: Module is not defined' (https://github.com/Live-Charts/LiveCharts2/issues/2229). Install the workload by running: dotnet workload install wasm-tools. See https://aka.ms/dotnet/wasm-build-tools for details." />
+
+  </Target>
+
+</Project>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/readme.md
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/readme.md
@@ -6,11 +6,16 @@ via `SkiaSharpInterop.js`. That link step requires the .NET WebAssembly
 build tools workload — without it, the first chart render throws
 `ReferenceError: Module is not defined` (see #2229).
 
-Install it once per machine:
+Install it:
 
 ```bash
 dotnet workload install wasm-tools
 ```
+
+.NET workloads are scoped to the SDK feature band, so a .NET SDK update — even a
+minor one that bumps the feature band (e.g. `10.0.1xx` → `10.0.2xx`) — can leave
+the workload missing again and re-trigger `LVC0001` on the next build. After
+updating the SDK, re-run the command above or `dotnet workload update`.
 
 The package emits build error `LVC0001` if the workload is missing, so
 consumers see the requirement at build time instead of debugging the

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/readme.md
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/readme.md
@@ -1,4 +1,24 @@
-﻿# About *.ts
+﻿# Consumer prerequisite: wasm-tools workload
+
+SkiaSharp.Views.Blazor must be linked into the consumer's WebAssembly
+bundle so its emscripten `Module` is exposed as `globalThis.SkiaSharpModule`
+via `SkiaSharpInterop.js`. That link step requires the .NET WebAssembly
+build tools workload — without it, the first chart render throws
+`ReferenceError: Module is not defined` (see #2229).
+
+Install it once per machine:
+
+```bash
+dotnet workload install wasm-tools
+```
+
+The package emits build error `LVC0001` if the workload is missing, so
+consumers see the requirement at build time instead of debugging the
+runtime crash. The check lives in
+`build/LiveChartsCore.SkiaSharpView.Blazor.targets` and is packed into
+`buildTransitive/` so direct and transitive consumers both get it.
+
+# About *.ts
 
 If the domInterop.ts changes, the *.js files must be manually updated, this due a possible bug where the
 *.js files were not consistently generated on the MSBuild process, by the Microsoft.TypeScript.MSBuild package.

--- a/tests/CoreTests/OtherTests/BlazorWasmToolsCheckTests.cs
+++ b/tests/CoreTests/OtherTests/BlazorWasmToolsCheckTests.cs
@@ -1,0 +1,63 @@
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class BlazorWasmToolsCheckTests
+{
+    [TestMethod]
+    public void TargetsFile_GuardsAgainstMissingWasmToolsWorkload()
+    {
+        // Issue #2229: a fresh Blazor WASM template + `dotnet add package
+        // LiveChartsCore.SkiaSharpView.Blazor` crashed at first render with
+        // `ReferenceError: Module is not defined` whenever the wasm-tools
+        // workload was missing. SkiaSharp's native libs were silently
+        // dropped; the SDK only emits a single buried warning that the
+        // user doesn't see.
+        //
+        // The fix is a .targets file shipped in buildTransitive/ of the
+        // package: when RuntimeIdentifier=browser-wasm but
+        // WasmNativeWorkloadAvailable!=true, raise LVC0001 so the build
+        // fails with the install command. Removing or weakening any of
+        // these tokens reopens the regression — so they must all stay.
+
+        var targets = Path.Combine(
+            RepoRoot(),
+            "src", "skiasharp", "LiveChartsCore.SkiaSharpView.Blazor",
+            "build", "LiveChartsCore.SkiaSharpView.Blazor.targets");
+
+        Assert.IsTrue(File.Exists(targets),
+            $"Missing build-time guard from PR #2229 fix: {targets}");
+
+        var content = File.ReadAllText(targets);
+
+        StringAssert.Contains(content, "Code=\"LVC0001\"");
+        StringAssert.Contains(content, "'$(RuntimeIdentifier)' == 'browser-wasm'");
+        StringAssert.Contains(content, "'$(WasmNativeWorkloadAvailable)' != 'true'");
+        StringAssert.Contains(content, "dotnet workload install wasm-tools");
+
+        // The csproj must also pack the file at the consumer-visible path,
+        // otherwise the guard ships in source but not in the NuGet.
+        var csproj = Path.Combine(
+            RepoRoot(),
+            "src", "skiasharp", "LiveChartsCore.SkiaSharpView.Blazor",
+            "LiveChartsCore.SkiaSharpView.Blazor.csproj");
+
+        var csprojContent = File.ReadAllText(csproj);
+        StringAssert.Contains(csprojContent,
+            "PackagePath=\"buildTransitive\\$(AssemblyName).targets\"");
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Directory.Build.props")))
+            dir = dir.Parent;
+
+        return dir?.FullName
+            ?? throw new System.InvalidOperationException(
+                "Could not locate repo root (Directory.Build.props) from " +
+                System.AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
## Summary

A fresh `dotnet new blazorwasm` + `dotnet add package LiveChartsCore.SkiaSharpView.Blazor` crashes at first chart render with `ReferenceError: Module is not defined` (#2229). Closes #2229 by turning the silent failure into an actionable build error.

## Why

`SkiaSharp.Views.Blazor`'s `SKHtmlCanvas.js` (3.119.x) references the bare `Module` / `Module.GL` identifiers as fallbacks:

```js
static getGL()     { return globalThis.SkiaSharpGL || Module.GL || GL; }
static getModule() { return globalThis.SkiaSharpModule || Module; }
```

Those globals are populated by `SkiaSharpInterop.js`, which emscripten only injects when the consumer's WebAssembly bundle is being relinked. Relinking requires the .NET WebAssembly build tools workload — `wasm-tools`. Without that workload, the SDK silently skips the link step and SkiaSharp's native libs are dropped (only a single buried warning hidden in 100+ other warnings). On the first chart render, `getGL()` evaluates the bare `Module` identifier and crashes.

A fresh Blazor template doesn't have `wasm-tools` installed by default, so every brand-new consumer hits this. SkiaSharp's own `SkiaSharp.NativeAssets.WebAssembly.targets` already tries to set `WasmBuildNative=true` and emit a workload warning, but the warning gets lost in build noise and the user only finds the cryptic runtime error.

This PR ships a `buildTransitive/LiveChartsCore.SkiaSharpView.Blazor.targets` that promotes the silent failure to `error LVC0001` whenever `RuntimeIdentifier=browser-wasm` but `WasmNativeWorkloadAvailable != true`. The message includes the exact install command (`dotnet workload install wasm-tools`) and a link to the issue, so users searching the runtime message find the fix immediately. Build succeeds normally on machines that already have the workload (the guard's gate is `WasmNativeWorkloadAvailable != true`, which the workload itself sets to true).

## What's in the change set

- **Commit 1 — fix**: new `build/LiveChartsCore.SkiaSharpView.Blazor.targets` (packed into `buildTransitive/`) plus csproj entry to ship it, and a brief maintainer note in the package's `readme.md`.
- **Commit 2 — test**: `tests/CoreTests/OtherTests/BlazorWasmToolsCheckTests.cs` locks the LVC0001 contract (file presence, condition tokens, error code, install command, csproj pack path). Reverting either the .targets file or the csproj pack entry fails the test with a pointer to this PR.
- **Commit 3 — docs**: Blazor-conditional tip in `docs/overview/1.2.install.md` so consumers see the wasm-tools step before they hit the build error.

## Test plan

- [x] Reproduced the original crash with a fresh `dotnet new blazorwasm -f net10.0` + `dotnet add package LiveChartsCore.SkiaSharpView.Blazor` on a machine without wasm-tools (headless Edge console: `Unhandled exception rendering component: ReferenceError: Module is not defined`).
- [x] Verified `WasmNativeWorkloadAvailable=false` is the root gate via `dotnet build -v:diag` trace.
- [x] Packed the updated library and confirmed the consumer build now fails with `error LVC0001` carrying the install command and issue link, instead of the runtime crash.
- [x] Confirmed the new MSTest (`TargetsFile_GuardsAgainstMissingWasmToolsWorkload`) passes with the fix and fails when the .targets file is removed.
- [x] Restored `samples/BlazorSample/Pages/Home.razor` so the repro changes aren't part of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)