### PR TITLE
perf(skia): label SKFont defer + gradient ApplyOpacityMask leak fix

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
@@ -39,7 +39,10 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
     {
         get
         {
-            PeekPaintInfo(out var skPaint, out _);
+            // Only the paint identity matters for the cache check — building the SKFont
+            // (PeekPaintInfo) on every access wasted an allocation on the cache-hit path,
+            // and label getters are hit per-frame for every axis/legend/data label.
+            var skPaint = PeekPaint();
 
             var changed =                         // changed if:
                 _previousKey != BuildBlobKey() || //   - the key changed, structural equality between previous and current
@@ -74,13 +77,19 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
 
     internal void PeekPaintInfo(out SKPaint skPaint, out SKFont font)
     {
-        var lvcSkiaPaint = (SkiaPaint?)Paint;
-        skPaint = lvcSkiaPaint?.UpdateSkiaPaint(null, null)
-            ?? throw new Exception("A paint is required to measure a label.");
+        var lvcSkiaPaint = PeekPaintCore();
+        skPaint = lvcSkiaPaint.UpdateSkiaPaint(null, null);
 
         font = lvcSkiaPaint._fontBuilder(
             skPaint, lvcSkiaPaint.GetSKTypeface(), TextSize);
     }
+
+    // Paint-only accessor for the blob cache check — avoids the SKFont allocation that
+    // PeekPaintInfo would emit even when the cached blob is still valid.
+    private SKPaint PeekPaint() => PeekPaintCore().UpdateSkiaPaint(null, null);
+
+    private SkiaPaint PeekPaintCore() =>
+        (SkiaPaint?)Paint ?? throw new Exception("A paint is required to measure a label.");
 
     private (string Text, float Size, Padding Padding, float MaxWidth) BuildBlobKey() =>
         (Text, TextSize, Padding, MaxWidth);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/Geometries/LabelGeometry.cs
@@ -42,11 +42,21 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
             // Only the paint identity matters for the cache check — building the SKFont
             // (PeekPaintInfo) on every access wasted an allocation on the cache-hit path,
             // and label getters are hit per-frame for every axis/legend/data label.
-            var skPaint = PeekPaint();
+            //
+            // Do NOT call UpdateSkiaPaint here — DrawingTextExtensions.DrawLabel calls
+            // PeekPaintInfo earlier in the same frame to set up the SKPaint (including the
+            // font-builder's text-specific properties like IsAntialias / LcdRenderText).
+            // Calling UpdateSkiaPaint inside this getter would clobber those settings on
+            // the cache-hit path (see PR #2256 review thread). Read the cached _skiaPaint
+            // reference directly — the cache-miss path below runs AsBlobArray which calls
+            // PeekPaintInfo and handles initial setup.
+            var lvcPaint = PeekPaintCore();
+            var skPaint = lvcPaint._skiaPaint;
 
-            var changed =                         // changed if:
-                _previousKey != BuildBlobKey() || //   - the key changed, structural equality between previous and current
-                _previousPaint != skPaint;        //   - the paint changed, otherwise we will be using disposed resources
+            var changed =                                  // changed if:
+                skPaint is null ||                         //   - never set up yet (first access; force cache miss)
+                _previousKey != BuildBlobKey() ||          //   - the key changed, structural equality between previous and current
+                _previousPaint != skPaint;                 //   - the paint changed, otherwise we will be using disposed resources
 
             if (!changed || string.IsNullOrEmpty(Text))
                 return _activeBlobs;
@@ -55,7 +65,7 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
 
             _activeBlobs = this.AsBlobArray();
             _previousKey = BuildBlobKey();
-            _previousPaint = skPaint;
+            _previousPaint = lvcPaint._skiaPaint;          // non-null after AsBlobArray ran
 
             return _activeBlobs;
         }
@@ -83,10 +93,6 @@ public class LabelGeometry : BaseLabelGeometry, IDrawnElement<SkiaSharpDrawingCo
         font = lvcSkiaPaint._fontBuilder(
             skPaint, lvcSkiaPaint.GetSKTypeface(), TextSize);
     }
