### PR TITLE
perf(line): reuse BezierData + skip SolidColorPaint Color when unchanged

### DIFF
--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -649,6 +649,11 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
         IEnumerable<ChartPoint> points,
         StackPosition? stacker)
     {
+        // Single BezierData reused across yields — mutating its fields between iterations
+        // is safe because Measure reads X0..Y2 into the segment via local accesses within
+        // the same foreach body; the reference never escapes a single MoveNext step.
+        BezierData? data = null;
+
         foreach (var item in points.AsSplineData())
         {
             if (item.IsFirst)
@@ -657,17 +662,17 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
 
                 var sc = stacker?.GetStack(item.Current).CumulativeStart ?? 0;
 
-                yield return new BezierData(item.Next)
-                {
-                    X0 = c.SecondaryValue,
-                    Y0 = c.PrimaryValue + sc,
-                    X1 = c.SecondaryValue,
-                    Y1 = c.PrimaryValue + sc,
-                    X2 = c.SecondaryValue,
-                    Y2 = c.PrimaryValue + sc,
-                    IsNextEmpty = item.IsNextEmpty
-                };
+                data ??= new BezierData(item.Next);
+                data.TargetPoint = item.Next;
+                data.X0 = c.SecondaryValue;
+                data.Y0 = c.PrimaryValue + sc;
+                data.X1 = c.SecondaryValue;
+                data.Y1 = c.PrimaryValue + sc;
+                data.X2 = c.SecondaryValue;
+                data.Y2 = c.PrimaryValue + sc;
+                data.IsNextEmpty = item.IsNextEmpty;
 
+                yield return data;
                 continue;
             }
 
@@ -725,15 +730,17 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             var c2X = xm2 + (xc2 - xm2) * _lineSmoothness + next.SecondaryValue - xm2;
             var c2Y = ym2 + (yc2 - ym2) * _lineSmoothness + next.PrimaryValue + nys - ym2;
 
-            yield return new BezierData(item.Next)
-            {
-                X0 = c1X,
-                Y0 = c1Y,
-                X1 = c2X,
-                Y1 = c2Y,
-                X2 = next.SecondaryValue,
-                Y2 = next.PrimaryValue + nys
-            };
+            data ??= new BezierData(item.Next);
+            data.TargetPoint = item.Next;
+            data.X0 = c1X;
+            data.Y0 = c1Y;
+            data.X1 = c2X;
+            data.Y1 = c2Y;
+            data.X2 = next.SecondaryValue;
+            data.Y2 = next.PrimaryValue + nys;
+            data.IsNextEmpty = false;
+
+            yield return data;
         }
     }
 

--- a/src/LiveChartsCore/CorePolarLineSeries.cs
+++ b/src/LiveChartsCore/CorePolarLineSeries.cs
@@ -636,6 +636,9 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
 
         LvcPoint previous, current, next, next2;
 
+        // Reused BezierData — see CoreLineSeries.GetSpline for the contract.
+        BezierData? data = null;
+
         for (var i = 0; i < points.Length; i++)
         {
             var isClosed = IsClosed && points.Length > 2;
@@ -720,15 +723,16 @@ public abstract class CorePolarLineSeries<TModel, TVisual, TLabel, TPathGeometry
                 y0 = c1Y;
             }
 
-            yield return new BezierData(points[i])
-            {
-                X0 = x0,
-                Y0 = y0,
-                X1 = c2X,
-                Y1 = c2Y,
-                X2 = next.X,
-                Y2 = next.Y
-            };
+            data ??= new BezierData(points[i]);
+            data.TargetPoint = points[i];
+            data.X0 = x0;
+            data.Y0 = y0;
+            data.X1 = c2X;
+            data.Y1 = c2Y;
+            data.X2 = next.X;
+            data.Y2 = next.Y;
+
+            yield return data;
         }
     }
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel}.SetDefaultPointTransitions(ChartPoint)"/>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
@@ -82,7 +82,11 @@ public class SolidColorPaint : SkiaPaint
     {
         var skiaContext = (SkiaSharpDrawingContext)drawingContext;
         _skiaPaint = UpdateSkiaPaint(skiaContext, drawnElement);
-        _skiaPaint.Color = Color;
+
+        // SKPaint.Color is a managed property that marshals to the native paint on next use;
+        // skipping the write when the source color hasn't moved avoids that pair on every
+        // paint-task selection. Most paints carry a static color in steady state.
+        if (_skiaPaint.Color != Color) _skiaPaint.Color = Color;
     }
 
     internal override Paint Transitionate(float progress, Paint target)


### PR DESCRIPTION
> [!NOTE]
> Drafted by Claude — review the diff and bench numbers before marking ready.

Two small surgical changes. The first is the biggest single allocation win in this perf series — **Line @ 10k drops ~800 KB per render**. The second is a one-line guard with no measurable bench impact but trivial.

## Commits

1. **`perf(line): reuse single BezierData instance across GetSpline yields`** — `CoreLineSeries.GetSpline` and `CorePolarLineSeries.GetSpline` both allocated a fresh `BezierData` (class) on every `yield return`. For a 10k-point LineSeries, that's 10k heap allocations per render just for the iterator state. Mutate one instance and yield the same reference between iterations; the consumer reads `X0..Y2` / `TargetPoint` into segment fields within the same `foreach` body, so reuse is observationally identical for `foreach`-style consumers.

    **Contract change** for external code: the `IEnumerable<BezierData>` returned by either `GetSpline` now yields the same object reference across iterations. Callers that materialize the enumerable (`.ToList()`, `.ToArray()`) or cache a reference across `MoveNext` steps would see all prior elements report the last-set values. The intent is documented inline. No in-tree consumer uses anything other than the standard `foreach`.

2. **`perf(skia): skip SolidColorPaint Color write when unchanged`** — `OnPaintStarted` was setting `_skiaPaint.Color = Color` on every paint-task selection. SKPaint.Color marshals to native on next use, so the write isn't free even when value-identical. Trivial guard, no behavior change. Won't show in the bench but a free hygiene win.

## Benchmark

Reinvalidate warm path, all series, BDN Release, master baseline + head in same session:

| Bench | Time Δ | Alloc base → head |
|---|---:|---:|
| **Line @ 10k** | within noise | **2.5 MB → 1.7 MB (−32%)** 🎯 |
| **PolarLine** | within noise | **476 → 398 KB (−16%)** |
| **Line @ 1k** | within noise | **643 → 565 KB (−12%)** |
| StackedArea | within noise | 1.8 → 1.7 MB (−5%) |
| Box / Candle / Column / Heat / Pie / Scatter / StepLine | within noise | unchanged (don't use `GetSpline`) |

`has_regression=False`. Time deltas are all within the bench noise band (the first run had a noisy StackedArea outlier at +27% that vanished on re-run). The headline is the **800 KB-per-render allocation drop on Line @ 10k** — biggest win since #2254. Other bezier-using series (Line @ 1k, PolarLine, StackedArea) get proportional drops.

Benches that don't use `GetSpline` are unchanged, which is the expected control behavior.

## Test plan

- [x] `dotnet test tests/CoreTests/ --framework net8.0 -c Release` → 537/537
- [x] `dotnet test tests/SnapshotTests/ -c Release` → 134/134
- [ ] Factos UI matrix on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)