### PR TITLE
refactor(box): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/BoxLayout.cs
+++ b/src/LiveChartsCore/BoxLayout.cs
@@ -1,0 +1,70 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Final per-frame geometry of a single box-and-whisker visual, returned from
+/// <c>MeasureBoxLayout</c>. The body spans (X, Y=max) → (X+Width, Min), with
+/// Third / Median / First as intermediate pixel-Y values.
+/// </summary>
+public readonly struct BoxLayout
+{
+    /// <summary>Initializes a new instance of <see cref="BoxLayout"/>.</summary>
+    public BoxLayout(
+        float x, float y, float width,
+        float third, float first, float min, float median,
+        float categoryHoverX, float categoryHoverWidth)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Third = third;
+        First = first;
+        Min = min;
+        Median = median;
+        CategoryHoverX = categoryHoverX;
+        CategoryHoverWidth = categoryHoverWidth;
+    }
+
+    /// <summary>Body left edge.</summary>
+    public float X { get; }
+    /// <summary>Max pixel-Y (top of the whisker).</summary>
+    public float Y { get; }
+    /// <summary>Body width.</summary>
+    public float Width { get; }
+    /// <summary>Third quartile pixel-Y.</summary>
+    public float Third { get; }
+    /// <summary>First quartile pixel-Y.</summary>
+    public float First { get; }
+    /// <summary>Min pixel-Y (bottom of the whisker).</summary>
+    public float Min { get; }
+    /// <summary>Median pixel-Y (line inside the box).</summary>
+    public float Median { get; }
+    /// <summary>Category-wide hover-area top-left X (centered on the category, ignores series-stacking offset).</summary>
+    public float CategoryHoverX { get; }
+    /// <summary>Category-wide hover-area width (axis unit-width, not series-divided width).</summary>
+    public float CategoryHoverWidth { get; }
+
+    /// <summary>Total whisker extent in pixels.</summary>
+    public float Height => Min - Y;
+}

--- a/src/LiveChartsCore/BoxMeasureContext.cs
+++ b/src/LiveChartsCore/BoxMeasureContext.cs
@@ -1,0 +1,105 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method
+/// orchestration on <see cref="CoreBoxSeries{TModel, TVisual, TLabel, TMiniatureGeometry}"/>
+/// and the per-point <c>MeasureBoxLayout</c> hook.
+/// </summary>
+public readonly ref struct BoxMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="BoxMeasureContext"/>.</summary>
+    public BoxMeasureContext(
+        CartesianChartEngine chart,
+        ICartesianAxis primaryAxis,
+        ICartesianAxis secondaryAxis,
+        Scaler primaryScale,
+        Scaler secondaryScale,
+        Scaler? previousPrimaryScale,
+        Scaler? previousSecondaryScale,
+        BoxMeasureHelper helper,
+        float categoryUnitWidth,
+        float previousCategoryUnitWidth,
+        float halfCategoryUnitWidth,
+        TooltipPosition tooltipPosition,
+        bool isFirstDraw,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        float dataLabelsSize)
+    {
+        Chart = chart;
+        PrimaryAxis = primaryAxis;
+        SecondaryAxis = secondaryAxis;
+        PrimaryScale = primaryScale;
+        SecondaryScale = secondaryScale;
+        PreviousPrimaryScale = previousPrimaryScale;
+        PreviousSecondaryScale = previousSecondaryScale;
+        Helper = helper;
+        CategoryUnitWidth = categoryUnitWidth;
+        PreviousCategoryUnitWidth = previousCategoryUnitWidth;
+        HalfCategoryUnitWidth = halfCategoryUnitWidth;
+        TooltipPosition = tooltipPosition;
+        IsFirstDraw = isFirstDraw;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        DataLabelsSize = dataLabelsSize;
+    }
+
+    /// <summary>The chart engine.</summary>
+    public CartesianChartEngine Chart { get; }
+    /// <summary>Primary (Y) value axis.</summary>
+    public ICartesianAxis PrimaryAxis { get; }
+    /// <summary>Secondary (X) category axis.</summary>
+    public ICartesianAxis SecondaryAxis { get; }
+    /// <summary>Y-axis pixel scaler for the current frame.</summary>
+    public Scaler PrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the current frame.</summary>
+    public Scaler SecondaryScale { get; }
+    /// <summary>Y-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousPrimaryScale { get; }
+    /// <summary>X-axis pixel scaler for the previous frame; null on first draw.</summary>
+    public Scaler? PreviousSecondaryScale { get; }
+    /// <summary>Per-series box position primitives (uw, uwm, cp, p, actualUw).</summary>
+    public BoxMeasureHelper Helper { get; }
+    /// <summary>Raw axis unit-width in pixels (pre-MaxBarWidth clamp).</summary>
+    public float CategoryUnitWidth { get; }
+    /// <summary>Previous-frame raw axis unit-width.</summary>
+    public float PreviousCategoryUnitWidth { get; }
+    /// <summary>Half the raw axis unit-width.</summary>
+    public float HalfCategoryUnitWidth { get; }
+    /// <summary>Tooltip anchor position resolved from the chart.</summary>
+    public TooltipPosition TooltipPosition { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>Top-left of the draw margin region in chart pixel coordinates.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+}

