### PR TITLE
refactor(financial): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/CoreFinancialSeries.cs
+++ b/src/LiveChartsCore/CoreFinancialSeries.cs
@@ -1,4 +1,4 @@
-﻿
+
 // The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
@@ -39,7 +39,7 @@ namespace LiveChartsCore;
 /// <typeparam name="TModel">The type of the model.</typeparam>
 /// <typeparam name="TVisual">The type of the visual.</typeparam>
 /// <typeparam name="TLabel">The type of the label.</typeparam>
-/// <typeparam name="TMiniatureGeometry">The type of the miniature geometry, used in tool tips and legends.</typeparam> 
+/// <typeparam name="TMiniatureGeometry">The type of the miniature geometry, used in tool tips and legends.</typeparam>
 /// <seealso cref="CartesianSeries{TModel, TVisual, TLabel}" />
 /// <seealso cref="ICartesianSeries" />
 public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
@@ -103,27 +103,26 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
         set => SetPaintProperty(ref field, value);
     } = Paint.Default;
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
+    // ---- template method ----------------------------------------------------
+
+    /// <summary>
+    /// Builds a per-frame measure context from the chart.
+    /// </summary>
+    protected virtual FinancialMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
-        var cartesianChart = (CartesianChartEngine)chart;
-        _ = GetAnimation(cartesianChart);
+        var primaryAxis = chart.GetYAxis(this);
+        var secondaryAxis = chart.GetXAxis(this);
 
-        var primaryAxis = cartesianChart.GetYAxis(this);
-        var secondaryAxis = cartesianChart.GetXAxis(this);
-
-        var drawLocation = cartesianChart.DrawMarginLocation;
-        var drawMarginSize = cartesianChart.DrawMarginSize;
-        var secondaryScale = secondaryAxis.GetNextScaler(cartesianChart);
-        var primaryScale = primaryAxis.GetNextScaler(cartesianChart);
-        var previousPrimaryScale = primaryAxis.GetActualScaler(cartesianChart);
-        var previousSecondaryScale = secondaryAxis.GetActualScaler(cartesianChart);
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
+        var secondaryScale = secondaryAxis.GetNextScaler(chart);
+        var primaryScale = primaryAxis.GetNextScaler(chart);
+        var previousPrimaryScale = primaryAxis.GetActualScaler(chart);
+        var previousSecondaryScale = secondaryAxis.GetActualScaler(chart);
 
         var uw = secondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
         var puw = previousSecondaryScale is null ? 0 : previousSecondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
         var uwm = 0.5f * uw;
-
-        var tp = chart.TooltipPosition;
 
         if (uw > MaxBarWidth)
         {
@@ -132,214 +131,318 @@ public abstract class CoreFinancialSeries<TModel, TVisual, TLabel, TMiniatureGeo
             puw = uw;
         }
 
