### PR TITLE
refactor(heat): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/CoreHeatSeries.cs
+++ b/src/LiveChartsCore/CoreHeatSeries.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -33,7 +33,7 @@ using LiveChartsCore.Painting;
 namespace LiveChartsCore;
 
 /// <summary>
-/// Defines a column series.
+/// Defines a heat series.
 /// </summary>
 /// <typeparam name="TModel">The type of the model.</typeparam>
 /// <typeparam name="TVisual">The type of the visual.</typeparam>
@@ -99,27 +99,23 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
     /// <inheritdoc cref="IHeatSeries.MaxValue"/>
     public double? MaxValue { get; set => SetProperty(ref field, value); }
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
+    // ---- template method ----------------------------------------------------
+
+    /// <summary>
+    /// Builds a per-frame measure context from the chart. Subclasses may
+    /// override to refine context construction.
+    /// </summary>
+    protected virtual HeatMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
-        if (_paintTaks is null)
-        {
-            _paintTaks = LiveCharts.DefaultSettings.GetProvider().GetSolidColorPaint();
-            _paintTaks.PaintStyle = PaintStyle.Fill;
-        }
+        var primaryAxis = chart.GetYAxis(this);
+        var secondaryAxis = chart.GetXAxis(this);
 
-        var cartesianChart = (CartesianChartEngine)chart;
-        _ = GetAnimation(cartesianChart);
-
-        var primaryAxis = cartesianChart.GetYAxis(this);
-        var secondaryAxis = cartesianChart.GetXAxis(this);
-
-        var drawLocation = cartesianChart.DrawMarginLocation;
-        var drawMarginSize = cartesianChart.DrawMarginSize;
-        var secondaryScale = secondaryAxis.GetNextScaler(cartesianChart);
-        var primaryScale = primaryAxis.GetNextScaler(cartesianChart);
-        var previousPrimaryScale = primaryAxis.GetActualScaler(cartesianChart);
-        var previousSecondaryScale = secondaryAxis.GetActualScaler(cartesianChart);
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
+        var secondaryScale = secondaryAxis.GetNextScaler(chart);
+        var primaryScale = primaryAxis.GetNextScaler(chart);
+        var previousPrimaryScale = primaryAxis.GetActualScaler(chart);
+        var previousSecondaryScale = secondaryAxis.GetActualScaler(chart);
 
         // Cell size is driven by the actual data spacing (computed once per measure
         // cycle in GetBounds) rather than Axis.UnitWidth, which defaults to 1 and is
@@ -129,24 +125,6 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
         var uws = secondaryScale.MeasureInPixels(xStep);
         var uwp = primaryScale.MeasureInPixels(yStep);
 
-        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-
-        if (_paintTaks is not null)
-        {
-            _paintTaks.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(_paintTaks, zone: CanvasZone.DrawMargin);
-        }
-        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-        {
-            DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
-        }
-
-        var dls = (float)DataLabelsSize;
-        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
-
-        var p = PointPadding;
-
         if (_heatKnownLength != HeatMap.Length)
         {
             _heatStops = HeatFunctions.BuildColorStops(HeatMap, ColorStops);
@@ -154,84 +132,238 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
         }
 
         var hasSvg = this.HasVariableSvgGeometry();
+        var isFirstDraw = !((Chart)chart).IsDrawn(((ISeries)this).SeriesId);
 
-        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
+        return new HeatMeasureContext(
+            chart, primaryAxis, secondaryAxis,
+            primaryScale, secondaryScale,
+            previousPrimaryScale, previousSecondaryScale,
+            cellWidth: uws,
+            cellHeight: uwp,
+            pointPadding: PointPadding,
+            weightBounds: WeightBounds,
+            heatMap: HeatMap,
+            heatStops: _heatStops,
+            isFirstDraw: isFirstDraw,
+            hasSvg: hasSvg,
+            drawLocation: drawLocation,
+            drawMarginSize: drawMarginSize,
+            dataLabelsSize: (float)DataLabelsSize);
+    }
 
