### PR TITLE
chore(deps): bump Factos to 0.9.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
     <UITesting>false</UITesting>
     <NoWarnUITests>$(NoWarn);NETSDK1198;NU1701;XC0022;XA0141;XAAADB0000;CS0067;CS0414;CS0108;CS0618;CS4014;CS8600;CS8601;CS8602;CS8603;CS8612;CS8618;CS8622;CS8625;CS8629;CS9264;</NoWarnUITests>
     <!-- Factos version https://github.com/beto-rodriguez/Factos -->
-    <FactosVersion>0.8.3</FactosVersion>
+    <FactosVersion>0.9.0</FactosVersion>
 
     <!-- Useful to toggle between using project references or nuget references -->
     <UseNuGetForSamples>false</UseNuGetForSamples>


### PR DESCRIPTION
## Summary
- Bumps `FactosVersion` from `0.8.3` to `0.9.0` in `Directory.Build.props`.
- All `Factos.*` PackageReferences in samples + UITests flow through `$(FactosVersion)`, so no other edits required.

## Test plan
- [x] `dotnet restore tests/UITests/UITests.csproj` succeeds (Factos 0.9.0 reachable on NuGet)
- [x] `dotnet build tests/UITests/UITests.csproj` succeeds (0 warnings, 0 errors — API compatible)
- [x] `dotnet restore samples/WPFSample/WPFSample.csproj` succeeds (Factos.WPF 0.9.0 reachable)
- [ ] Factos UI matrix jobs pass in CI (test-browser / test-android / test-mac / test-core / test-snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)