-
-    // Paint-only accessor for the blob cache check — avoids the SKFont allocation that
-    // PeekPaintInfo would emit even when the cached blob is still valid.
-    private SKPaint PeekPaint() => PeekPaintCore().UpdateSkiaPaint(null, null);
 
     private SkiaPaint PeekPaintCore() =>
         (SkiaPaint?)Paint ?? throw new Exception("A paint is required to measure a label.");

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -59,6 +59,8 @@ public class LinearGradientPaint(
         : SkiaPaint
 {
     private SKShader? _shader;
+    private SKColorFilter? _opacityFilter;
+    private float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
 
     private SKColor[] GradientStops { get; set; } = gradientStops;
@@ -129,10 +131,20 @@ public class LinearGradientPaint(
     {
         if (_skiaPaint is null || opacity > 0.99) return;
 
-        _skiaPaint.ColorFilter =
-            SKColorFilter.CreateBlendMode(
+        // Previously this allocated an SKColorFilter every call and `RestoreOpacityMask`
+        // dropped the reference without disposing — the native handle leaked to GC
+        // finalization. Cache by opacity value; for static or coarsely-quantized opacity
+        // (most cases) the native filter is created once and reused.
+        if (_opacityFilter is null || _opacityFilterAlpha != opacity)
+        {
+            _opacityFilter?.Dispose();
+            _opacityFilter = SKColorFilter.CreateBlendMode(
                 new SKColor(255, 255, 255, (byte)(255 * opacity)),
                 SKBlendMode.DstIn);
+            _opacityFilterAlpha = opacity;
+        }
+
+        _skiaPaint.ColorFilter = _opacityFilter;
     }
 
     internal override void RestoreOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement)
@@ -189,6 +201,10 @@ public class LinearGradientPaint(
 
         _shader?.Dispose();
         _shader = null;
+
+        _opacityFilter?.Dispose();
+        _opacityFilter = null;
+        _opacityFilterAlpha = -1f;
     }
 
     private SKShader GetShader()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -59,8 +59,8 @@ public class LinearGradientPaint(
         : SkiaPaint
 {
     private SKShader? _shader;
-    private SKColorFilter? _opacityFilter;
-    private float _opacityFilterAlpha = -1f;
+    internal SKColorFilter? _opacityFilter;
+    internal float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
 
     private SKColor[] GradientStops { get; set; } = gradientStops;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -35,8 +35,8 @@ namespace LiveChartsCore.SkiaSharpView.Painting;
 public class RadialGradientPaint : SkiaPaint
 {
     private SKShader? _shader;
-    private SKColorFilter? _opacityFilter;
-    private float _opacityFilterAlpha = -1f;
+    internal SKColorFilter? _opacityFilter;
+    internal float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
     private readonly SKColor[] _gradientStops;
     private SKPoint _center;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -35,6 +35,8 @@ namespace LiveChartsCore.SkiaSharpView.Painting;
 public class RadialGradientPaint : SkiaPaint
 {
     private SKShader? _shader;
+    private SKColorFilter? _opacityFilter;
+    private float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
     private readonly SKColor[] _gradientStops;
     private SKPoint _center;
@@ -108,10 +110,20 @@ public class RadialGradientPaint : SkiaPaint
     {
         if (_skiaPaint is null || opacity > 0.99) return;
 
-        _skiaPaint.ColorFilter =
-            SKColorFilter.CreateBlendMode(
+        // See LinearGradientPaint.ApplyOpacityMask — same leak fix: previously a fresh
+        // SKColorFilter was created every call and Restore dropped the reference without
+        // disposing. Cache by opacity; for steady-state opacity the native filter is
+        // created once and reused.
+        if (_opacityFilter is null || _opacityFilterAlpha != opacity)
+        {
+            _opacityFilter?.Dispose();
+            _opacityFilter = SKColorFilter.CreateBlendMode(
                 new SKColor(255, 255, 255, (byte)(255 * opacity)),
                 SKBlendMode.DstIn);
+            _opacityFilterAlpha = opacity;
+        }
+
+        _skiaPaint.ColorFilter = _opacityFilter;
     }
 
     internal override void RestoreOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement)
@@ -164,6 +176,10 @@ public class RadialGradientPaint : SkiaPaint
 
         _shader?.Dispose();
         _shader = null;
+
+        _opacityFilter?.Dispose();
+        _opacityFilter = null;
+        _opacityFilterAlpha = -1f;
     }
 
     private SKShader GetShader()

--- a/tests/CoreTests/OtherTests/GradientPaintsTests.cs
+++ b/tests/CoreTests/OtherTests/GradientPaintsTests.cs
@@ -1,6 +1,8 @@
 using System;
+using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -200,5 +202,113 @@ public class GradientPaintsTests
         var to = new RadialGradientPaint(s_threeStops);
 
         Assert.ThrowsExactly<ArgumentException>(() => _ = from.Transitionate(0.5f, to));
+    }
+
+    // The next three tests cover the opacity-filter cache + disposal contract introduced
+    // in this PR. Before the fix, every call to ApplyOpacityMask built a fresh
+    // SKColorFilter and RestoreOpacityMask dropped the reference without disposing —
+    // native handles leaked to GC finalization. The cache now keys on the opacity value
+    // and disposes the cached filter properly in DisposeTask.
+
+    [TestMethod]
+    public void LinearGradient_ApplyOpacityMask_ReusesFilterForSameOpacity()
+    {
+        var (paint, context) = NewLinearGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        var first = paint._opacityFilter;
+        Assert.IsNotNull(first);
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        Assert.AreSame(first, paint._opacityFilter,
+            "Same opacity value must reuse the cached SKColorFilter.");
+    }
+
+    [TestMethod]
+    public void LinearGradient_ApplyOpacityMask_RebuildsForDifferentOpacity()
+    {
+        var (paint, context) = NewLinearGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        var first = paint._opacityFilter;
+
+        paint.ApplyOpacityMask(context, 0.25f, null);
+        Assert.AreNotSame(first, paint._opacityFilter,
+            "Different opacity value must rebuild the cached filter.");
+        Assert.AreEqual(0.25f, paint._opacityFilterAlpha);
+    }
+
+    [TestMethod]
+    public void LinearGradient_DisposeTask_ReleasesCachedOpacityFilter()
+    {
+        var (paint, context) = NewLinearGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        Assert.IsNotNull(paint._opacityFilter);
+
+        paint.DisposeTask();
+        Assert.IsNull(paint._opacityFilter,
+            "DisposeTask must dispose and null the cached SKColorFilter.");
+    }
+
+    [TestMethod]
+    public void RadialGradient_ApplyOpacityMask_ReusesFilterForSameOpacity()
+    {
+        var (paint, context) = NewRadialGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        var first = paint._opacityFilter;
+        Assert.IsNotNull(first);
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        Assert.AreSame(first, paint._opacityFilter,
+            "Same opacity value must reuse the cached SKColorFilter.");
+    }
+
+    [TestMethod]
+    public void RadialGradient_ApplyOpacityMask_RebuildsForDifferentOpacity()
+    {
+        var (paint, context) = NewRadialGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        var first = paint._opacityFilter;
+
+        paint.ApplyOpacityMask(context, 0.25f, null);
+        Assert.AreNotSame(first, paint._opacityFilter,
+            "Different opacity value must rebuild the cached filter.");
+        Assert.AreEqual(0.25f, paint._opacityFilterAlpha);
+    }
+
+    [TestMethod]
+    public void RadialGradient_DisposeTask_ReleasesCachedOpacityFilter()
+    {
+        var (paint, context) = NewRadialGradientWithContext();
+
+        paint.ApplyOpacityMask(context, 0.5f, null);
+        Assert.IsNotNull(paint._opacityFilter);
+
+        paint.DisposeTask();
+        Assert.IsNull(paint._opacityFilter,
+            "DisposeTask must dispose and null the cached SKColorFilter.");
+    }
+
+    private static (LinearGradientPaint Paint, SkiaSharpDrawingContext Context) NewLinearGradientWithContext()
+    {
+        var canvas = new CoreMotionCanvas();
+        var surface = SKSurface.Create(new SKImageInfo(100, 100))!;
+        var context = new SkiaSharpDrawingContext(canvas, surface.Canvas, SKColor.Empty);
+        var paint = new LinearGradientPaint(s_twoStops);
+        paint.OnPaintStarted(context, null);
+        return (paint, context);
+    }
+
+    private static (RadialGradientPaint Paint, SkiaSharpDrawingContext Context) NewRadialGradientWithContext()
+    {
+        var canvas = new CoreMotionCanvas();
+        var surface = SKSurface.Create(new SKImageInfo(100, 100))!;
+        var context = new SkiaSharpDrawingContext(canvas, surface.Canvas, SKColor.Empty);
+        var paint = new RadialGradientPaint(s_twoStops);
+        paint.OnPaintStarted(context, null);
+        return (paint, context);
     }
 }

--- a/tests/CoreTests/OtherTests/LabelGeometryCacheTests.cs
+++ b/tests/CoreTests/OtherTests/LabelGeometryCacheTests.cs
@@ -1,0 +1,41 @@
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class LabelGeometryCacheTests
+{
+    // Regression for the PR #2256 review thread: the BlobArray cache-hit path must not
+    // call UpdateSkiaPaint, which would overwrite paint properties (IsAntialias / StrokeCap
+    // / etc.) set by the font-builder when DrawingTextExtensions.DrawLabel runs
+    // PeekPaintInfo earlier in the same frame.
+    [TestMethod]
+    public void BlobArrayCacheHit_PreservesFontBuilderPaintProperties()
+    {
+        // LvcSkiaPaint has IsAntialias = false; the default font-builder forces the SKPaint's
+        // IsAntialias to true regardless. The bug was that re-entering the BlobArray getter
+        // on the cache-hit path called UpdateSkiaPaint which copied IsAntialias=false back
+        // onto the SKPaint, breaking subsequent DrawText calls in the same frame.
+        var paint = new SolidColorPaint(SKColors.Black) { IsAntialias = false };
+        var label = new LabelGeometry { Text = "test", Paint = paint, TextSize = 12 };
+
+        // First access: cache miss → AsBlobArray runs PeekPaintInfo → fontBuilder sets
+        // IsAntialias = true on the SKPaint.
+        _ = label.BlobArray;
+        Assert.IsNotNull(paint._skiaPaint);
+        Assert.IsTrue(
+            paint._skiaPaint.IsAntialias,
+            "sanity: default fontBuilder forces SKPaint.IsAntialias = true on first build.");
+
+        // Second access: must be a cache hit and must NOT invoke UpdateSkiaPaint. If it
+        // did, IsAntialias would be reset to the LvcPaint property value (false).
+        _ = label.BlobArray;
+        Assert.IsTrue(
+            paint._skiaPaint.IsAntialias,
+            "regression: BlobArray getter on cache-hit must not invoke UpdateSkiaPaint and "
+                + "clobber the font-builder's IsAntialias setting.");
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Drafted by Claude — review the diff and bench numbers before marking ready.

Two small surgical changes to the SkiaSharp paint pipeline. The first is a real allocation reduction across every chart with axis labels; the second is a native-handle leak fix that's also a small allocation win for gradient paints with animated opacity.

## Commits

1. **`perf(skia): skip SKFont alloc on LabelGeometry.BlobArray cache hit`** — `BlobArray` getter called `PeekPaintInfo` on every access, which built an `SKFont` via the paint's font-builder delegate even when the cached blob was still valid. Per-frame for every axis tick / legend entry / data label. Split into a paint-only fast path for the cache check; `PeekPaintInfo` and `AsBlobArray` stay untouched. (Originally from the closed #2255 — the only commit there that actually moved the bench.)

2. **`perf(skia): cache + dispose SKColorFilter in gradient ApplyOpacityMask`** — `LinearGradientPaint` and `RadialGradientPaint` both built a fresh `SKColorFilter` in `ApplyOpacityMask` every call and then `RestoreOpacityMask` dropped the reference by setting `_skiaPaint.ColorFilter = null` **without disposing**. The native handle survived until `SKObject`'s finalizer ran, leaving both the managed wrapper and the native filter on the GC's finalization queue. Cache by opacity value — for steady-state opacity (the common case) the filter is created once and reused — and dispose properly in `DisposeTask` alongside the existing `_shader` cleanup. Both leak fix and small allocation win for gradient paints with animated opacity.

## Benchmark

Reinvalidate warm path, all series, BDN Release, master baseline + head in same session:

| Bench | Time Δ | Alloc base → head |
|---|---:|---:|
| Box | +1.7% (noise) | 552 → 540 KB (−2.1%) |
| Candle | +0.1% | 577 → 565 KB (−2.1%) |
| Column | +4.9% (noise) | 482 → 471 KB (−2.4%) |
| Heat | +0.8% | 463 → 453 KB (−2.4%) |
| Line @ 1k | +2.2% (noise) | 643 → 631 KB (−1.8%) |
| **Line @ 10k** | +4.8% (noise) | 2.5 MB → 2.5 MB (~same) |
| Pie | +7.6% (noise — Pie has no labels) | ~same |
| PolarLine | +1.8% (noise) | 476 → 469 KB (−1.4%) |
| Scatter | +1.6% (noise) | 486 → 474 KB (−2.4%) |
| Stacked | −2.6% | ~same |
| Step | −0.1% | 564 → 553 KB (−2.1%) |

`has_regression=False`. Time deltas all within the bench noise band (Pie +7.6% on a series that touches zero of the changed code paths is the tell). The allocation drop is the LabelGeometry win — every chart with axis labels sheds ~11 KB per render. Pie shows no alloc change because it has no axis labels (correctly).

**Note:** the gradient fix doesn't appear in the bench because none of the existing series benchmarks exercise gradient paints with `ApplyOpacityMask`. That fix lands here primarily for correctness — the native-handle leak isn't visible in BDN's allocation column (it tracks managed allocations only) but does show in long-running gradient-paint charts as finalizer-queue pressure.

## Test plan

- [x] `dotnet test tests/CoreTests/ --framework net8.0 -c Release` → 537/537
- [x] `dotnet test tests/SnapshotTests/ -c Release` → 134/134
- [ ] Factos UI matrix on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)