-        var provider = LiveCharts.DefaultSettings.GetProvider();
+    /// <summary>
+    /// Computes the final-frame cell rect + interpolated color for a single
+    /// heat cell.
+    /// </summary>
+    protected virtual HeatLayout MeasureHeatLayout(ChartPoint point, in HeatMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var primary = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue);
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var tertiary = (float)coordinate.TertiaryValue;
+
+        var color = HeatFunctions.InterpolateColor(tertiary, ctx.WeightBounds, ctx.HeatMap, ctx.HeatStops);
+
+        var uws = ctx.CellWidth;
+        var uwp = ctx.CellHeight;
+        var p = ctx.PointPadding;
+
+        return new HeatLayout(
+            x: secondary - uws * 0.5f + p.Left,
+            y: primary - uwp * 0.5f + p.Top,
+            width: uws - p.Left - p.Right,
+            height: uwp - p.Top - p.Bottom,
+            hoverX: secondary - uws * 0.5f,
+            hoverY: primary - uwp * 0.5f,
+            hoverWidth: uws,
+            hoverHeight: uwp,
+            color: color);
+    }
+
+    /// <summary>
+    /// Ensures the cell visual exists. On first creation initializes it with
+    /// transparent color so the heat color animates in via alpha. Mid-life
+    /// entries (the previous-scale-available branch) source the initial X/Y
+    /// from where the cell would have been in the previous frame's scaling.
+    /// </summary>
+    protected virtual TVisual EnsureVisualForPoint(ChartPoint point, in HeatMeasureContext ctx)
+    {
+        var visual = point.Context.Visual as TVisual;
+        if (visual is not null) return visual;
+
+        var coordinate = point.Coordinate;
+        var uws = ctx.CellWidth;
+        var uwp = ctx.CellHeight;
+        var p = ctx.PointPadding;
+
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var primary = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue);
+
+        var xi = secondary - uws * 0.5f;
+        var yi = primary - uwp * 0.5f;
+
+        if (ctx.PreviousSecondaryScale is not null && ctx.PreviousPrimaryScale is not null)
+        {
+            xi = ctx.PreviousSecondaryScale.ToPixels(coordinate.SecondaryValue) - uws * 0.5f;
+            yi = ctx.PreviousPrimaryScale.ToPixels(coordinate.PrimaryValue) - uwp * 0.5f;
+        }
+
+        var baseColor = HeatFunctions.InterpolateColor(
+            (float)coordinate.TertiaryValue, ctx.WeightBounds, ctx.HeatMap, ctx.HeatStops);
+
+        var r = new TVisual
+        {
+            X = xi + p.Left,
+            Y = yi + p.Top,
+            Width = uws - p.Left - p.Right,
+            Height = uwp - p.Top - p.Bottom,
+            Color = LvcColor.FromArgb(0, baseColor.R, baseColor.G, baseColor.B),
+        };
+
+        point.Context.Visual = r;
+        OnPointCreated(point);
+
+        _ = everFetched.Add(point);
+
+        return r;
+    }
+
+    /// <summary>
+    /// Collapses the cell to its current grid position with alpha=0 + remove-on-completed.
+    /// </summary>
+    protected virtual void CollapseEmptyVisual(ChartPoint point, in HeatMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var uws = ctx.CellWidth;
+        var uwp = ctx.CellHeight;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var primary = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue);
+
+        if (point.Context.Visual is TVisual visual)
+        {
+            visual.X = secondary - uws * 0.5f;
+            visual.Y = primary - uwp * 0.5f;
+            visual.Width = uws;
+            visual.Height = uwp;
+            visual.RemoveOnCompleted = true;
+            visual.Color = LvcColor.FromArgb(0, visual.Color);
+            point.Context.Visual = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            label.X = secondary - uws * 0.5f;
+            label.Y = primary - uwp * 0.5f;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+            point.Context.Label = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets per-Z-index ordering on the heat-fill paint + data-labels paint and
+    /// registers them as drawable tasks. Heat has no Fill / Stroke / ErrorPaint;
+    /// the shared <c>_paintTaks</c> SolidColorPaint carries every cell's color
+    /// via the per-visual <c>Color</c> property.
+    /// </summary>
+    private void InitializePaints(CartesianChartEngine chart)
+    {
+        if (_paintTaks is null)
+        {
+            _paintTaks = LiveCharts.DefaultSettings.GetProvider().GetSolidColorPaint();
+            _paintTaks.PaintStyle = PaintStyle.Fill;
+        }
+
+        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
+
+        _paintTaks.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
+        chart.Canvas.AddDrawableTask(_paintTaks, zone: CanvasZone.DrawMargin);
+
+        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
+        {
+            DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
+            chart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if it doesn't exist yet, updates its text
+    /// + style, and positions it via <c>GetLabelPosition</c> with the cell rect.
+    /// </summary>
+    private void MeasureDataLabel(ChartPoint point, in HeatLayout layout, in HeatMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default) return;
+
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        if (label is null)
+        {
+            // Preserves the original CoreHeatSeries quirk: initial label Y used
+            // `uws` (the X step) instead of `uwp` (the Y step). The label is
+            // animation-sourced so the position only matters for the first frame;
+            // snapshot baselines pin this behavior.
+            var primary = ctx.PrimaryScale.ToPixels(point.Coordinate.PrimaryValue);
+            var l = new TLabel
+            {
+                X = layout.HoverX,
+                Y = primary - ctx.CellWidth * 0.5f,
+                RotateTransform = (float)DataLabelsRotation,
+                MaxWidth = (float)DataLabelsMaxWidth,
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
+        }
+
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.Paint = DataLabelsPaint;
+
+        if (ctx.IsFirstDraw)
+            label.CompleteTransition(
+                BaseLabelGeometry.TextSizeProperty,
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty,
+                BaseLabelGeometry.RotateTransformProperty);
+
+        var labelPosition = GetLabelPosition(
+            layout.X, layout.Y, layout.Width, layout.Height,
+            label.Measure(), DataLabelsPosition, SeriesProperties,
+            point.Coordinate.PrimaryValue > Pivot, ctx.DrawLocation, ctx.DrawMarginSize);
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
+        var ctx = BeginMeasure(cartesianChart);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
+
+        InitializePaints(cartesianChart);
 
         foreach (var point in Fetch(cartesianChart))
         {
-            var coordinate = point.Coordinate;
-            var visual = point.Context.Visual as TVisual;
-            var primary = primaryScale.ToPixels(coordinate.PrimaryValue);
-            var secondary = secondaryScale.ToPixels(coordinate.SecondaryValue);
-            var tertiary = (float)coordinate.TertiaryValue;
-
-            var baseColor = HeatFunctions.InterpolateColor(tertiary, WeightBounds, HeatMap, _heatStops);
-
             if (point.IsEmpty || !IsVisible)
             {
-                if (visual is not null)
-                {
-                    visual.X = secondary - uws * 0.5f;
-                    visual.Y = primary - uwp * 0.5f;
-                    visual.Width = uws;
-                    visual.Height = uwp;
-                    visual.RemoveOnCompleted = true;
-                    visual.Color = LvcColor.FromArgb(0, visual.Color);
-                    point.Context.Visual = null;
-                }
-
-                if (point.Context.Label is not null)
-                {
-                    var label = (TLabel)point.Context.Label;
-
-                    label.X = secondary - uws * 0.5f;
-                    label.Y = primary - uwp * 0.5f;
-                    label.Opacity = 0;
-                    label.RemoveOnCompleted = true;
-
-                    point.Context.Label = null;
-                }
-
+                CollapseEmptyVisual(point, in ctx);
                 pointsCleanup.Clean(point);
-
                 continue;
             }
 
-            if (visual is null)
-            {
-                var xi = secondary - uws * 0.5f;
-                var yi = primary - uwp * 0.5f;
+            var visual = EnsureVisualForPoint(point, in ctx);
 
-                if (previousSecondaryScale is not null && previousPrimaryScale is not null)
-                {
-                    var previousP = previousPrimaryScale.ToPixels(pivot);
-                    var previousPrimary = previousPrimaryScale.ToPixels(coordinate.PrimaryValue);
-                    var bp = Math.Abs(previousPrimary - previousP);
-                    var cyp = coordinate.PrimaryValue > pivot ? previousPrimary : previousPrimary - bp;
-
-                    xi = previousSecondaryScale.ToPixels(coordinate.SecondaryValue) - uws * 0.5f;
-                    yi = previousPrimaryScale.ToPixels(coordinate.PrimaryValue) - uwp * 0.5f;
-                }
-
-                var r = new TVisual
-                {
-                    X = xi + p.Left,
-                    Y = yi + p.Top,
-                    Width = uws - p.Left - p.Right,
-                    Height = uwp - p.Top - p.Bottom,
-                    Color = LvcColor.FromArgb(0, baseColor.R, baseColor.G, baseColor.B)
-                };
-
-                visual = r;
-                point.Context.Visual = visual;
-                OnPointCreated(point);
-
-                _ = everFetched.Add(point);
-            }
-
-            if (hasSvg)
+            if (ctx.HasSvg)
             {
                 var svgVisual = (IVariableSvgPath)visual;
                 if (_geometrySvgChanged || svgVisual.SVGPath is null)
@@ -240,63 +372,31 @@ public abstract class CoreHeatSeries<TModel, TVisual, TLabel>
 
             _paintTaks?.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
-            visual.X = secondary - uws * 0.5f + p.Left;
-            visual.Y = primary - uwp * 0.5f + p.Top;
-            visual.Width = uws - p.Left - p.Right;
-            visual.Height = uwp - p.Top - p.Bottom;
-            visual.Color = LvcColor.FromArgb(baseColor.A, baseColor.R, baseColor.G, baseColor.B);
+            var layout = MeasureHeatLayout(point, in ctx);
+
+            visual.X = layout.X;
+            visual.Y = layout.Y;
+            visual.Width = layout.Width;
+            visual.Height = layout.Height;
+            visual.Color = layout.Color;
             visual.RemoveOnCompleted = false;
 
             if (point.Context.HoverArea is not RectangleHoverArea ha)
                 point.Context.HoverArea = ha = new RectangleHoverArea();
             _ = ha
-                .SetDimensions(secondary - uws * 0.5f, primary - uwp * 0.5f, uws, uwp)
+                .SetDimensions(layout.HoverX, layout.HoverY, layout.HoverWidth, layout.HoverHeight)
                 .CenterXToolTip()
                 .CenterYToolTip();
 
             pointsCleanup.Clean(point);
 
-            if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-            {
-                var label = (TLabel?)point.Context.Label;
-
-                if (label is null)
-                {
-                    var l = new TLabel { X = secondary - uws * 0.5f, Y = primary - uws * 0.5f, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                    l.Animate(
-                        GetAnimation(cartesianChart),
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty);
-                    label = l;
-                    point.Context.Label = l;
-                }
-
-                DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
-
-                label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = dls;
-                label.Padding = DataLabelsPadding;
-                label.Paint = DataLabelsPaint;
-
-                if (isFirstDraw)
-                    label.CompleteTransition(
-                        BaseLabelGeometry.TextSizeProperty,
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty,
-                        BaseLabelGeometry.RotateTransformProperty);
-
-                var labelPosition = GetLabelPosition(
-                     secondary - uws * 0.5f + p.Left, primary - uwp * 0.5f + p.Top, uws - p.Left - p.Right, uwp - p.Top - p.Bottom,
-                     label.Measure(), DataLabelsPosition, SeriesProperties, coordinate.PrimaryValue > Pivot, drawLocation, drawMarginSize);
-                label.X = labelPosition.X;
-                label.Y = labelPosition.Y;
-            }
+            MeasureDataLabel(point, in layout, in ctx);
 
             OnPointMeasured(point);
         }
 
         pointsCleanup.CollectPoints(
-            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+            everFetched, cartesianChart.View, ctx.PrimaryScale, ctx.SecondaryScale, SoftDeleteOrDisposePoint);
         _geometrySvgChanged = false;
     }
 

--- a/src/LiveChartsCore/HeatLayout.cs
+++ b/src/LiveChartsCore/HeatLayout.cs
@@ -1,0 +1,79 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Final per-frame geometry + heat color of a single heat cell, returned from
+/// <c>MeasureHeatLayout</c>. Heat cells differ from other rect-shaped series in
+/// that the dimensions are static (set once at the cell's grid position) while
+/// the color animates through the gradient based on the point's weight.
+/// </summary>
+public readonly struct HeatLayout
+{
+    /// <summary>Initializes a new instance of <see cref="HeatLayout"/>.</summary>
+    /// <param name="x">Cell rect top-left X (centered on the grid intersection minus padding).</param>
+    /// <param name="y">Cell rect top-left Y.</param>
+    /// <param name="width">Cell width in pixels.</param>
+    /// <param name="height">Cell height in pixels.</param>
+    /// <param name="hoverX">Hover-area top-left X (matches the gridded cell, before padding).</param>
+    /// <param name="hoverY">Hover-area top-left Y.</param>
+    /// <param name="hoverWidth">Hover-area width (pre-padding cell width).</param>
+    /// <param name="hoverHeight">Hover-area height (pre-padding cell height).</param>
+    /// <param name="color">Final heat color (interpolated from the gradient at the point's weight).</param>
+    public HeatLayout(
+        float x, float y, float width, float height,
+        float hoverX, float hoverY, float hoverWidth, float hoverHeight,
+        LvcColor color)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        HoverX = hoverX;
+        HoverY = hoverY;
+        HoverWidth = hoverWidth;
+        HoverHeight = hoverHeight;
+        Color = color;
+    }
+
+    /// <summary>Cell visual rect top-left X.</summary>
+    public float X { get; }
+    /// <summary>Cell visual rect top-left Y.</summary>
+    public float Y { get; }
+    /// <summary>Cell width.</summary>
+    public float Width { get; }
+    /// <summary>Cell height.</summary>
+    public float Height { get; }
+    /// <summary>Hover-area top-left X (cell grid without padding).</summary>
+    public float HoverX { get; }
+    /// <summary>Hover-area top-left Y.</summary>
+    public float HoverY { get; }
+    /// <summary>Hover-area width.</summary>
+    public float HoverWidth { get; }
+    /// <summary>Hover-area height.</summary>
+    public float HoverHeight { get; }
+    /// <summary>Interpolated heat color.</summary>
+    public LvcColor Color { get; }
+}

--- a/src/LiveChartsCore/HeatMeasureContext.cs
+++ b/src/LiveChartsCore/HeatMeasureContext.cs
@@ -1,0 +1,116 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method orchestration
+/// on <see cref="CoreHeatSeries{TModel, TVisual, TLabel}"/> and the per-cell
+/// <c>MeasureHeatLayout</c> hook. Ref struct so passing it by <c>in</c> to hooks
+/// costs nothing.
+/// </summary>
+public readonly ref struct HeatMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="HeatMeasureContext"/>.</summary>
+    public HeatMeasureContext(
+        CartesianChartEngine chart,
+        ICartesianAxis primaryAxis,
+        ICartesianAxis secondaryAxis,
+        Scaler primaryScale,
+        Scaler secondaryScale,
+        Scaler? previousPrimaryScale,
+        Scaler? previousSecondaryScale,
+        float cellWidth,
+        float cellHeight,
+        Padding pointPadding,
+        Bounds weightBounds,
+        LvcColor[] heatMap,
+        List<Tuple<double, LvcColor>> heatStops,
+        bool isFirstDraw,
+        bool hasSvg,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        float dataLabelsSize)
+    {
+        Chart = chart;
+        PrimaryAxis = primaryAxis;
+        SecondaryAxis = secondaryAxis;
+        PrimaryScale = primaryScale;
+        SecondaryScale = secondaryScale;
+        PreviousPrimaryScale = previousPrimaryScale;
+        PreviousSecondaryScale = previousSecondaryScale;
+        CellWidth = cellWidth;
+        CellHeight = cellHeight;
+        PointPadding = pointPadding;
+        WeightBounds = weightBounds;
+        HeatMap = heatMap;
+        HeatStops = heatStops;
+        IsFirstDraw = isFirstDraw;
+        HasSvg = hasSvg;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        DataLabelsSize = dataLabelsSize;
+    }
+
+    /// <summary>The chart engine.</summary>
+    public CartesianChartEngine Chart { get; }
+    /// <summary>Primary (Y) axis.</summary>
+    public ICartesianAxis PrimaryAxis { get; }
+    /// <summary>Secondary (X) axis.</summary>
+    public ICartesianAxis SecondaryAxis { get; }
+    /// <summary>Y-axis pixel scaler for the current frame.</summary>
+    public Scaler PrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the current frame.</summary>
+    public Scaler SecondaryScale { get; }
+    /// <summary>Y-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousPrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousSecondaryScale { get; }
+    /// <summary>Heat cell width in pixels (data-step-driven; see issue #1511).</summary>
+    public float CellWidth { get; }
+    /// <summary>Heat cell height in pixels.</summary>
+    public float CellHeight { get; }
+    /// <summary>Per-cell padding applied inside the grid square.</summary>
+    public Padding PointPadding { get; }
+    /// <summary>Weight bounds across the series (Min..Max of TertiaryValue).</summary>
+    public Bounds WeightBounds { get; }
+    /// <summary>Configured gradient stops (cold .. hot).</summary>
+    public LvcColor[] HeatMap { get; }
+    /// <summary>Pre-built gradient stop list for HeatFunctions.InterpolateColor.</summary>
+    public List<Tuple<double, LvcColor>> HeatStops { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>True if the visual carries a variable SVG path.</summary>
+    public bool HasSvg { get; }
+    /// <summary>Top-left of the draw margin region in chart pixel coordinates.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+}


### PR DESCRIPTION
> _Drafted by Claude on Beto's behalf — review the prose, not just the diff._

## Summary

Applies the same template-method pattern as the bar (#2269) and scatter (#2270) refactors to `CoreHeatSeries`. **Step 3 of 8** of the cross-series Invalidate refactor.

Heat is structurally simpler than scatter (no Fill/Stroke/ErrorPaint — just a shared `SolidColorPaint` whose color is set per-visual via the `Color` property; no error visuals; geometry dimensions are static while color animates). The template/hooks pattern still applies cleanly.

## What lands

Two new public top-level types:

- `HeatMeasureContext` — per-frame state (axes, scales, cell width/height, point padding, weight bounds, heat stops, draw margin, IsFirstDraw, hasSvg)
- `HeatLayout` — cell rect (with padding) + hover rect (full grid cell, pre-padding) + interpolated heat color

Five virtual hooks on `CoreHeatSeries`:

| Hook | Purpose |
|---|---|
| `BeginMeasure(chart)` | Context + cell-step derivation + lazy heat-stop rebuild |
| `MeasureHeatLayout(point, ctx)` | Per-cell rect + color |
| `EnsureVisualForPoint(point, ctx)` | Visual creation with transparent color (alpha fades in) |
| `CollapseEmptyVisual(point, ctx)` | alpha=0 + RemoveOnCompleted for empty/invisible cells |

Two private helpers (parallel to the bar/scatter PRs):

- `InitializePaints(chart)` — `_paintTaks` Z-index + AddDrawableTask
- `MeasureDataLabel(point, ...)` — label create/update/position cycle

## Behavior preservation

- **636 / 636** CoreTests pass — including `HeatSeries_FirstDraw` per-frame color trajectory from PR #2268, which pins the alpha fade-in (R/G/B static per cell, A interpolating 0 → 255)
- **142 / 142** SnapshotTests pass
- Multi-target build clean

## Quirk preserved

The original `CoreHeatSeries.Invalidate` set the label's initial Y to `primary - uws * 0.5f` (using the X step `uws` instead of Y step `uwp`). The label is animation-sourced from this position so the typo only affects the first frame's animation origin. Snapshot baselines pin the current behavior; a comment in `MeasureDataLabel` flags it. Fix is a one-character change (`uws` → `uwp`) in a future cleanup pass.

## Test plan

- [x] `dotnet test tests/CoreTests/CoreTests.csproj -c Debug --framework net8.0` — 636/636
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj -c Debug` — 142/142
- [x] `dotnet build src/LiveChartsCore/LiveChartsCore.csproj -c Debug` — 0 errors across all 4 TFMs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)