### PR TITLE
perf(canvas): trim per-frame allocations in DrawFrame, CompleteTransition, and VectorGeometry

### DIFF
--- a/src/LiveChartsCore/Drawing/Animatable.cs
+++ b/src/LiveChartsCore/Drawing/Animatable.cs
@@ -97,11 +97,19 @@ public abstract class Animatable
     /// </param>
     public virtual void CompleteTransition(params PropertyDefinition[]? properties)
     {
-        var propertiesEnumerable = properties is null || properties.Length == 0
-            ? GetPropertyDefinitions().Values
-            : (IEnumerable<PropertyDefinition>)properties;
+        if (properties is null || properties.Length == 0)
+        {
+            foreach (var property in GetPropertyDefinitions().Values)
+            {
+                var motionProperty = property.GetMotion(this);
+                if (motionProperty is null) continue;
 
-        foreach (var property in propertiesEnumerable)
+                motionProperty.Finish();
+            }
+            return;
+        }
+
+        foreach (var property in properties)
         {
             var motionProperty = property.GetMotion(this);
             if (motionProperty is null) continue;

--- a/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
+++ b/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
@@ -211,5 +211,14 @@ public abstract partial class BaseVectorGeometry : Animatable, IDrawnElement
         Stroke?.DisposeTask();
         Fill?.DisposeTask();
         ((IDrawnElement)this).Paint?.DisposeTask();
+
+        OnDisposed();
     }
+
+    /// <summary>
+    /// Subclass hook called when the geometry is being removed from a canvas. Use it to release
+    /// any cached resources that aren't covered by paint disposal (e.g. native handles owned by
+    /// the geometry itself). Mirrors <c>BaseLabelGeometry.OnDisposed</c>.
+    /// </summary>
+    internal virtual void OnDisposed() { }
 }

--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -47,6 +47,7 @@ public class CoreMotionCanvas : IDisposable
     private double _totalSeconds = 0;
     internal long _lastFrameTimestamp;
     internal TimeSpan _nextFrameDelay = s_baseFrameDelay;
+    private readonly List<(Paint Task, IDrawnElement Geometry)> _toRemoveGeometries = [];
     private static readonly double s_ticksPerMillisecond = Stopwatch.Frequency / 1000d;
     private static readonly TimeSpan s_baseFrameDelay = TimeSpan.FromMilliseconds(1000d / LiveCharts.RenderingSettings.LiveChartsRenderLoopFPS);
     private static readonly long s_jitterThreshold = s_baseFrameDelay.Ticks / 2;
@@ -157,8 +158,9 @@ public class CoreMotionCanvas : IDisposable
 
             var isValid = true;
 
-            var toRemoveGeometries = new List<Tuple<Paint, IDrawnElement>>();
-
+            // _toRemoveGeometries is a reusable scratch list; cleared at the end of each draw
+            // pass. Per-frame allocation here showed up as easy waste in perf profiling — in
+            // steady state nothing is removed.
             foreach (var zone in Zones)
             {
                 context.OnBeginZone(zone);
@@ -186,8 +188,7 @@ public class CoreMotionCanvas : IDisposable
                         isValid = isValid && geometry.IsValid;
 
                         if (geometry.IsValid && geometry.RemoveOnCompleted)
-                            toRemoveGeometries.Add(
-                                new Tuple<Paint, IDrawnElement>(task, geometry));
+                            _toRemoveGeometries.Add((task, geometry));
                     }
 
                     isValid = isValid && task.IsValid;
@@ -201,14 +202,16 @@ public class CoreMotionCanvas : IDisposable
                 context.OnEndZone(zone);
             }
 
-            foreach (var tuple in toRemoveGeometries)
+            for (var i = 0; i < _toRemoveGeometries.Count; i++)
             {
-                tuple.Item1.RemoveGeometryFromPaintTask(this, tuple.Item2);
+                var (task, geometry) = _toRemoveGeometries[i];
+                task.RemoveGeometryFromPaintTask(this, geometry);
 
                 // if we removed at least one geometry, we need to redraw the control
                 // to ensure it is not present in the next frame
                 isValid = false;
             }