--- a/src/LiveChartsCore/BoxMeasureHelper.cs
+++ b/src/LiveChartsCore/BoxMeasureHelper.cs
@@ -1,0 +1,95 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Computes the per-series box-position primitives (unit-width, half-unit-width,
+/// center-position, pivot pixel) for a single frame. Promoted from a nested type
+/// on <see cref="CoreBoxSeries{TModel, TVisual, TLabel, TMiniatureGeometry}"/> so
+/// the template-method <see cref="BoxMeasureContext"/> can pass it via <c>in</c>
+/// to per-point hooks.
+/// </summary>
+public sealed class BoxMeasureHelper
+{
+    /// <summary>Initializes a new instance of <see cref="BoxMeasureHelper"/>.</summary>
+    public BoxMeasureHelper(
+        Scaler scaler,
+        CartesianChartEngine cartesianChart,
+        IBoxSeries boxSeries,
+        ICartesianAxis axis,
+        float p,
+        float minP,
+        float maxP)
+    {
+        this.p = p;
+        if (p < minP) this.p = minP;
+        if (p > maxP) this.p = maxP;
+
+        uw = scaler.MeasureInPixels(axis.UnitWidth);
+        actualUw = uw;
+
+        var gp = (float)boxSeries.Padding;
+
+        if (uw - gp < 1) gp -= uw - gp;
+
+        uw -= gp;
+        uwm = 0.5f * uw;
+
+        var pos = cartesianChart.SeriesContext.GetBoxPosition(boxSeries);
+        var count = cartesianChart.SeriesContext.GetBoxSeriesCount();
+
+        cp = 0f;
+
+        var padding = (float)boxSeries.Padding;
+
+        uw /= count;
+        var mw = (float)boxSeries.MaxBarWidth;
+        if (uw > mw) uw = mw;
+        uwm = 0.5f * uw;
+        cp = (pos - count / 2f) * uw + uwm;
+
+        // apply the padding
+        uw -= padding;
+        cp += padding * 0.5f;
+
+        if (uw < 1)
+        {
+            uw = 1;
+            uwm = 0.5f;
+        }
+    }
+
+    /// <summary>Effective box body width (after padding + position).</summary>
+    public float uw;
+    /// <summary>Half the effective box width.</summary>
+    public float uwm;
+    /// <summary>Center position offset for this series within the category.</summary>
+    public float cp;
+    /// <summary>Pivot pixel position (clamped to draw margin).</summary>
+    public float p;
+    /// <summary>Raw axis unit-width (before padding), used for category-wide hover rects.</summary>
+    public float actualUw;
+}

--- a/src/LiveChartsCore/CoreBoxSeries.cs
+++ b/src/LiveChartsCore/CoreBoxSeries.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -34,7 +34,7 @@ using LiveChartsCore.Painting;
 namespace LiveChartsCore;
 
 /// <summary>
-/// Defines a candle sticks series.
+/// Defines a box-and-whisker series.
 /// </summary>
 /// <typeparam name="TModel">The type of the model.</typeparam>
 /// <typeparam name="TVisual">The type of the visual.</typeparam>
@@ -82,30 +82,32 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     /// <inheritdoc cref="IBoxSeries.Padding"/>
     public double Padding { get; set => SetProperty(ref field, value); } = 5;
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
+    // ---- template method ----------------------------------------------------
+
+    /// <summary>
+    /// Builds a per-frame measure context from the chart.
+    /// </summary>
+    protected virtual BoxMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
-        var cartesianChart = (CartesianChartEngine)chart;
-        _ = GetAnimation(cartesianChart);
+        var primaryAxis = chart.GetYAxis(this);
+        var secondaryAxis = chart.GetXAxis(this);
 
-        var primaryAxis = cartesianChart.GetYAxis(this);
-        var secondaryAxis = cartesianChart.GetXAxis(this);
-
-        var drawLocation = cartesianChart.DrawMarginLocation;
-        var drawMarginSize = cartesianChart.DrawMarginSize;
-        var secondaryScale = secondaryAxis.GetNextScaler(cartesianChart);
-        var primaryScale = primaryAxis.GetNextScaler(cartesianChart);
-        var previousPrimaryScale = primaryAxis.GetActualScaler(cartesianChart);
-        var previousSecondaryScale = secondaryAxis.GetActualScaler(cartesianChart);
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
+        var secondaryScale = secondaryAxis.GetNextScaler(chart);
+        var primaryScale = primaryAxis.GetNextScaler(chart);
+        var previousPrimaryScale = primaryAxis.GetActualScaler(chart);
+        var previousSecondaryScale = secondaryAxis.GetActualScaler(chart);
 
         var uw = secondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
         var puw = previousSecondaryScale is null ? 0 : previousSecondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
         var uwm = 0.5f * uw;
 
-        var helper = new MeasureHelper(secondaryScale, cartesianChart, this, secondaryAxis, primaryScale.ToPixels(pivot),
-            cartesianChart.DrawMarginLocation.Y, cartesianChart.DrawMarginLocation.Y + cartesianChart.DrawMarginSize.Height);
-
-        var tp = chart.TooltipPosition;
+        var helper = new BoxMeasureHelper(
+            secondaryScale, chart, this, secondaryAxis,
+            primaryScale.ToPixels(pivot),
+            chart.DrawMarginLocation.Y,
+            chart.DrawMarginLocation.Y + chart.DrawMarginSize.Height);
 
         if (uw > MaxBarWidth)
         {
@@ -114,186 +116,283 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
             puw = uw;
         }
 
+        var isFirstDraw = !((Chart)chart).IsDrawn(((ISeries)this).SeriesId);
+
+        return new BoxMeasureContext(
+            chart, primaryAxis, secondaryAxis,
+            primaryScale, secondaryScale,
+            previousPrimaryScale, previousSecondaryScale,
+            helper: helper,
+            categoryUnitWidth: uw,
+            previousCategoryUnitWidth: puw,
+            halfCategoryUnitWidth: uwm,
+            tooltipPosition: chart.TooltipPosition,
+            isFirstDraw: isFirstDraw,
+            drawLocation: drawLocation,
+            drawMarginSize: drawMarginSize,
+            dataLabelsSize: (float)DataLabelsSize);
+    }
+
+    /// <summary>
+    /// Computes the final-frame box geometry — body rect + five quartile/extremum
+    /// pixel-Y values.
+    /// </summary>
+    protected virtual BoxLayout MeasureBoxLayout(ChartPoint point, in BoxMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var helper = ctx.Helper;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+
+        var high = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue);
+        var open = ctx.PrimaryScale.ToPixels(coordinate.TertiaryValue);
+        var close = ctx.PrimaryScale.ToPixels(coordinate.QuaternaryValue);
+        var low = ctx.PrimaryScale.ToPixels(coordinate.QuinaryValue);
+        var median = ctx.PrimaryScale.ToPixels(coordinate.SenaryValue);
+
+        var x = secondary - helper.uwm + helper.cp;
+
+        return new BoxLayout(
+            x: x,
+            y: high,
+            width: helper.uw,
+            third: open,
+            first: close,
+            min: low,
+            median: median,
+            categoryHoverX: secondary - helper.actualUw * 0.5f,
+            categoryHoverWidth: helper.actualUw);
+    }
+
+    /// <summary>
+    /// Ensures the visual exists. On first creation initializes it at the box's
+    /// X position with all five quartile/extremum values collapsed to the median,
+    /// so the box expands from a horizontal line.
+    /// </summary>
+    protected virtual TVisual EnsureVisualForPoint(ChartPoint point, in BoxMeasureContext ctx)
+    {
+        var visual = point.Context.Visual as TVisual;
+        if (visual is not null) return visual;
+
+        var coordinate = point.Coordinate;
+        var helper = ctx.Helper;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var median = ctx.PrimaryScale.ToPixels(coordinate.SenaryValue);
+
+        var xi = secondary - helper.uwm + helper.cp;
+        var uwi = helper.uw;
+
+        // Mid-life entry: animate from previous frame's position.
+        if (ctx.PreviousSecondaryScale is not null && ctx.PreviousPrimaryScale is not null)
+        {
+            xi = ctx.PreviousSecondaryScale.ToPixels(coordinate.SecondaryValue) - ctx.HalfCategoryUnitWidth;
+            uwi = helper.uw;
+        }
+
+        var r = new TVisual
+        {
+            X = xi,
+            Width = uwi,
+            Y = median,
+            Third = median,
+            First = median,
+            Min = median,
+            Median = median,
+        };
+
+        point.Context.Visual = r;
+        OnPointCreated(point);
+
+        _ = everFetched.Add(point);
+
+        return r;
+    }
+
+    /// <summary>
+    /// Collapses the box to its median-Y line for empty/invisible points.
+    /// </summary>
+    protected virtual void CollapseEmptyVisual(ChartPoint point, in BoxMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var helper = ctx.Helper;
+        var secondary = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        var median = ctx.PrimaryScale.ToPixels(coordinate.SenaryValue);
+
+        if (point.Context.Visual is TVisual visual)
+        {
+            visual.X = secondary - helper.uwm + helper.cp;
+            visual.Width = ctx.CategoryUnitWidth;
+            visual.Y = median;
+            visual.Third = median;
+            visual.First = median;
+            visual.Min = median;
+            visual.Median = median;
+            visual.RemoveOnCompleted = true;
+            point.Context.Visual = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            label.X = secondary - helper.uwm + helper.cp;
+            label.Y = median;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+            point.Context.Label = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets per-Z-index ordering on Fill / Stroke / DataLabelsPaint and registers
+    /// them as drawable tasks. Box has no error paints.
+    /// </summary>
+    private void InitializePaints(CartesianChartEngine chart)
+    {
         var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
 
         if (Stroke is not null && Stroke != Paint.Default)
         {
             Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
         }
         if (Fill is not null && Fill != Paint.Default)
         {
             Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
         }
         if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
         {
             DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
-            cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+            chart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
+        }
+    }
+
+    /// <summary>
+    /// Configures the hover-area tooltip anchor based on the chart's
+    /// <see cref="TooltipPosition"/>. Box honors the full set of positions like
+    /// candlesticks.
+    /// </summary>
+    private static void ConfigureHoverAnchor(RectangleHoverArea ha, TooltipPosition tp)
+    {
+        switch (tp)
+        {
+            case TooltipPosition.Hidden:
+                break;
+            case TooltipPosition.Auto:
+            case TooltipPosition.Top: _ = ha.CenterXToolTip().StartYToolTip(); break;
+            case TooltipPosition.Bottom: _ = ha.CenterXToolTip().EndYToolTip(); break;
+            case TooltipPosition.Left: _ = ha.StartXToolTip().CenterYToolTip(); break;
+            case TooltipPosition.Right: _ = ha.EndXToolTip().CenterYToolTip(); break;
+            case TooltipPosition.Center: _ = ha.CenterXToolTip().CenterYToolTip(); break;
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if needed, updates its text + style, and
+    /// positions it via <c>GetLabelPosition</c> with the box's body rect.
+    /// </summary>
+    private void MeasureDataLabel(ChartPoint point, in BoxLayout layout, in BoxMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default) return;
+
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        if (label is null)
+        {
+            var l = new TLabel
+            {
+                X = layout.X,
+                Y = layout.Y,
+                RotateTransform = (float)DataLabelsRotation,
+                MaxWidth = (float)DataLabelsMaxWidth,
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
         }
 
-        var dls = (float)DataLabelsSize;
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.Paint = DataLabelsPaint;
+
+        var m = label.Measure();
+        var labelPosition = GetLabelPosition(
+            layout.X, layout.Y, layout.Width, layout.Height, m, DataLabelsPosition,
+            SeriesProperties, point.Coordinate.PrimaryValue > Pivot, ctx.DrawLocation, ctx.DrawMarginSize);
+        if (DataLabelsTranslate is not null)
+            label.TranslateTransform = new LvcPoint(
+                m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
+
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
+        var ctx = BeginMeasure(cartesianChart);
         var pointsCleanup = ChartPointCleanupContext.For(everFetched);
+
+        InitializePaints(cartesianChart);
 
         foreach (var point in Fetch(cartesianChart))
         {
-            var coordinate = point.Coordinate;
-            var visual = point.Context.Visual as TVisual;
-            var secondary = secondaryScale.ToPixels(coordinate.SecondaryValue);
-
-            var high = primaryScale.ToPixels(coordinate.PrimaryValue);
-            var open = primaryScale.ToPixels(coordinate.TertiaryValue);
-            var close = primaryScale.ToPixels(coordinate.QuaternaryValue);
-            var low = primaryScale.ToPixels(coordinate.QuinaryValue);
-            var median = primaryScale.ToPixels(coordinate.SenaryValue);
-            var middle = open;
-
             if (point.IsEmpty || !IsVisible)
             {
-                if (visual is not null)
-                {
-                    visual.X = secondary - helper.uwm + helper.cp;
-                    visual.Width = uw;
-                    visual.Y = median; // y coordinate is the highest
-                    visual.Third = median;
-                    visual.First = median;
-                    visual.Min = median;
-                    visual.Median = median;
-                    visual.RemoveOnCompleted = true;
-                    point.Context.Visual = null;
-                }
-
-                if (point.Context.Label is not null)
-                {
-                    var label = (TLabel)point.Context.Label;
-
-                    label.X = secondary - helper.uwm + helper.cp;
-                    label.Y = median;
-                    label.Opacity = 0;
-                    label.RemoveOnCompleted = true;
-
-                    point.Context.Label = null;
-                }
-
+                CollapseEmptyVisual(point, in ctx);
                 pointsCleanup.Clean(point);
-
                 continue;
             }
 
-            if (visual is null)
-            {
-                var xi = secondary - helper.uwm + helper.cp;
-                var uwi = helper.uw;
-
-                if (previousSecondaryScale is not null && previousPrimaryScale is not null)
-                {
-                    var previousP = previousPrimaryScale.ToPixels(pivot);
-                    var previousPrimary = previousPrimaryScale.ToPixels(coordinate.PrimaryValue);
-                    var bp = Math.Abs(previousPrimary - previousP);
-                    var cyp = coordinate.PrimaryValue > pivot ? previousPrimary : previousPrimary - bp;
-
-                    xi = previousSecondaryScale.ToPixels(coordinate.SecondaryValue) - uwm;
-                    uwi = helper.uw;
-                }
-
-                var r = new TVisual
-                {
-                    X = xi,
-                    Width = uwi,
-                    Y = median, // y == high
-                    Third = median,
-                    First = median,
-                    Min = median,
-                    Median = median
-                };
-
-                visual = r;
-                point.Context.Visual = visual;
-                OnPointCreated(point);
-
-                _ = everFetched.Add(point);
-            }
+            var visual = EnsureVisualForPoint(point, in ctx);
 
             if (Stroke is not null && Stroke != Paint.Default)
                 Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
             if (Fill is not null && Fill != Paint.Default)
                 Fill.AddGeometryToPaintTask(cartesianChart.Canvas, visual);
 
-            var x = secondary - helper.uwm + helper.cp;
+            var layout = MeasureBoxLayout(point, in ctx);
 
-            visual.X = x;
-            visual.Width = helper.uw;
-            visual.Y = high;
-            visual.Third = open;
-            visual.First = close;
-            visual.Min = low;
-            visual.Median = median;
+            visual.X = layout.X;
+            visual.Width = layout.Width;
+            visual.Y = layout.Y;
+            visual.Third = layout.Third;
+            visual.First = layout.First;
+            visual.Min = layout.Min;
+            visual.Median = layout.Median;
             visual.RemoveOnCompleted = false;
 
             if (point.Context.HoverArea is not RectangleHoverArea ha)
                 point.Context.HoverArea = ha = new RectangleHoverArea();
 
-            _ = ha.SetDimensions(secondary - helper.actualUw * 0.5f, high, helper.actualUw, Math.Abs(low - high));
+            _ = ha.SetDimensions(layout.CategoryHoverX, layout.Y, layout.CategoryHoverWidth, layout.Height);
 
             if (chart.FindingStrategy == FindingStrategy.ExactMatch)
                 _ = ha
-                    .SetDimensions(x, high, helper.uw, low)
+                    .SetDimensions(layout.X, layout.Y, layout.Width, layout.Min)
                     .CenterXToolTip();
 
-            switch (tp)
-            {
-                case TooltipPosition.Hidden:
-                    break;
-                case TooltipPosition.Auto:
-                case TooltipPosition.Top: _ = ha.CenterXToolTip().StartYToolTip(); break;
-                case TooltipPosition.Bottom: _ = ha.CenterXToolTip().EndYToolTip(); break;
-                case TooltipPosition.Left: _ = ha.StartXToolTip().CenterYToolTip(); break;
-                case TooltipPosition.Right: _ = ha.EndXToolTip().CenterYToolTip(); break;
-                case TooltipPosition.Center: _ = ha.CenterXToolTip().CenterYToolTip(); break;
-                default:
-                    break;
-            }
+            ConfigureHoverAnchor(ha, ctx.TooltipPosition);
 
             pointsCleanup.Clean(point);
 
-            if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-            {
-                var label = (TLabel?)point.Context.Label;
-
-                if (label is null)
-                {
-                    var l = new TLabel { X = secondary - helper.uwm + helper.cp, Y = high, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                    l.Animate(
-                        GetAnimation(cartesianChart),
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty);
-                    label = l;
-                    point.Context.Label = l;
-                }
-
-                DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
-
-                label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = dls;
-                label.Padding = DataLabelsPadding;
-                label.Paint = DataLabelsPaint;
-
-                var m = label.Measure();
-                var labelPosition = GetLabelPosition(
-                    x, high, helper.uw, Math.Abs(low - high), m, DataLabelsPosition,
-                    SeriesProperties, coordinate.PrimaryValue > Pivot, drawLocation, drawMarginSize);
-                if (DataLabelsTranslate is not null) label.TranslateTransform =
-                        new LvcPoint(m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
-
-                label.X = labelPosition.X;
-                label.Y = labelPosition.Y;
-            }
+            MeasureDataLabel(point, in layout, in ctx);
 
             OnPointMeasured(point);
         }
 
         pointsCleanup.CollectPoints(
-            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+            everFetched, cartesianChart.View, ctx.PrimaryScale, ctx.SecondaryScale, SoftDeleteOrDisposePoint);
     }
 
     /// <inheritdoc cref="Series{TModel, TVisual, TLabel}.FindPointsInPosition(Chart, LvcPoint, FindingStrategy, FindPointFor)"/>
@@ -437,76 +536,6 @@ public abstract class CoreBoxSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     {
         base.OnPaintChanged(propertyName);
         OnPropertyChanged();
-    }
-
-    /// <summary>
-    /// A mesure helper class.
-    /// </summary>
-    protected class MeasureHelper
-    {
-        /// <summary>
-        /// Initializes a new instance of the measue helper class.
-        /// </summary>
-        /// <param name="scaler">The scaler.</param>
-        /// <param name="cartesianChart">The chart.</param>
-        /// <param name="boxSeries">The series.</param>
-        /// <param name="axis">The axis.</param>
-        /// <param name="p">The pivot.</param>
-        /// <param name="minP">The min pivot allowed.</param>
-        /// <param name="maxP">The max pivot allowed.</param>
-        public MeasureHelper(
-            Scaler scaler,
-            CartesianChartEngine cartesianChart,
-            IBoxSeries boxSeries,
-            ICartesianAxis axis,
-            float p,
-            float minP,
-            float maxP)
-        {
-            this.p = p;
-            if (p < minP) this.p = minP;
-            if (p > maxP) this.p = maxP;
-
-            uw = scaler.MeasureInPixels(axis.UnitWidth);
-            actualUw = uw;
-
-            var gp = (float)boxSeries.Padding;
-
-            if (uw - gp < 1) gp -= uw - gp;
-
-            uw -= gp;
-            uwm = 0.5f * uw;
-
-            int pos, count;
-
-            pos = cartesianChart.SeriesContext.GetBoxPosition(boxSeries);
-            count = cartesianChart.SeriesContext.GetBoxSeriesCount();
-
-            cp = 0f;
-
-            var padding = (float)boxSeries.Padding;
-
-            uw /= count;
-            var mw = (float)boxSeries.MaxBarWidth;
-            if (uw > mw) uw = mw;
-            uwm = 0.5f * uw;
-            cp = (pos - count / 2f) * uw + uwm;
-
-            // apply the pading
-            uw -= padding;
-            cp += padding * 0.5f;
-
-            if (uw < 1)
-            {
-                uw = 1;
-                uwm = 0.5f;
-            }
-        }
-
-        /// <summary>
-        /// helper units.
-        /// </summary>
-        public float uw, uwm, cp, p, actualUw;
     }
 
     private static SeriesProperties GetProperties()


### PR DESCRIPTION
> _Drafted by Claude on Beto's behalf — review the prose, not just the diff._

## Summary

Applies the template-method pattern to `CoreBoxSeries`. **Step 5 of 8** of the cross-series Invalidate refactor.

Structurally similar to financial (#2272) — five-value visuals with a custom hit-test override — but uses standard Fill/Stroke (not Up*/Down* pairs) and has a per-series `BoxMeasureHelper` for box-position math within the category.

## What lands

Three new public top-level types:

- `BoxMeasureHelper` — per-series box-position primitives (promoted from a nested class)
- `BoxMeasureContext` — per-frame state (axes, scales, helper, category unit-width + previous, tooltip position, draw margin, IsFirstDraw)
- `BoxLayout` — body rect + 5 quartile/extremum pixel-Y + category hover rect

Four virtual hooks: `BeginMeasure`, `MeasureBoxLayout`, `EnsureVisualForPoint`, `CollapseEmptyVisual`.

Three private helpers (+ one static): `InitializePaints`, `ConfigureHoverAnchor`, `MeasureDataLabel`.

The custom `FindPointsInPosition` for ExactMatch (uses `v.Min` instead of `v.Height` for hit-test) is unchanged.

## Behavior preservation

- **636 / 636** CoreTests pass — including `BoxSeries_FirstDraw` and `BoxSeries_DataChange` per-frame trajectories from PR #2268 that pin Third / Median / First / Min motion
- **142 / 142** SnapshotTests pass
- Multi-target build clean

## Test plan

- [x] CoreTests, SnapshotTests, multi-target build
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)