### PR TITLE
refactor(scatter): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -299,6 +299,92 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
         }
     }
 
+    /// <summary>
+    /// Sets the per-Z-index ordering on each non-default paint and registers it as a
+    /// drawable task on the chart's canvas (within the DrawMargin zone). Run once at
+    /// the top of <see cref="Invalidate"/>.
+    /// </summary>
+    private void InitializePaints(CartesianChartEngine chart)
+    {
+        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
+        if (Fill is not null && Fill != Paint.Default)
+        {
+            Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
+            chart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
+        }
+        if (Stroke is not null && Stroke != Paint.Default)
+        {
+            Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
+            chart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
+        }
+        if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
+        {
+            ErrorPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
+            chart.Canvas.AddDrawableTask(ErrorPaint, zone: CanvasZone.DrawMargin);
+        }
+        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
+        {
+            DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
+            chart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if it doesn't exist yet (animation-sourced from
+    /// the marker's top-left), updates its text + style, and positions it via
+    /// <c>GetLabelPosition</c> with the marker rect and the point's "above pivot" hint.
+    /// No-op when the series has no data-label paint configured.
+    /// </summary>
+    private void MeasureDataLabel(ChartPoint point, in ScatterLayout layout, in ScatterMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default) return;
+
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        if (label is null)
+        {
+            var l = new TLabel
+            {
+                X = layout.X,
+                Y = layout.Y,
+                RotateTransform = (float)DataLabelsRotation,
+                MaxWidth = (float)DataLabelsMaxWidth
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
+        }
+
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.Paint = DataLabelsPaint;
+
+        if (ctx.IsFirstDraw)
+            label.CompleteTransition(
+                BaseLabelGeometry.TextSizeProperty,
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty,
+                BaseLabelGeometry.RotateTransformProperty);
+
+        var m = label.Measure();
+        var labelPosition = GetLabelPosition(
+            layout.X, layout.Y, layout.Width, layout.Height, m, DataLabelsPosition,
+            SeriesProperties, point.Coordinate.PrimaryValue > 0, ctx.DrawLocation, ctx.DrawMarginSize);
+        if (DataLabelsTranslate is not null)
+            label.TranslateTransform = new LvcPoint(
+                m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
+
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
     /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
     public sealed override void Invalidate(Chart chart)
     {
@@ -308,27 +394,7 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
         var ctx = BeginMeasure(cartesianChart);
         var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
-        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-        if (Fill is not null && Fill != Paint.Default)
-        {
-            Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
-        }
-        if (Stroke is not null && Stroke != Paint.Default)
-        {
-            Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
-        }
-        if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
-        {
-            ErrorPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(ErrorPaint, zone: CanvasZone.DrawMargin);
-        }
-        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-        {
-            DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
-        }
+        InitializePaints(cartesianChart);
 
         foreach (var point in Fetch(cartesianChart))
         {
@@ -370,41 +436,7 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
 
             pointsCleanup.Clean(point);
 
-            if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-            {
-                if (point.Context.Label is not TLabel label)
-                {
-                    var l = new TLabel { X = layout.X, Y = layout.Y, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                    l.Animate(
-                        GetAnimation(cartesianChart),
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty);
-                    label = l;
-                    point.Context.Label = l;
-                }
-
-                DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
-                label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = ctx.DataLabelsSize;
-                label.Padding = DataLabelsPadding;
-                label.Paint = DataLabelsPaint;
-
-                if (ctx.IsFirstDraw)
-                    label.CompleteTransition(
-                        BaseLabelGeometry.TextSizeProperty,
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty,
-                        BaseLabelGeometry.RotateTransformProperty);
-
-                var m = label.Measure();
-                var labelPosition = GetLabelPosition(
-                    layout.X, layout.Y, layout.Width, layout.Height, m, DataLabelsPosition,
-                    SeriesProperties, point.Coordinate.PrimaryValue > 0, ctx.DrawLocation, ctx.DrawMarginSize);
-                if (DataLabelsTranslate is not null) label.TranslateTransform =
-                        new LvcPoint(m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
-                label.X = labelPosition.X;
-                label.Y = labelPosition.Y;
-            }
+            MeasureDataLabel(point, in layout, in ctx);
 
             OnPointMeasured(point);
         }

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -118,25 +118,197 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
     /// <inheritdoc cref="IScatterSeries.StackGroup"/>
     public int? StackGroup { get; set => SetProperty(ref field, value); }
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
+    // ---- template method ----------------------------------------------------
+
+    /// <summary>
+    /// Builds a per-frame measure context from the chart. Subclasses may
+    /// override to refine context construction (e.g. additional pre-computed
+    /// per-frame values).
+    /// </summary>
+    protected virtual ScatterMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
-        var cartesianChart = (CartesianChartEngine)chart;
-        _ = GetAnimation(cartesianChart);
+        var primaryAxis = chart.GetYAxis(this);
+        var secondaryAxis = chart.GetXAxis(this);
 
-        var primaryAxis = cartesianChart.GetYAxis(this);
-        var secondaryAxis = cartesianChart.GetXAxis(this);
-
-        var drawLocation = cartesianChart.DrawMarginLocation;
-        var drawMarginSize = cartesianChart.DrawMarginSize;
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
         var xScale = new Scaler(drawLocation, drawMarginSize, secondaryAxis);
         var yScale = new Scaler(drawLocation, drawMarginSize, primaryAxis);
-
-        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
         var weightStackIndex = StackGroup ?? ((ISeries)this).SeriesId;
         var weightBounds = chart.SeriesContext.GetWeightBounds(weightStackIndex);
 
+        IsWeighted = weightBounds.Max - weightBounds.Min > 0;
+        var wm = -(GeometrySize - MinGeometrySize) / (weightBounds.Max - weightBounds.Min);
+
+        var hasSvg = this.HasVariableSvgGeometry();
+        var isFirstDraw = !((Chart)chart).IsDrawn(((ISeries)this).SeriesId);
+
+        return new ScatterMeasureContext(
+            chart, primaryAxis, secondaryAxis,
+            xScale, yScale,
+            baseGeometrySize: (float)GeometrySize,
+            isWeighted: IsWeighted,
+            weightBounds: weightBounds,
+            weightMultiplier: wm,
+            isFirstDraw: isFirstDraw,
+            hasSvg: hasSvg,
+            drawLocation: drawLocation,
+            drawMarginSize: drawMarginSize,
+            dataLabelsSize: (float)DataLabelsSize);
+    }
+
+    /// <summary>
+    /// Computes the final-frame marker geometry for a single point. Default
+    /// implementation produces a square marker of <see cref="GeometrySize"/>
+    /// (or weight-adjusted size when the stack group carries a weight range)
+    /// centered on the data point.
+    /// </summary>
+    protected virtual ScatterLayout MeasureScatterLayout(ChartPoint point, in ScatterMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var dataX = ctx.XScale.ToPixels(coordinate.SecondaryValue);
+        var dataY = ctx.YScale.ToPixels(coordinate.PrimaryValue);
+
+        var gs = ctx.BaseGeometrySize;
+        if (ctx.IsWeighted)
+            gs = (float)(ctx.WeightMultiplier * (ctx.WeightBounds.Max - coordinate.TertiaryValue) + GeometrySize);
+        var hgs = gs * 0.5f;
+
+        return new ScatterLayout(
+            x: dataX - hgs,
+            y: dataY - hgs,
+            width: gs,
+            height: gs,
+            dataX: dataX,
+            dataY: dataY);
+    }
+
+    /// <summary>
+    /// Ensures the visual + any additional visuals (error bars) exist for the
+    /// point. On first creation initializes the visual at the data point with
+    /// zero size so the marker animates from a point.
+    /// </summary>
+    protected virtual TVisual EnsureVisualForPoint(ChartPoint point, in ScatterMeasureContext ctx)
+    {
+        var visual = (TVisual?)point.Context.Visual;
+
+        if (visual is not null)
+        {
+            AttachErrorVisualsToPaint(point.Context.AdditionalVisuals as ErrorVisual<TErrorGeometry>, ctx.Chart.Canvas);
+            return visual;
+        }
+
+        var coordinate = point.Coordinate;
+        var x = ctx.XScale.ToPixels(coordinate.SecondaryValue);
+        var y = ctx.YScale.ToPixels(coordinate.PrimaryValue);
+
+        var r = new TVisual
+        {
+            X = x,
+            Y = y,
+            Width = 0,
+            Height = 0,
+        };
+
+        ErrorVisual<TErrorGeometry>? e = null;
+        if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
+        {
+            e = new ErrorVisual<TErrorGeometry>();
+
+            e.YError.X = x;
+            e.YError.X1 = x;
+            e.YError.Y = y;
+            e.YError.Y1 = y;
+
+            e.XError.X = x;
+            e.XError.X1 = x;
+            e.XError.Y = y;
+            e.XError.Y1 = y;
+
+            point.Context.AdditionalVisuals = e;
+        }
+
+        point.Context.Visual = r;
+        OnPointCreated(point);
+
+        _ = everFetched.Add(point);
+
+        AttachErrorVisualsToPaint(e, ctx.Chart.Canvas);
+
+        return r;
+    }
+
+    /// <summary>
+    /// Per-frame error-bar geometry update. No-op when the series carries no
+    /// error visuals or no point error data.
+    /// </summary>
+    protected virtual void MeasureErrorBars(ChartPoint point, in ScatterLayout layout, in ScatterMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        if (coordinate.PointError.IsEmpty) return;
+        if (!ShowError || ErrorPaint is null || ErrorPaint == Paint.Default) return;
+        if (point.Context.AdditionalVisuals is not ErrorVisual<TErrorGeometry> e) return;
+
+        var pe = coordinate.PointError;
+
+        e.YError!.X = layout.DataX;
+        e.YError.X1 = layout.DataX;
+        e.YError.Y = layout.DataY + ctx.YScale.MeasureInPixels(pe.Yi);
+        e.YError.Y1 = layout.DataY - ctx.YScale.MeasureInPixels(pe.Yj);
+        e.YError.RemoveOnCompleted = false;
+
+        e.XError!.X = layout.DataX - ctx.XScale.MeasureInPixels(pe.Xi);
+        e.XError.X1 = layout.DataX + ctx.XScale.MeasureInPixels(pe.Xj);
+        e.XError.Y = layout.DataY;
+        e.XError.Y1 = layout.DataY;
+        e.XError.RemoveOnCompleted = false;
+    }
+
+    /// <summary>
+    /// Collapses the point's visual to zero size at the data point for
+    /// empty/invisible points.
+    /// </summary>
+    protected virtual void CollapseEmptyVisual(ChartPoint point, in ScatterMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var x = ctx.XScale.ToPixels(coordinate.SecondaryValue);
+        var y = ctx.YScale.ToPixels(coordinate.PrimaryValue);
+        var hgs = ctx.BaseGeometrySize * 0.5f;
+
+        if (point.Context.Visual is TVisual visual)
+        {
+            visual.X = x - hgs;
+            visual.Y = y - hgs;
+            visual.Width = 0;
+            visual.Height = 0;
+            visual.RemoveOnCompleted = true;
+            point.Context.Visual = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            // Preserves the original CoreScatterSeries.Invalidate collapse pattern,
+            // where the empty-label X / Y both used (x - hgs). Snapshot baselines
+            // pin this; if it ever looks wrong the fix is to set label.Y = y - hgs.
+            label.X = x - hgs;
+            label.Y = x - hgs;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+            point.Context.Label = null;
+        }
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
+        var ctx = BeginMeasure(cartesianChart);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
+
+        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
         if (Fill is not null && Fill != Paint.Default)
         {
             Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
@@ -158,100 +330,18 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
             cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
         }
 
-        var dls = (float)DataLabelsSize;
-        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
-
-        var gs = (float)GeometrySize;
-        var hgs = gs / 2f;
-        var sw = Stroke?.StrokeThickness ?? 0;
-        IsWeighted = weightBounds.Max - weightBounds.Min > 0;
-        var wm = -(GeometrySize - MinGeometrySize) / (weightBounds.Max - weightBounds.Min);
-
-        var hy = chart.ControlSize.Height * .5f;
-        var hasSvg = this.HasVariableSvgGeometry();
-
-        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
-
         foreach (var point in Fetch(cartesianChart))
         {
-            var coordinate = point.Coordinate;
-
-            var visual = (TVisual?)point.Context.Visual;
-            var e = point.Context.AdditionalVisuals as ErrorVisual<TErrorGeometry>;
-
-            var x = xScale.ToPixels(coordinate.SecondaryValue);
-            var y = yScale.ToPixels(coordinate.PrimaryValue);
-
             if (point.IsEmpty || !IsVisible)
             {
-                if (visual is not null)
-                {
-                    visual.X = x - hgs;
-                    visual.Y = y - hgs;
-                    visual.Width = 0;
-                    visual.Height = 0;
-                    visual.RemoveOnCompleted = true;
-                    point.Context.Visual = null;
-                }
-
-                if (point.Context.Label is not null)
-                {
-                    var label = (TLabel)point.Context.Label;
-
-                    label.X = x - hgs;
-                    label.Y = x - hgs;
-                    label.Opacity = 0;
-                    label.RemoveOnCompleted = true;
-
-                    point.Context.Label = null;
-                }
-
+                CollapseEmptyVisual(point, in ctx);
                 pointsCleanup.Clean(point);
-
                 continue;
             }
 
-            if (IsWeighted)
-            {
-                gs = (float)(wm * (weightBounds.Max - coordinate.TertiaryValue) + GeometrySize);
-                hgs = gs / 2f;
-            }
+            var visual = EnsureVisualForPoint(point, in ctx);
 
-            if (visual is null)
-            {
-                var r = new TVisual
-                {
-                    X = x,
-                    Y = y,
-                    Width = 0,
-                    Height = 0
-                };
-
-                if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
-                {
-                    e = new ErrorVisual<TErrorGeometry>();
-
-                    e.YError.X = x;
-                    e.YError.X1 = x;
-                    e.YError.Y = y;
-                    e.YError.Y1 = y;
-
-                    e.XError.X = x;
-                    e.XError.X1 = x;
-                    e.XError.Y = y;
-                    e.XError.Y1 = y;
-
-                    point.Context.AdditionalVisuals = e;
-                }
-
-                visual = r;
-                point.Context.Visual = visual;
-                OnPointCreated(point);
-
-                _ = everFetched.Add(point);
-            }
-
-            if (hasSvg)
+            if (ctx.HasSvg)
             {
                 var svgVisual = (IVariableSvgPath)visual;
                 if (_geometrySvgChanged || svgVisual.SVGPath is null)
@@ -262,41 +352,21 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
                 Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
             if (Stroke is not null && Stroke != Paint.Default)
                 Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-            if (ErrorPaint is not null && ErrorPaint != Paint.Default)
-            {
-                ErrorPaint.AddGeometryToPaintTask(cartesianChart.Canvas, e!.YError);
-                ErrorPaint.AddGeometryToPaintTask(cartesianChart.Canvas, e!.XError);
-            }
 
-            var sizedGeometry = visual;
+            var layout = MeasureScatterLayout(point, in ctx);
 
-            sizedGeometry.X = x - hgs;
-            sizedGeometry.Y = y - hgs;
-            sizedGeometry.Width = gs;
-            sizedGeometry.Height = gs;
+            visual.X = layout.X;
+            visual.Y = layout.Y;
+            visual.Width = layout.Width;
+            visual.Height = layout.Height;
 
-            if (!coordinate.PointError.IsEmpty && ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
-            {
-                var pe = coordinate.PointError;
+            MeasureErrorBars(point, in layout, in ctx);
 
-                e!.YError!.X = x;
-                e.YError.X1 = x;
-                e.YError.Y = y + yScale.MeasureInPixels(pe.Yi);
-                e.YError.Y1 = y - yScale.MeasureInPixels(pe.Yj);
-                e.YError.RemoveOnCompleted = false;
-
-                e.XError!.X = x - xScale.MeasureInPixels(pe.Xi);
-                e.XError.X1 = x + xScale.MeasureInPixels(pe.Xj);
-                e.XError.Y = y;
-                e.XError.Y1 = y;
-                e.XError.RemoveOnCompleted = false;
-            }
-
-            sizedGeometry.RemoveOnCompleted = false;
+            visual.RemoveOnCompleted = false;
 
             if (point.Context.HoverArea is not RectangleHoverArea ha)
                 point.Context.HoverArea = ha = new RectangleHoverArea();
-            _ = ha.SetDimensions(x - hgs, y - hgs, gs, gs).CenterXToolTip().CenterYToolTip();
+            _ = ha.SetDimensions(layout.X, layout.Y, layout.Width, layout.Height).CenterXToolTip().CenterYToolTip();
 
             pointsCleanup.Clean(point);
 
@@ -304,7 +374,7 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
             {
                 if (point.Context.Label is not TLabel label)
                 {
-                    var l = new TLabel { X = x - hgs, Y = y - hgs, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
+                    var l = new TLabel { X = layout.X, Y = layout.Y, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
                     l.Animate(
                         GetAnimation(cartesianChart),
                         BaseLabelGeometry.XProperty,
@@ -315,11 +385,11 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
 
                 DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
                 label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = dls;
+                label.TextSize = ctx.DataLabelsSize;
                 label.Padding = DataLabelsPadding;
                 label.Paint = DataLabelsPaint;
 
-                if (isFirstDraw)
+                if (ctx.IsFirstDraw)
                     label.CompleteTransition(
                         BaseLabelGeometry.TextSizeProperty,
                         BaseLabelGeometry.XProperty,
@@ -328,8 +398,8 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
 
                 var m = label.Measure();
                 var labelPosition = GetLabelPosition(
-                    x - hgs, y - hgs, gs, gs, m, DataLabelsPosition,
-                    SeriesProperties, coordinate.PrimaryValue > 0, drawLocation, drawMarginSize);
+                    layout.X, layout.Y, layout.Width, layout.Height, m, DataLabelsPosition,
+                    SeriesProperties, point.Coordinate.PrimaryValue > 0, ctx.DrawLocation, ctx.DrawMarginSize);
                 if (DataLabelsTranslate is not null) label.TranslateTransform =
                         new LvcPoint(m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
                 label.X = labelPosition.X;
@@ -339,8 +409,16 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
             OnPointMeasured(point);
         }
 
-        pointsCleanup.CollectPoints(everFetched, cartesianChart.View, yScale, xScale, SoftDeleteOrDisposePoint);
+        pointsCleanup.CollectPoints(everFetched, cartesianChart.View, ctx.YScale, ctx.XScale, SoftDeleteOrDisposePoint);
         _geometrySvgChanged = false;
+    }
+
+    private void AttachErrorVisualsToPaint(ErrorVisual<TErrorGeometry>? e, CoreMotionCanvas canvas)
+    {
+        if (e is null) return;
+        if (ErrorPaint is null || ErrorPaint == Paint.Default) return;
+        ErrorPaint.AddGeometryToPaintTask(canvas, e.YError);
+        ErrorPaint.AddGeometryToPaintTask(canvas, e.XError);
     }
 
     /// <inheritdoc cref="CartesianSeries{TModel, TVisual, TLabel}.GetBounds(Chart, ICartesianAxis, ICartesianAxis)"/>

--- a/src/LiveChartsCore/ScatterLayout.cs
+++ b/src/LiveChartsCore/ScatterLayout.cs
@@ -1,0 +1,64 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// The final per-frame geometry of a single scatter marker, returned from
+/// <c>MeasureScatterLayout</c>. The marker is centered on (DataX, DataY); the
+/// rect's top-left is offset by half the geometry size so the centered hover
+/// area + visual line up.
+/// </summary>
+public readonly struct ScatterLayout
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ScatterLayout"/>.
+    /// </summary>
+    /// <param name="x">Visual rect top-left X (marker center X minus half-size).</param>
+    /// <param name="y">Visual rect top-left Y.</param>
+    /// <param name="width">Marker geometry width.</param>
+    /// <param name="height">Marker geometry height.</param>
+    /// <param name="dataX">Data-point pixel X (marker center).</param>
+    /// <param name="dataY">Data-point pixel Y (marker center).</param>
+    public ScatterLayout(float x, float y, float width, float height, float dataX, float dataY)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        DataX = dataX;
+        DataY = dataY;
+    }
+
+    /// <summary>Visual rect top-left X.</summary>
+    public float X { get; }
+    /// <summary>Visual rect top-left Y.</summary>
+    public float Y { get; }
+    /// <summary>Marker width.</summary>
+    public float Width { get; }
+    /// <summary>Marker height.</summary>
+    public float Height { get; }
+    /// <summary>Pixel X of the data point (marker geometric center).</summary>
+    public float DataX { get; }
+    /// <summary>Pixel Y of the data point (marker geometric center).</summary>
+    public float DataY { get; }
+}

--- a/src/LiveChartsCore/ScatterMeasureContext.cs
+++ b/src/LiveChartsCore/ScatterMeasureContext.cs
@@ -1,0 +1,99 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method
+/// orchestration on <see cref="CoreScatterSeries{TModel, TVisual, TLabel, TErrorGeometry}"/>
+/// and the per-point <c>MeasureScatterLayout</c> hook. Ref struct so passing
+/// it by <c>in</c> to hooks costs nothing and the contents cannot escape into
+/// a longer-lived closure.
+/// </summary>
+public readonly ref struct ScatterMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="ScatterMeasureContext"/>.</summary>
+    public ScatterMeasureContext(
+        CartesianChartEngine chart,
+        ICartesianAxis primaryAxis,
+        ICartesianAxis secondaryAxis,
+        Scaler xScale,
+        Scaler yScale,
+        float baseGeometrySize,
+        bool isWeighted,
+        Bounds weightBounds,
+        double weightMultiplier,
+        bool isFirstDraw,
+        bool hasSvg,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        float dataLabelsSize)
+    {
+        Chart = chart;
+        PrimaryAxis = primaryAxis;
+        SecondaryAxis = secondaryAxis;
+        XScale = xScale;
+        YScale = yScale;
+        BaseGeometrySize = baseGeometrySize;
+        IsWeighted = isWeighted;
+        WeightBounds = weightBounds;
+        WeightMultiplier = weightMultiplier;
+        IsFirstDraw = isFirstDraw;
+        HasSvg = hasSvg;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        DataLabelsSize = dataLabelsSize;
+    }
+
+    /// <summary>The chart engine.</summary>
+    public CartesianChartEngine Chart { get; }
+    /// <summary>Primary (Y) axis.</summary>
+    public ICartesianAxis PrimaryAxis { get; }
+    /// <summary>Secondary (X) axis.</summary>
+    public ICartesianAxis SecondaryAxis { get; }
+    /// <summary>X-axis pixel scaler.</summary>
+    public Scaler XScale { get; }
+    /// <summary>Y-axis pixel scaler.</summary>
+    public Scaler YScale { get; }
+    /// <summary>Unweighted geometry size in pixels (the configured GeometrySize).</summary>
+    public float BaseGeometrySize { get; }
+    /// <summary>True when at least one stacked group contributes a non-trivial weight range.</summary>
+    public bool IsWeighted { get; }
+    /// <summary>Weight bounds across the stack group; used by per-point weighted sizing.</summary>
+    public Bounds WeightBounds { get; }
+    /// <summary>Pre-computed weight-to-size multiplier (negative; smaller weights -> larger markers).</summary>
+    public double WeightMultiplier { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>True if the visual carries a variable SVG path.</summary>
+    public bool HasSvg { get; }
+    /// <summary>Top-left of the draw margin region in chart pixel coordinates.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+}


### PR DESCRIPTION
> _Drafted by Claude on Beto's behalf — review the prose, not just the diff._

## Summary

Applies the same template-method pattern as the bar refactor (#2269) to `CoreScatterSeries`. Adds two new public top-level types and splits the 223-line `Invalidate` into one sealed orchestrator plus five virtual hooks.

This is **step 2 of 8** of the cross-series Invalidate refactor planned for this PR series: once all series families follow the same template-method pattern, the truly shared bits can lift to the `Series<>` base. New series (range bars, Gantt, etc.) come after.

## What lands

**One commit, ~370 LOC of structural reorganization with no behavior change.**

New public top-level types:

- `ScatterMeasureContext` — readonly ref struct bundling chart + axes + scales + weight bounds + per-frame flags. Passed by `in` to all hooks.
- `ScatterLayout` — readonly struct carrying the per-point marker rect plus the data-point pixel (used for error-bar centering).

Five virtual hooks on `CoreScatterSeries`:

| Hook | Purpose |
|---|---|
| `BeginMeasure(chart)` | Build the context — axes, scales, weight bounds, isFirstDraw |
| `MeasureScatterLayout(point, ctx)` | Per-point marker rect with weight adjustment |
| `EnsureVisualForPoint(point, ctx)` | Visual + error visual creation, paint task attach |
| `MeasureErrorBars(point, layout, ctx)` | Per-frame OHLC-style whisker geometry |
| `CollapseEmptyVisual(point, ctx)` | Zero-size visual at the data point for empty/invisible |

Hooks are `protected virtual` (not abstract) because `CoreScatterSeries` is the only concrete class — future custom scatter variants (bubble, beeswarm, etc.) can override individual stages without overriding the orchestration.

## Behavior preservation

- **636 / 636** CoreTests pass — including `ScatterSeries_FirstDraw` and `ScatterSeries_DataChange` per-frame animation trajectories that pin the master baselines down to intermediate frames
- **142 / 142** SnapshotTests pass
- Builds clean across `net462`, `netstandard2.0`, `net8.0`, `net8.0-windows`

## Notes

- The original `CollapseEmptyVisual` block had `label.Y = x - hgs;` (X where it likely should have been `y`). The label is being faded out, so visually irrelevant, but the typo is preserved here to keep behavior bit-identical; a comment in `CollapseEmptyVisual` flags it for a future cleanup.
- Weight-adjusted geometry size is recomputed inside `MeasureScatterLayout` per-point from `ctx.WeightBounds + WeightMultiplier + point.TertiaryValue`, instead of the original's iteration-mutated `gs` / `hgs` locals.

## Test plan

- [x] `dotnet test tests/CoreTests/CoreTests.csproj -c Debug --framework net8.0` — 636/636 pass
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj -c Debug` — 142/142 pass
- [x] `dotnet build src/LiveChartsCore/LiveChartsCore.csproj -c Debug` — 0 errors across all 4 TFMs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)