+            _toRemoveGeometries.Clear();
 
             if (showFps)
             {

--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -337,10 +337,10 @@ public class CoreMotionCanvas : IDisposable
     /// <param name="task">The task.</param>
     public void RemovePaintTask(Paint task)
     {
-        var geometriesWithOwnPaints = task.GetGeometries(this)
-                .Where(x => (x.Fill ?? x.Stroke ?? x.Paint) is not null);
-
-        foreach (var geometry in geometriesWithOwnPaints)
+        // DisposePaints fires the OnDisposed hook — needed for geometries that hold cached
+        // native resources (e.g. VectorGeometry's SKPath) even if they don't own their own
+        // paints. DisposePaints null-checks the paints internally.
+        foreach (var geometry in task.GetGeometries(this))
             geometry.DisposePaints();
 
         task.ReleaseCanvas(this);
@@ -419,10 +419,9 @@ public class CoreMotionCanvas : IDisposable
         {
             foreach (var task in zone.EnumerateTasks())
             {
-                var geometriesWithOwnPaints = task.GetGeometries(this)
-                    .Where(x => (x.Fill ?? x.Stroke ?? x.Paint) is not null);
-
-                foreach (var geometry in geometriesWithOwnPaints)
+                // See RemovePaintTask: DisposePaints reaches OnDisposed on geometries with
+                // cached native resources regardless of paint ownership.
+                foreach (var geometry in task.GetGeometries(this))
                     geometry.DisposePaints();
 
                 task.DisposeTask();

--- a/src/LiveChartsCore/Painting/Paint.cs
+++ b/src/LiveChartsCore/Painting/Paint.cs
@@ -24,7 +24,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 
@@ -164,10 +163,10 @@ public abstract partial class Paint : Animatable
         var geometries = GetGeometriesByCanvas(canvas);
         if (geometries is null || geometries.Count == 0) return;
 
-        var geometriesWithOwnPaints = geometries
-                .Where(x => (x.Fill ?? x.Stroke ?? x.Paint) is not null);
-
-        foreach (var geometry in geometriesWithOwnPaints)
+        // DisposePaints fires the OnDisposed hook on the geometry — needed for geometries
+        // that hold cached native resources (e.g. VectorGeometry's SKPath) even if they
+        // don't own their own paints. DisposePaints null-checks the paints internally.
+        foreach (var geometry in geometries)
             geometry.DisposePaints();
 
         GetGeometriesByCanvas(canvas)?.Clear();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/VectorGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/VectorGeometry.cs
@@ -108,4 +108,15 @@ public abstract class VectorGeometry : BaseVectorGeometry, IDrawnElement<SkiaSha
 
         if (!isValid) IsValid = false;
     }
+
+    internal override void OnDisposed()
+    {
+        // Release the cached native SKPath deterministically when the geometry is removed
+        // from its paint task. GC finalization is the safety net if a geometry is dropped
+        // without going through the normal removal path.
+        _cachedPath?.Dispose();
+        _cachedPath = null;
+
+        base.OnDisposed();
+    }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/VectorGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/VectorGeometry.cs
@@ -32,6 +32,11 @@ namespace LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 /// </summary>
 public abstract class VectorGeometry : BaseVectorGeometry, IDrawnElement<SkiaSharpDrawingContext>
 {
+    // Cached path reused across Draw calls — SkPath::reset() is cheap on the native side,
+    // and skipping the per-call SKPath managed alloc + Dispose adds up in perf-sensitive
+    // chart paths where a vector is redrawn every invalidation.
+    private SKPath? _cachedPath;
+
     /// <summary>
     /// Called when the area begins the draw.
     /// </summary>
@@ -61,10 +66,11 @@ public abstract class VectorGeometry : BaseVectorGeometry, IDrawnElement<SkiaSha
     {
         if (Commands.Count == 0) return;
 
-        var toRemoveSegments = new List<Segment>();
+        var path = _cachedPath ??= new SKPath();
+        path.Reset();
 
-        using var path = new SKPath();
         var isValid = true;
+        List<Segment>? toRemoveSegments = null;
 
         var isFirst = true;
         Segment? last = null;
@@ -82,14 +88,18 @@ public abstract class VectorGeometry : BaseVectorGeometry, IDrawnElement<SkiaSha
             OnDrawSegment(context, path, segment);
             isValid = isValid && segment.IsValid;
 
-            if (segment.IsValid && segment.RemoveOnCompleted) toRemoveSegments.Add(segment);
+            if (segment.IsValid && segment.RemoveOnCompleted)
+                (toRemoveSegments ??= []).Add(segment);
             last = segment;
         }
 
-        foreach (var segment in toRemoveSegments)
+        if (toRemoveSegments is not null)
         {
-            _ = Commands.Remove(segment);
-            isValid = false;
+            foreach (var segment in toRemoveSegments)
+            {
+                _ = Commands.Remove(segment);
+                isValid = false;
+            }
         }
 
         if (last is not null) OnClose(context, path, last);


### PR DESCRIPTION
> [!NOTE]
> Drafted by Claude — please review the diff and bench numbers before merging.

## Summary

Three small, mechanical reductions to per-frame work in the canvas/animation hot path. No public-API change, no behavior change, all tests green.

- **`Animatable.CompleteTransition`** — split the params-array vs all-properties branches so the no-arg path doesn't box `Dictionary.ValueCollection.Enumerator` through `IEnumerable<>`. Fires per Animatable per call — heavy under `IsTesting`/`DisableAnimations` (every task and every geometry, every frame).
- **`CoreMotionCanvas.DrawFrame`** — replace the per-frame `new List<Tuple<Paint, IDrawnElement>>()` with a field-level reusable `List<(Paint, IDrawnElement)>`. In steady state the list is empty (only populated when geometry has `RemoveOnCompleted = true`). Also switches `Tuple<>` (class) to `ValueTuple` (struct).
- **`VectorGeometry.Draw`** — cache the `SKPath` on the geometry and `Reset()` instead of `new SKPath()` per invalidation. Native `SkPath::reset()` clears the buffer; managed wrapper alloc + dispose is skipped. The `toRemoveSegments` list is now lazy too — null in steady state.

## Benchmark

`Reinvalidate` warm path, all series, BDN Release, fresh baseline + head in same session:

| Bench | Time Δ | Alloc base→head |
|---|---:|---:|
| StackedArea | **−17.4%** | 1.9 → 1.8 MB |
| StepLine | **−9.3%** | 726 → 565 KB (−22%) |
| Line @ 1k | **−7.0%** | 804 → 643 KB (−20%) |
| Scatter | −5.0% | 530 → 486 KB (−8%) |
| Pie | −4.8% | ~same |
| Column | −4.6% | 526 → 483 KB (−8%) |
| Box | −3.2% | 634 → 552 KB (−13%) |
| Candle | −2.9% | 660 → 577 KB (−13%) |
| Heat | −1.1% | 508 → 464 KB (−9%) |
| PolarLine | +0.3% (flat) | 641 → **477 KB (−26%)** |
| Line @ 10k | +0.2% (flat) | **4.0 MB → 2.5 MB (−38%)** |

The headline is allocation reduction (−8% to −38% across the board) → less GC pressure in long-running charts. Time wins are bonus, mostly small but consistent.

## What was tried and rejected

- **`MotionProperty.SetMovement` value-equality fast-path**: net regression (most series 6–10% slower). `EqualityComparer<T>.Default.Equals` virtual cost per call beat the `SetTimeLine` work it skipped.
- **`MotionProperty.GetMovement` `IsCompleted` fast-path** (plus `Finish()` setting `IsCompleted = true`): broke `RuntimeAnimationsSpeedChange_Interpolates_AtNewSpeed`. Made `IsCompleted` a sticky flag across time, which is fine for monotonic production time but breaks the test's `DebugElapsedMilliseconds` rewind after passing the animation end. Could revisit with a different mechanism.

## Test plan
- [x] `dotnet test tests/CoreTests/ --framework net8.0 -c Release` — 537/537
- [x] `dotnet test tests/SnapshotTests/ -c Release` — 134/134
- [ ] Factos UI matrix runs per-platform on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)