+        var isFirstDraw = !((Chart)chart).IsDrawn(((ISeries)this).SeriesId);
+
+        return new FinancialMeasureContext(
+            chart, primaryAxis, secondaryAxis,
+            primaryScale, secondaryScale,
+            previousPrimaryScale, previousSecondaryScale,
+            candleWidth: uw,
+            previousCandleWidth: puw,
+            halfCandleWidth: uwm,
+            tooltipPosition: chart.TooltipPosition,
+            isFirstDraw: isFirstDraw,
+            drawLocation: drawLocation,
+            drawMarginSize: drawMarginSize,
+            dataLabelsSize: (float)DataLabelsSize);
+    }
+
+    /// <summary>
+    /// Computes the final-frame candle geometry — body rect + OHLC pixel-Y
+    /// values + bullish flag.
+    /// </summary>
+    protected virtual FinancialLayout MeasureFinancialLayout(ChartPoint point, in FinancialMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+
+        var high = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue);
+        var open = ctx.PrimaryScale.ToPixels(coordinate.TertiaryValue);
+        var close = ctx.PrimaryScale.ToPixels(coordinate.QuaternaryValue);
+        var low = ctx.PrimaryScale.ToPixels(coordinate.QuinaryValue);
+
+        // open > close in pixel-Y means lower open VALUE than close VALUE — bullish.
+        return new FinancialLayout(
+            x: secondary - ctx.HalfCandleWidth,
+            y: high,
+            width: ctx.CandleWidth,
+            open: open,
+            close: close,
+            low: low,
+            isBullish: open > close);
+    }
+
+    /// <summary>
+    /// Ensures the visual exists. On first creation initializes it at the candle's
+    /// X position with all OHLC values collapsed to the open price, so the candle
+    /// expands from a horizontal line into its final shape.
+    /// </summary>
+    protected virtual TVisual EnsureVisualForPoint(ChartPoint point, in FinancialMeasureContext ctx)
+    {
+        var visual = point.Context.Visual as TVisual;
+        if (visual is not null) return visual;
+
+        var coordinate = point.Coordinate;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var open = ctx.PrimaryScale.ToPixels(coordinate.TertiaryValue);
+
+        var xi = secondary - ctx.HalfCandleWidth;
+        var uwi = ctx.CandleWidth;
+
+        // Mid-life entry: animate from previous-frame's position so a new candle
+        // joining an existing series doesn't pop in from origin.
+        if (ctx.PreviousSecondaryScale is not null && ctx.PreviousPrimaryScale is not null)
+        {
+            xi = ctx.PreviousSecondaryScale.ToPixels(coordinate.SecondaryValue) - ctx.HalfCandleWidth;
+            uwi = ctx.PreviousCandleWidth;
+        }
+
+        var middle = open;
+        var r = new TVisual
+        {
+            X = xi,
+            Width = uwi,
+            Y = middle,
+            Open = middle,
+            Close = middle,
+            Low = middle,
+        };
+
+        point.Context.Visual = r;
+        OnPointCreated(point);
+
+        _ = everFetched.Add(point);
+
+        return r;
+    }
+
+    /// <summary>
+    /// Collapses the candle to its open-Y line for empty/invisible points so the
+    /// visual fades out cleanly via the RemoveOnCompleted transition.
+    /// </summary>
+    protected virtual void CollapseEmptyVisual(ChartPoint point, in FinancialMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var middle = ctx.PrimaryScale.ToPixels(coordinate.TertiaryValue);
+
+        if (point.Context.Visual is TVisual visual)
+        {
+            visual.X = secondary - ctx.HalfCandleWidth;
+            visual.Width = ctx.CandleWidth;
+            visual.Y = middle;
+            visual.Open = middle;
+            visual.Close = middle;
+            visual.Low = middle;
+            visual.RemoveOnCompleted = true;
+            point.Context.Visual = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            label.X = secondary - ctx.HalfCandleWidth;
+            label.Y = middle;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+            point.Context.Label = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets per-Z-index ordering on the four candle paints + data-labels paint and
+    /// registers them as drawable tasks. Per-candle add/remove cycling between
+    /// Up* and Down* paints based on bullish/bearish state happens later via
+    /// <see cref="AttachVisualToPaints"/>.
+    /// </summary>
+    private void InitializePaints(CartesianChartEngine chart)
+    {
         var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
         if (UpFill is not null && UpFill != Paint.Default)
         {
             UpFill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(UpFill, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(UpFill, zone: CanvasZone.DrawMargin);
         }
         if (DownFill is not null && DownFill != Paint.Default)
         {
             DownFill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DownFill, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(DownFill, zone: CanvasZone.DrawMargin);
         }
         if (UpStroke is not null && UpStroke != Paint.Default)
         {
             UpStroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(UpStroke, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(UpStroke, zone: CanvasZone.DrawMargin);
         }
         if (DownStroke is not null && DownStroke != Paint.Default)
         {
             DownStroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DownStroke, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(DownStroke, zone: CanvasZone.DrawMargin);
         }
         if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
         {
             DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+        }
+    }
+
+    /// <summary>
+    /// Attaches the candle visual to the bullish or bearish paint pair, and
+    /// detaches it from the opposite pair — so the same visual can switch sides
+    /// as the candle flips between bullish and bearish across frames.
+    /// </summary>
+    private void AttachVisualToPaints(TVisual visual, bool isBullish, CartesianChartEngine chart)
+    {
+        if (isBullish)
+        {
+            if (UpFill is not null && UpFill != Paint.Default)
+                UpFill.AddGeometryToPaintTask(chart.Canvas, visual);
+            if (UpStroke is not null && UpStroke != Paint.Default)
+                UpStroke.AddGeometryToPaintTask(chart.Canvas, visual);
+            if (DownFill is not null && DownFill != Paint.Default)
+                DownFill.RemoveGeometryFromPaintTask(chart.Canvas, visual);
+            if (DownStroke is not null && DownStroke != Paint.Default)
+                DownStroke.RemoveGeometryFromPaintTask(chart.Canvas, visual);
+        }
+        else
+        {
+            if (DownFill is not null && DownFill != Paint.Default)
+                DownFill.AddGeometryToPaintTask(chart.Canvas, visual);
+            if (DownStroke is not null && DownStroke != Paint.Default)
+                DownStroke.AddGeometryToPaintTask(chart.Canvas, visual);
+            if (UpFill is not null && UpFill != Paint.Default)
+                UpFill.RemoveGeometryFromPaintTask(chart.Canvas, visual);
+            if (UpStroke is not null && UpStroke != Paint.Default)
+                UpStroke.RemoveGeometryFromPaintTask(chart.Canvas, visual);
+        }
+    }
+
+    /// <summary>
+    /// Configures the hover-area tooltip anchor based on the chart's
+    /// <see cref="TooltipPosition"/>. Unlike Cartesian bars (Start/EndY by pivot),
+    /// candlesticks honor the full set of positions because tooltips usually
+    /// follow the OHLC summary panel.
+    /// </summary>
+    private static void ConfigureHoverAnchor(RectangleHoverArea ha, TooltipPosition tp)
+    {
+        switch (tp)
+        {
+            case TooltipPosition.Hidden:
+                break;
+            case TooltipPosition.Auto:
+            case TooltipPosition.Top: _ = ha.CenterXToolTip().StartYToolTip(); break;
+            case TooltipPosition.Bottom: _ = ha.CenterXToolTip().EndYToolTip(); break;
+            case TooltipPosition.Left: _ = ha.StartXToolTip().CenterYToolTip(); break;
+            case TooltipPosition.Right: _ = ha.EndXToolTip().CenterYToolTip(); break;
+            case TooltipPosition.Center: _ = ha.CenterXToolTip().CenterYToolTip(); break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if needed, updates its text + style, and
+    /// positions it via <c>GetLabelPosition</c> with the candle's body rect.
+    /// </summary>
+    private void MeasureDataLabel(ChartPoint point, in FinancialLayout layout, in FinancialMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default) return;
+
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        if (label is null)
+        {
+            var l = new TLabel
+            {
+                X = layout.X,
+                Y = layout.Y,
+                RotateTransform = (float)DataLabelsRotation,
+                MaxWidth = (float)DataLabelsMaxWidth,
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
         }
 
-        var dls = (float)DataLabelsSize;
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.Paint = DataLabelsPaint;
+
+        if (ctx.IsFirstDraw)
+            label.CompleteTransition(
+                BaseLabelGeometry.TextSizeProperty,
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty,
+                BaseLabelGeometry.RotateTransformProperty);
+
+        var m = label.Measure();
+        var labelPosition = GetLabelPosition(
+            layout.X, layout.Y, layout.Width, layout.Height, m, DataLabelsPosition,
+            SeriesProperties, point.Coordinate.PrimaryValue > Pivot, ctx.DrawLocation, ctx.DrawMarginSize);
+        if (DataLabelsTranslate is not null)
+            label.TranslateTransform = new LvcPoint(
+                m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
+
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
+        var ctx = BeginMeasure(cartesianChart);
         var pointsCleanup = ChartPointCleanupContext.For(everFetched);
 
-        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
+        InitializePaints(cartesianChart);
 
         foreach (var point in Fetch(cartesianChart))
         {
-            var coordinate = point.Coordinate;
-            var visual = point.Context.Visual as TVisual;
-            var secondary = secondaryScale.ToPixels(coordinate.SecondaryValue);
-
-            var high = primaryScale.ToPixels(coordinate.PrimaryValue);
-            var open = primaryScale.ToPixels(coordinate.TertiaryValue);
-            var close = primaryScale.ToPixels(coordinate.QuaternaryValue);
-            var low = primaryScale.ToPixels(coordinate.QuinaryValue);
-            var middle = open;
-
             if (point.IsEmpty || !IsVisible)
             {
-                if (visual is not null)
-                {
-                    visual.X = secondary - uwm;
-                    visual.Width = uw;
-                    visual.Y = middle; // y coordinate is the highest
-                    visual.Open = middle;
-                    visual.Close = middle;
-                    visual.Low = middle;
-                    visual.RemoveOnCompleted = true;
-                    point.Context.Visual = null;
-                }
-
-                if (point.Context.Label is not null)
-                {
-                    var label = (TLabel)point.Context.Label;
-
-                    label.X = secondary - uwm;
-                    label.Y = middle;
-                    label.Opacity = 0;
-                    label.RemoveOnCompleted = true;
-
-                    point.Context.Label = null;
-                }
-
+                CollapseEmptyVisual(point, in ctx);
                 pointsCleanup.Clean(point);
-
                 continue;
             }
 
-            if (visual is null)
-            {
-                var xi = secondary - uwm;
-                var uwi = uw;
+            var visual = EnsureVisualForPoint(point, in ctx);
 
-                if (previousSecondaryScale is not null && previousPrimaryScale is not null)
-                {
-                    var previousP = previousPrimaryScale.ToPixels(pivot);
-                    var previousPrimary = previousPrimaryScale.ToPixels(coordinate.PrimaryValue);
-                    var bp = Math.Abs(previousPrimary - previousP);
-                    var cyp = coordinate.PrimaryValue > pivot ? previousPrimary : previousPrimary - bp;
+            var layout = MeasureFinancialLayout(point, in ctx);
 
-                    xi = previousSecondaryScale.ToPixels(coordinate.SecondaryValue) - uwm;
-                    uwi = puw;
-                }
+            AttachVisualToPaints(visual, layout.IsBullish, cartesianChart);
 
-                var r = new TVisual
-                {
-                    X = xi,
-                    Width = uwi,
-                    Y = middle, // y == high
-                    Open = middle,
-                    Close = middle,
-                    Low = middle
-                };
-
-                visual = r;
-                point.Context.Visual = visual;
-                OnPointCreated(point);
-
-                _ = everFetched.Add(point);
-            }
-
-            if (open > close)
-            {
-                if (UpFill is not null && UpFill != Paint.Default)
-                    UpFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (UpStroke is not null && UpStroke != Paint.Default)
-                    UpStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (DownFill is not null && DownFill != Paint.Default)
-                    DownFill.RemoveGeometryFromPaintTask(cartesianChart.Canvas, visual);
-                if (DownStroke is not null && DownStroke != Paint.Default)
-                    DownStroke.RemoveGeometryFromPaintTask(cartesianChart.Canvas, visual);
-            }
-            else
-            {
-                if (DownFill is not null && DownFill != Paint.Default)
-                    DownFill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (DownStroke is not null && DownStroke != Paint.Default)
-                    DownStroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
-                if (UpFill is not null && UpFill != Paint.Default)
-                    UpFill.RemoveGeometryFromPaintTask(cartesianChart.Canvas, visual);
-                if (UpStroke is not null && UpStroke != Paint.Default)
-                    UpStroke.RemoveGeometryFromPaintTask(cartesianChart.Canvas, visual);
-            }
-
-            var x = secondary - uwm;
-
-            visual.X = x;
-            visual.Width = uw;
-            visual.Y = high;
-            visual.Open = open;
-            visual.Close = close;
-            visual.Low = low;
+            visual.X = layout.X;
+            visual.Width = layout.Width;
+            visual.Y = layout.Y;
+            visual.Open = layout.Open;
+            visual.Close = layout.Close;
+            visual.Low = layout.Low;
             visual.RemoveOnCompleted = false;
 
             if (point.Context.HoverArea is not RectangleHoverArea ha)
                 point.Context.HoverArea = ha = new RectangleHoverArea();
 
-            _ = ha.SetDimensions(secondary - uwm, high, uw, Math.Abs(low - high));
+            _ = ha.SetDimensions(layout.X, layout.Y, layout.Width, layout.Height);
 
-            switch (tp)
-            {
-                case TooltipPosition.Hidden:
-                    break;
-                case TooltipPosition.Auto:
-                case TooltipPosition.Top: _ = ha.CenterXToolTip().StartYToolTip(); break;
-                case TooltipPosition.Bottom: _ = ha.CenterXToolTip().EndYToolTip(); break;
-                case TooltipPosition.Left: _ = ha.StartXToolTip().CenterYToolTip(); break;
-                case TooltipPosition.Right: _ = ha.EndXToolTip().CenterYToolTip(); break;
-                case TooltipPosition.Center: _ = ha.CenterXToolTip().CenterYToolTip(); break;
-                default:
-                    break;
-            }
+            ConfigureHoverAnchor(ha, ctx.TooltipPosition);
 
             pointsCleanup.Clean(point);
 
-            if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-            {
-                var label = (TLabel?)point.Context.Label;
-
-                if (label is null)
-                {
-                    var l = new TLabel { X = secondary - uwm, Y = high, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                    l.Animate(
-                        GetAnimation(cartesianChart),
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty);
-                    label = l;
-                    point.Context.Label = l;
-                }
-
-                DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
-
-                label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = dls;
-                label.Padding = DataLabelsPadding;
-                label.Paint = DataLabelsPaint;
-
-                if (isFirstDraw)
-                    label.CompleteTransition(
-                        BaseLabelGeometry.TextSizeProperty,
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty,
-                        BaseLabelGeometry.RotateTransformProperty);
-
-                var m = label.Measure();
-                var labelPosition = GetLabelPosition(
-                    x, high, uw, Math.Abs(low - high), m, DataLabelsPosition,
-                    SeriesProperties, coordinate.PrimaryValue > Pivot, drawLocation, drawMarginSize);
-                if (DataLabelsTranslate is not null) label.TranslateTransform =
-                        new LvcPoint(m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
-
-                label.X = labelPosition.X;
-                label.Y = labelPosition.Y;
-            }
+            MeasureDataLabel(point, in layout, in ctx);
 
             OnPointMeasured(point);
         }
 
         pointsCleanup.CollectPoints(
-            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+            everFetched, cartesianChart.View, ctx.PrimaryScale, ctx.SecondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="ICartesianSeries.GetBounds(Chart, ICartesianAxis, ICartesianAxis)"/>

--- a/src/LiveChartsCore/FinancialLayout.cs
+++ b/src/LiveChartsCore/FinancialLayout.cs
@@ -1,0 +1,73 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Final per-frame geometry of a single candle, returned from
+/// <c>MeasureFinancialLayout</c>. The candle body spans (X, Y=high) →
+/// (X+Width, Low); Open / Close are intermediate pixel-Y values bounded
+/// by High (smallest) and Low (largest) since the Y axis grows downward.
+/// </summary>
+public readonly struct FinancialLayout
+{
+    /// <summary>Initializes a new instance of <see cref="FinancialLayout"/>.</summary>
+    /// <param name="x">Body left edge (secondary - half-width).</param>
+    /// <param name="y">High pixel-Y (top of the candle).</param>
+    /// <param name="width">Candle body width.</param>
+    /// <param name="open">Open pixel-Y.</param>
+    /// <param name="close">Close pixel-Y.</param>
+    /// <param name="low">Low pixel-Y (bottom of the candle).</param>
+    /// <param name="isBullish">
+    /// True when the candle is bullish (close value &gt; open value). In pixel-Y
+    /// space — where lower Y means higher value — this is <c>open > close</c>.
+    /// Drives which paint pair (Up* vs Down*) the visual attaches to.
+    /// </param>
+    public FinancialLayout(float x, float y, float width, float open, float close, float low, bool isBullish)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Open = open;
+        Close = close;
+        Low = low;
+        IsBullish = isBullish;
+    }
+
+    /// <summary>Body left edge.</summary>
+    public float X { get; }
+    /// <summary>High pixel-Y (top of the candle's vertical extent).</summary>
+    public float Y { get; }
+    /// <summary>Candle body width.</summary>
+    public float Width { get; }
+    /// <summary>Open pixel-Y.</summary>
+    public float Open { get; }
+    /// <summary>Close pixel-Y.</summary>
+    public float Close { get; }
+    /// <summary>Low pixel-Y (bottom of the candle's vertical extent).</summary>
+    public float Low { get; }
+    /// <summary>True when the close value is greater than the open value.</summary>
+    public bool IsBullish { get; }
+
+    /// <summary>Total vertical extent in pixels (Low - Y, since Y axis grows down).</summary>
+    public float Height => Low - Y;
+}

--- a/src/LiveChartsCore/FinancialMeasureContext.cs
+++ b/src/LiveChartsCore/FinancialMeasureContext.cs
@@ -1,0 +1,101 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method
+/// orchestration on <see cref="CoreFinancialSeries{TModel, TVisual, TLabel, TMiniatureGeometry}"/>
+/// and the per-point <c>MeasureFinancialLayout</c> hook.
+/// </summary>
+public readonly ref struct FinancialMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="FinancialMeasureContext"/>.</summary>
+    public FinancialMeasureContext(
+        CartesianChartEngine chart,
+        ICartesianAxis primaryAxis,
+        ICartesianAxis secondaryAxis,
+        Scaler primaryScale,
+        Scaler secondaryScale,
+        Scaler? previousPrimaryScale,
+        Scaler? previousSecondaryScale,
+        float candleWidth,
+        float previousCandleWidth,
+        float halfCandleWidth,
+        TooltipPosition tooltipPosition,
+        bool isFirstDraw,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        float dataLabelsSize)
+    {
+        Chart = chart;
+        PrimaryAxis = primaryAxis;
+        SecondaryAxis = secondaryAxis;
+        PrimaryScale = primaryScale;
+        SecondaryScale = secondaryScale;
+        PreviousPrimaryScale = previousPrimaryScale;
+        PreviousSecondaryScale = previousSecondaryScale;
+        CandleWidth = candleWidth;
+        PreviousCandleWidth = previousCandleWidth;
+        HalfCandleWidth = halfCandleWidth;
+        TooltipPosition = tooltipPosition;
+        IsFirstDraw = isFirstDraw;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        DataLabelsSize = dataLabelsSize;
+    }
+
+    /// <summary>The chart engine.</summary>
+    public CartesianChartEngine Chart { get; }
+    /// <summary>Primary (Y) axis = value axis for financial.</summary>
+    public ICartesianAxis PrimaryAxis { get; }
+    /// <summary>Secondary (X) axis = time axis for financial.</summary>
+    public ICartesianAxis SecondaryAxis { get; }
+    /// <summary>Y-axis pixel scaler for the current frame.</summary>
+    public Scaler PrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the current frame.</summary>
+    public Scaler SecondaryScale { get; }
+    /// <summary>Y-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousPrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousSecondaryScale { get; }
+    /// <summary>Candle body width in pixels (clamped to MaxBarWidth).</summary>
+    public float CandleWidth { get; }
+    /// <summary>Previous-frame candle width (animation source).</summary>
+    public float PreviousCandleWidth { get; }
+    /// <summary>Half the candle width (precomputed centering offset).</summary>
+    public float HalfCandleWidth { get; }
+    /// <summary>Tooltip anchor position resolved from the chart at the start of measure.</summary>
+    public TooltipPosition TooltipPosition { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>Top-left of the draw margin region in chart pixel coordinates.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+}


### PR DESCRIPTION
> _Drafted by Claude on Beto's behalf — review the prose, not just the diff._

## Summary

Applies the template-method pattern (parallel to #2269/#2270/#2271) to `CoreFinancialSeries`. **Step 4 of 8** of the cross-series Invalidate refactor.

Financial introduces two complications the earlier PRs didn't have:

1. **Four paints, not two.** UpFill/DownFill/UpStroke/DownStroke — and each candle attaches to either the Up* pair OR the Down* pair based on `open > close` (in pixel-Y, which means a bullish candle). Same visual can flip between pairs across frames, so the helper handles add+remove symmetrically.

2. **Full tooltip-position handling.** Candles honor the full `TooltipPosition` enum (Top/Bottom/Left/Right/Center) — unlike Cartesian bars which only do Start/End Y by pivot. Lifted out as a static helper.

## What lands

New public top-level types:

- `FinancialMeasureContext` — axes + scales + candle width / half-width / previous-width + tooltip position + draw margin + IsFirstDraw
- `FinancialLayout` — body rect (X, Y=high, Width) + OHLC pixel-Y (Open, Close, Low) + IsBullish flag

Four virtual hooks:

| Hook | Purpose |
|---|---|
| `BeginMeasure(chart)` | Axes + scales + candle width clamped to MaxBarWidth |
| `MeasureFinancialLayout(point, ctx)` | OHLC pixel values + IsBullish |
| `EnsureVisualForPoint(point, ctx)` | Visual with OHLC collapsed to open (candle expands from a horizontal line) |
| `CollapseEmptyVisual(point, ctx)` | Collapse to open-Y for empty/invisible points |

Three private helpers:

- `InitializePaints(chart)` — UpFill/DownFill/UpStroke/DownStroke + DataLabelsPaint Z-index + AddDrawableTask
- `AttachVisualToPaints(visual, isBullish, chart)` — add to bullish OR bearish pair + remove from the opposite
- `MeasureDataLabel(point, layout, ctx)` — label create/update/position

Plus a static `ConfigureHoverAnchor(ha, tooltipPosition)` for the full tooltip-position switch.

## Behavior preservation

- **636 / 636** CoreTests pass — including `CandlestickSeries_FirstDraw` and `CandlestickSeries_DataChange` per-frame trajectories from PR #2268 that pin OHLC pixel motion
- **142 / 142** SnapshotTests pass
- Multi-target build clean

## Test plan

- [x] `dotnet test tests/CoreTests/CoreTests.csproj -c Debug --framework net8.0` — 636/636
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj -c Debug` — 142/142
- [x] `dotnet build src/LiveChartsCore/LiveChartsCore.csproj -c Debug` — 0 errors across all 4 TFMs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)