### PR TITLE
perf(canvas): tier-1 cross-cutting allocation trims

### DIFF
--- a/src/LiveChartsCore/Drawing/Animatable.cs
+++ b/src/LiveChartsCore/Drawing/Animatable.cs
@@ -57,11 +57,19 @@ public abstract class Animatable
     /// </param>
     public void SetTransition(Animation? animation, params PropertyDefinition[]? properties)
     {
-        var propertiesEnumerable = properties is null || properties.Length == 0
-            ? GetPropertyDefinitions().Values
-            : (IEnumerable<PropertyDefinition>)properties;
+        if (properties is null || properties.Length == 0)
+        {
+            foreach (var property in GetPropertyDefinitions().Values)
+            {
+                var motionProperty = property.GetMotion(this);
+                if (motionProperty is null) continue;
 
-        foreach (var property in propertiesEnumerable)
+                motionProperty.Animation = animation;
+            }
+            return;
+        }
+
+        foreach (var property in properties)
         {
             var motionProperty = property.GetMotion(this);
             if (motionProperty is null) continue;
@@ -77,11 +85,19 @@ public abstract class Animatable
     /// </param>
     public void RemoveTransition(params PropertyDefinition[]? properties)
     {
-        var propertiesEnumerable = properties is null || properties.Length == 0
-            ? GetPropertyDefinitions().Values
-            : (IEnumerable<PropertyDefinition>)properties;
+        if (properties is null || properties.Length == 0)
+        {
+            foreach (var property in GetPropertyDefinitions().Values)
+            {
+                var motionProperty = property.GetMotion(this);
+                if (motionProperty is null) continue;
 
-        foreach (var property in propertiesEnumerable)
+                motionProperty.Animation = null;
+            }
+            return;
+        }
+
+        foreach (var property in properties)
         {
             var motionProperty = property.GetMotion(this);
             if (motionProperty is null) continue;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
@@ -39,7 +39,10 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
     {
         get
         {
-            PeekPaintInfo(out var skPaint, out _);
+            // Only the paint identity matters for the cache check — building the SKFont
+            // (PeekPaintInfo) on every access wasted an allocation on the cache-hit path,
+            // and label getters are hit per-frame for every axis/legend/data label.
+            var skPaint = PeekPaint();
 
             var changed =                         // changed if:
                 _previousKey != BuildBlobKey() || //   - the key changed, structural equality between previous and current
@@ -74,13 +77,19 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
 
     internal void PeekPaintInfo(out SKPaint skPaint, out SKFont font)
     {
-        var lvcSkiaPaint = (SkiaPaint?)Paint;
-        skPaint = lvcSkiaPaint?.UpdateSkiaPaint(null, null)
-            ?? throw new Exception("A paint is required to measure a label.");
+        var lvcSkiaPaint = PeekPaintCore();
+        skPaint = lvcSkiaPaint.UpdateSkiaPaint(null, null);
 
         font = lvcSkiaPaint._fontBuilder(
             skPaint, lvcSkiaPaint.GetSKTypeface(), TextSize);
     }
+
+    // Paint-only accessor for the blob cache check — avoids the SKFont allocation that
+    // PeekPaintInfo would emit even when the cached blob is still valid.
+    private SKPaint PeekPaint() => PeekPaintCore().UpdateSkiaPaint(null, null);
+
+    private SkiaPaint PeekPaintCore() =>
+        (SkiaPaint?)Paint ?? throw new Exception("A paint is required to measure a label.");
 
     private (string Text, float Size, Padding Padding, float MaxWidth) BuildBlobKey() =>
         (Text, TextSize, Padding, MaxWidth);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -193,7 +193,12 @@ public class SkiaSharpDrawingContext(
         {
             // we will draw using the active paint while the element paint is null
 
-            if (ActiveLvcPaint.PaintStyle.HasFlag(PaintStyle.Fill))
+            // Direct bitwise instead of Enum.HasFlag — fires per geometry per frame; on
+            // net462 (still a supported target) HasFlag boxes both operands. On net8 the
+            // JIT intrinsifies it, but bitwise is identical there and faster everywhere else.
+            var style = ActiveLvcPaint.PaintStyle;
+
+            if ((style & PaintStyle.Fill) != 0)
             {
                 var elementFill = element.Fill;
 
@@ -203,7 +208,7 @@ public class SkiaSharpDrawingContext(
                     DrawByPaint(elementFill, element, opacity);
             }
 
-            if (ActiveLvcPaint.PaintStyle.HasFlag(PaintStyle.Stroke))
+            if ((style & PaintStyle.Stroke) != 0)
             {
                 var elementStroke = element.Stroke;
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by Claude — review the diff and bench numbers before marking ready.

Follow-up to #2254. Three small mechanical changes targeting cross-cutting paths (motion canvas, animations, paint pipeline) — every chart goes through these, regardless of series type. No behavior change.

## Commits

1. **`perf(motion): split SetTransition / RemoveTransition to avoid IEnumerable<> boxing`** — same pattern as `CompleteTransition` in #2254. The params-array vs all-properties branches were unified via a ternary that boxed `Dictionary.ValueCollection.Enumerator` through `IEnumerable<>`. Splitting the two `foreach` paths lets each use the struct enumerator inline.

2. **`perf(skia): replace Enum.HasFlag with bitwise in per-geometry Draw`** — `SkiaSharpDrawingContext.Draw` fires per geometry per frame and uses `PaintStyle.HasFlag(...)` twice. On `net462` (still supported, strong-named via `LiveCharts.snk`) `HasFlag` boxes both operands. On `net8` the JIT intrinsifies, but bitwise is identical there — no JIT dependency.

3. **`perf(skia): skip SKFont alloc on LabelGeometry.BlobArray cache hit`** — `BlobArray` getter called `PeekPaintInfo` on every access, which built an `SKFont` via the paint's font-builder delegate even when the cached blob was still valid. Per-frame for every axis tick / legend entry / data label. Split into a paint-only fast path for the cache check; `PeekPaintInfo` and `AsBlobArray` stay untouched.

## What was dropped (force-pushed away)

An earlier commit cached the transparent-background `SKPaint` on the `SkiaSharpDrawingContext` to skip its per-frame allocation. Removed because `SkiaSharpDrawingContext` is created fresh per paint event in every platform integration (Avalonia / WPF / MAUI / WinUI / Uno / Blazor / Eto / WinForms / InMemory) — the cache field never gets reused, and the change replaced `using var` deterministic disposal with finalizer-based cleanup. Real fix would require making the context `IDisposable` and threading `using var` through ~13 call sites; not justified by the (zero) measured benefit.

## Benchmark

Reinvalidate warm path, all series, BDN Release, master baseline + head in same session:

| Bench | Time Δ | Alloc base → head |
|---|---:|---:|
| Box | +2.6% (noise) | 552 → 539 KB (−2.3%) |
| Candle | +1.0% (noise) | 577 → 563 KB (−2.4%) |
| Column | +7.6% (noise) | 482 → 470 KB (−2.6%) |
| Heat | +2.0% (noise) | 463 → 451 KB (−2.6%) |
| Line @ 1k | +1.9% (noise) | 643 → 630 KB (−2.0%) |
| **Line @ 10k** | +3.1% (noise) | **2.5 MB → 2.4 MB (−4.5%)** |
| Pie | +5.5% (noise) | ~same |
| PolarLine | +2.0% (noise) | 476 → 467 KB (−1.8%) |
| Scatter | +2.6% (noise) | 486 → 473 KB (−2.7%) |
| Stacked | +7.0% (noise) | ~same |
| Step | +2.1% (noise) | 564 → 551 KB (−2.3%) |

`has_regression=False`. Times all fall inside the bench's noise band — Stacked/Pie show the largest "deltas" on series that touch zero of the changed code paths, which is the tell. The headline is the consistent allocation drop driven by the `LabelGeometry` fix — every chart with an axis sheds ~10-14 KB per render. Pie shows no alloc change because it has no axis labels (correctly).

## Test plan

- [x] `dotnet test tests/CoreTests/ --framework net8.0 -c Release` → 537/537
- [x] `dotnet test tests/SnapshotTests/ -c Release` → 134/134
- [ ] Factos UI matrix on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)