### PR TITLE
refactor(pie): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/CorePieSeries.cs
+++ b/src/LiveChartsCore/CorePieSeries.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -57,9 +57,6 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     /// <summary>
     /// Gets or sets the stroke.
     /// </summary>
-    /// <value>
-    /// The stroke.
-    /// </value>
     public Paint? Stroke
     {
         get;
@@ -69,9 +66,6 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     /// <summary>
     /// Gets or sets the fill.
     /// </summary>
-    /// <value>
-    /// The fill.
-    /// </value>
     public Paint? Fill
     {
         get;
@@ -118,12 +112,9 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     public PolarLabelsPosition DataLabelsPosition { get; set => SetProperty(ref field, value); } = PolarLabelsPosition.Middle;
 
     /// <summary>
-    /// Gets or sets the tool tip label formatter for the Y axis, this function will build the label when a point in this series 
+    /// Gets or sets the tool tip label formatter for the Y axis, this function will build the label when a point in this series
     /// is shown inside a tool tip.
     /// </summary>
-    /// <value>
-    /// The tool tip label formatter.
-    /// </value>
     public Func<ChartPoint<TModel, TVisual, TLabel>, string>? ToolTipLabelFormatter
     {
         get => _tooltipLabelFormatter;
@@ -136,17 +127,21 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
         set => SetProperty(ref _tooltipLabelFormatter, value);
     }
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
-    {
-        var pieChart = (PieChartEngine)chart;
-        _ = GetAnimation(pieChart);
+    // ---- template method ----------------------------------------------------
 
-        var drawLocation = pieChart.DrawMarginLocation;
-        var drawMarginSize = pieChart.DrawMarginSize;
+    /// <summary>
+    /// Builds a per-frame measure context from the chart. Resolves the available
+    /// radial space (subtracting stroke / pushout / outer-label correction),
+    /// rotation parameters, and applies the <see cref="RadialAlign"/> clamp when
+    /// the computed radial width exceeds <see cref="MaxRadialColumnWidth"/>.
+    /// </summary>
+    protected virtual PieMeasureContext BeginMeasure(PieChartEngine chart, int sliceCount)
+    {
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
         var minDimension = drawMarginSize.Width < drawMarginSize.Height ? drawMarginSize.Width : drawMarginSize.Height;
 
-        var maxPushout = (float)pieChart.PushoutBounds.Max;
+        var maxPushout = (float)chart.PushoutBounds.Max;
         var pushout = (float)Pushout;
         var innerRadius = (float)InnerRadius;
 
@@ -158,41 +153,12 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
         var outerRadiusOffset = (float)OuterRadiusOffset;
         minDimension -= outerRadiusOffset;
 
-        var view = (IPieChartView)pieChart.View;
+        var view = (IPieChartView)chart.View;
         var initialRotation = (float)Math.Truncate(view.InitialRotation);
         var completeAngle = (float)view.MaxAngle;
 
         var startValue = view.MinValue;
         double? chartTotal = double.IsNaN(view.MaxValue) ? null : view.MaxValue;
-
-        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
-        if (Fill is not null && Fill != Paint.Default)
-        {
-            Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-            pieChart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
-        }
-        if (Stroke is not null && Stroke != Paint.Default)
-        {
-            Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-            pieChart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
-        }
-        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-        {
-            DataLabelsPaint.ZIndex = PaintConstants.PieSeriesDataLabelsBaseZIndex + actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
-            // this does not require clipping...
-            //DataLabelsPaint.SetClipRectangle(pieChart.Canvas, new LvcRectangle(drawLocation, drawMarginSize));
-            pieChart.Canvas.AddDrawableTask(DataLabelsPaint);
-        }
-
-        var cx = drawLocation.X + drawMarginSize.Width * 0.5f;
-        var cy = drawLocation.Y + drawMarginSize.Height * 0.5f;
-
-        var dls = (float)DataLabelsSize;
-        var stacker = pieChart.SeriesContext.GetStackPosition(this, GetStackGroup())
-            ?? throw new NullReferenceException("Unexpected null stacker");
-        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
-
-        var fetched = Fetch(pieChart).ToArray();
 
         var stackedInnerRadius = innerRadius;
         var relativeInnerRadius = (float)RelativeInnerRadius;
@@ -201,7 +167,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
         var cornerRadius = (float)CornerRadius;
 
         var mdc = minDimension;
-        var wc = mdc - (mdc - 2 * innerRadius) * (fetched.Length - 1) / fetched.Length - relativeOuterRadius * 2;
+        var wc = mdc - (mdc - 2 * innerRadius) * (sliceCount - 1) / sliceCount - relativeOuterRadius * 2;
 
         if (wc * 0.5f - stackedInnerRadius > maxRadialWidth)
         {
@@ -226,6 +192,303 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
             }
         }
 
+        var stacker = chart.SeriesContext.GetStackPosition(this, GetStackGroup())
+            ?? throw new NullReferenceException("Unexpected null stacker");
+
+        var cx = drawLocation.X + drawMarginSize.Width * 0.5f;
+        var cy = drawLocation.Y + drawMarginSize.Height * 0.5f;
+
+        var isFirstDraw = !((Chart)chart).IsDrawn(((ISeries)this).SeriesId);
+
+        return new PieMeasureContext(
+            chart, cx, cy,
+            minDimension: minDimension,
+            innerRadius: innerRadius,
+            pushOut: pushout,
+            relativeInnerRadius: relativeInnerRadius,
+            relativeOuterRadius: relativeOuterRadius,
+            cornerRadius: cornerRadius,
+            initialRotation: initialRotation,
+            completeAngle: completeAngle,
+            startValue: startValue,
+            chartTotal: chartTotal,
+            isClockWise: view.IsClockwise,
+            stacker: stacker,
+            sliceCount: sliceCount,
+            isFirstDraw: isFirstDraw,
+            drawLocation: drawLocation,
+            drawMarginSize: drawMarginSize,
+            dataLabelsSize: (float)DataLabelsSize);
+    }
+
+    /// <summary>
+    /// Computes the per-slice angular and radial geometry. Takes the current
+    /// running <paramref name="stackedInnerRadius"/> and <paramref name="sliceIndex"/>
+    /// (1-based) so the radial math can stack outward through nested rings.
+    /// </summary>
+    protected virtual PieLayout MeasurePieLayout(
+        ChartPoint point,
+        float stackedInnerRadius,
+        int sliceIndex,
+        in PieMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+
+        var stack = ctx.Stacker.GetStack(point);
+        var stackedValue = stack.Start;
+        var total = ctx.ChartTotal ?? stack.Total;
+
+        double start, sweep;
+
+        if (total == 0)
+        {
+            start = 0;
+            sweep = 0;
+        }
+        else
+        {
+            // Clamp the stack so a value greater than the chart's effective range
+            // cannot produce a sweep larger than the chart's complete angle, which
+            // renders as a broken arc (issue #2131). The cap differs per branch
+            // because each one uses a different denominator for the angle math.
+            if (IsRelativeToMinValue)
+            {
+                var h = total - ctx.StartValue;
+                var clampedStackedValue = Math.Min(stackedValue, h);
+                var clampedTop = Math.Min(stackedValue + coordinate.PrimaryValue, h);
+                var h1 = clampedTop;
+                start = clampedStackedValue / h * ctx.CompleteAngle;
+                sweep = h1 / h * ctx.CompleteAngle - start;
+                if (!ctx.IsClockWise) start = ctx.CompleteAngle - start - sweep;
+            }
+            else
+            {
+                var clampedStackedValue = Math.Min(stackedValue, total);
+                var clampedTop = Math.Min(stackedValue + coordinate.PrimaryValue, total);
+                var h = total - ctx.StartValue;
+                var h1 = clampedTop - ctx.StartValue;
+                start = clampedStackedValue / total * ctx.CompleteAngle;
+                sweep = h1 / h * ctx.CompleteAngle - start;
+                if (!ctx.IsClockWise) start = ctx.CompleteAngle - start - sweep;
+            }
+        }
+
+        if (IsFillSeries)
+        {
+            start = 0;
+            sweep = ctx.CompleteAngle - 0.1f;
+        }
+
+        var md = ctx.MinDimension;
+        var stackedOuterRadius = md - (md - 2 * ctx.InnerRadius) * (ctx.SliceCount - sliceIndex) / ctx.SliceCount - ctx.RelativeOuterRadius * 2;
+
+        var sweepF = (float)sweep;
+        // Issue #2131 — clamp a full-circle sweep just under 360 so the path stays
+        // closed instead of degenerating into a broken arc.
+        if ((float)start + ctx.InitialRotation == ctx.InitialRotation && sweep == 360)
+            sweepF = 359.99f;
+
+        return new PieLayout(
+            centerX: ctx.CenterX,
+            centerY: ctx.CenterY,
+            x: ctx.DrawLocation.X + (ctx.DrawMarginSize.Width - stackedOuterRadius) * 0.5f,
+            y: ctx.DrawLocation.Y + (ctx.DrawMarginSize.Height - stackedOuterRadius) * 0.5f,
+            width: stackedOuterRadius,
+            height: stackedOuterRadius,
+            startAngle: (float)(start + ctx.InitialRotation),
+            sweepAngle: sweepF,
+            pushOut: ctx.PushOut,
+            innerRadius: stackedInnerRadius,
+            outerRadius: stackedOuterRadius,
+            cornerRadius: ctx.CornerRadius);
+    }
+
+    /// <summary>
+    /// Ensures the visual exists. On first creation initializes the slice at zero
+    /// size at the chart center so the slice sweeps outward and grows.
+    /// </summary>
+    protected virtual TVisual EnsureVisualForPoint(ChartPoint point, double startAngle, in PieMeasureContext ctx)
+    {
+        var visual = point.Context.Visual as TVisual;
+        if (visual is not null) return visual;
+
+        var p = new TVisual
+        {
+            CenterX = ctx.CenterX,
+            CenterY = ctx.CenterY,
+            X = ctx.CenterX,
+            Y = ctx.CenterY,
+            Width = 0,
+            Height = 0,
+            StartAngle = (float)(ctx.IsFirstDraw ? ctx.InitialRotation : startAngle + ctx.InitialRotation),
+            SweepAngle = 0,
+            PushOut = 0,
+            InnerRadius = 0,
+            CornerRadius = 0,
+        };
+
+        point.Context.Visual = p;
+        OnPointCreated(point);
+
+        _ = everFetched.Add(point);
+
+        return p;
+    }
+
+    /// <summary>
+    /// Collapses the slice to zero size at the chart center for empty/invisible
+    /// points so the slice fades / shrinks out cleanly.
+    /// </summary>
+    protected virtual void CollapseEmptyVisual(ChartPoint point, in PieMeasureContext ctx)
+    {
+        if (point.Context.Visual is TVisual visual)
+        {
+            visual.CenterX = ctx.CenterX;
+            visual.CenterY = ctx.CenterY;
+            visual.X = ctx.CenterX;
+            visual.Y = ctx.CenterY;
+            visual.Width = 0;
+            visual.Height = 0;
+            visual.SweepAngle = 0;
+            visual.StartAngle = ctx.InitialRotation;
+            visual.PushOut = 0;
+            visual.InnerRadius = 0;
+            visual.CornerRadius = 0;
+            visual.RemoveOnCompleted = true;
+            point.Context.Visual = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            label.X = ctx.CenterX;
+            label.Y = ctx.CenterY;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+            point.Context.Label = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets per-Z-index ordering on Fill / Stroke / DataLabelsPaint and registers
+    /// them as drawable tasks. Data labels use a special base offset
+    /// (PieSeriesDataLabelsBaseZIndex) so they always sit above slices, and don't
+    /// clip to the draw margin.
+    /// </summary>
+    private void InitializePaints(PieChartEngine chart)
+    {
+        var actualZIndex = ZIndex == 0 ? ((ISeries)this).SeriesId : ZIndex;
+
+        if (Fill is not null && Fill != Paint.Default)
+        {
+            Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
+            chart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
+        }
+        if (Stroke is not null && Stroke != Paint.Default)
+        {
+            Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
+            chart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
+        }
+        if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
+        {
+            DataLabelsPaint.ZIndex = PaintConstants.PieSeriesDataLabelsBaseZIndex + actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
+            chart.Canvas.AddDrawableTask(DataLabelsPaint);
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if needed, updates its text + style, and
+    /// positions it via <c>GetLabelPolarPosition</c> using the slice's angular
+    /// extent and inner / outer radii. Handles tangent / cotangent rotation
+    /// modifiers from <see cref="LiveCharts.TangentAngle"/>.
+    /// </summary>
+    private void MeasureDataLabel(
+        ChartPoint point,
+        in PieLayout layout,
+        float stackedInnerRadius,
+        float stackedOuterRadius,
+        float baseRotation,
+        bool isTangent,
+        bool isCotangent,
+        in PieMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default || IsFillSeries) return;
+
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        var middleAngle = layout.StartAngle + layout.SweepAngle * 0.5f;
+
+        var actualRotation = baseRotation +
+                (isTangent ? middleAngle - 90 : 0) +
+                (isCotangent ? middleAngle : 0);
+
+        if ((isTangent || isCotangent) && ((actualRotation + 90) % 360) > 180)
+            actualRotation += 180;
+
+        if (label is null)
+        {
+            var l = new TLabel
+            {
+                X = ctx.CenterX,
+                Y = ctx.CenterY,
+                RotateTransform = actualRotation,
+                MaxWidth = (float)DataLabelsMaxWidth,
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
+        }
+
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.RotateTransform = actualRotation;
+        label.Paint = DataLabelsPaint;
+
+        var start = layout.StartAngle - ctx.InitialRotation;
+        AlignLabel(label, start, ctx.InitialRotation, layout.SweepAngle);
+
+        if (ctx.IsFirstDraw)
+            label.CompleteTransition(
+                BaseLabelGeometry.TextSizeProperty,
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty,
+                BaseLabelGeometry.RotateTransformProperty);
+
+        var labelPosition = GetLabelPolarPosition(
+            ctx.CenterX,
+            ctx.CenterY,
+            stackedInnerRadius,
+            (stackedOuterRadius + ctx.RelativeOuterRadius * 2) * 0.5f,
+            layout.StartAngle,
+            layout.SweepAngle,
+            label.Measure(),
+            DataLabelsPosition);
+
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var pieChart = (PieChartEngine)chart;
+        _ = GetAnimation(pieChart);
+
+        var fetched = Fetch(pieChart).ToArray();
+        var ctx = BeginMeasure(pieChart, fetched.Length);
+        var pointsCleanup = ChartPointCleanupContext.For(everFetched);
+
+        InitializePaints(pieChart);
+
+        // Decode TangentAngle / CotangentAngle modifiers from DataLabelsRotation
+        // once per measure cycle (they're stored as flag bits on top of the
+        // numeric rotation angle).
         var r = (float)DataLabelsRotation;
         var isTangent = false;
         var isCotangent = false;
@@ -242,224 +505,94 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
             isCotangent = true;
         }
 
-        var i = 1f;
-        var isClockWise = view.IsClockwise;
-
-        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
+        var stackedInnerRadius = ctx.InnerRadius;
+        var i = 1;
 
         foreach (var point in fetched)
         {
-            var coordinate = point.Coordinate;
-            var visual = point.Context.Visual as TVisual;
-
             if (point.IsEmpty || !IsVisible)
             {
-                if (visual is not null)
-                {
-                    visual.CenterX = cx;
-                    visual.CenterY = cy;
-                    visual.X = cx;
-                    visual.Y = cy;
-                    visual.Width = 0;
-                    visual.Height = 0;
-                    visual.SweepAngle = 0;
-                    visual.StartAngle = initialRotation;
-                    visual.PushOut = 0;
-                    visual.InnerRadius = 0;
-                    visual.CornerRadius = 0;
-                    visual.RemoveOnCompleted = true;
-                    point.Context.Visual = null;
-                }
-
-                if (point.Context.Label is not null)
-                {
-                    var label = (TLabel)point.Context.Label;
-
-                    label.X = cx;
-                    label.Y = cy;
-                    label.Opacity = 0;
-                    label.RemoveOnCompleted = true;
-
-                    point.Context.Label = null;
-                }
-
+                CollapseEmptyVisual(point, in ctx);
                 pointsCleanup.Clean(point);
 
-                var md2 = minDimension;
-                var w2 = md2 - (md2 - 2 * innerRadius) * (fetched.Length - i) / fetched.Length - relativeOuterRadius * 2;
-                stackedInnerRadius = (w2 + relativeOuterRadius * 2) * 0.5f;
+                // Advance the stacking radius even for empty slices so the next
+                // visible slice doesn't pile up on top of an invisible one.
+                var md2 = ctx.MinDimension;
+                var w2 = md2 - (md2 - 2 * ctx.InnerRadius) * (fetched.Length - i) / fetched.Length - ctx.RelativeOuterRadius * 2;
+                stackedInnerRadius = (w2 + ctx.RelativeOuterRadius * 2) * 0.5f;
                 i++;
                 continue;
             }
 
-            var stack = stacker.GetStack(point);
+            // Compute the slice's pre-layout start angle so EnsureVisualForPoint
+            // can seed mid-life entries (a slice appearing after isFirstDraw) with
+            // a sensible animation source.
+            var stack = ctx.Stacker.GetStack(point);
             var stackedValue = stack.Start;
-            var total = chartTotal ?? stack.Total;
-
-            double start, sweep;
-
+            var total = ctx.ChartTotal ?? stack.Total;
+            double rawStart;
             if (total == 0)
+                rawStart = 0;
+            else if (IsRelativeToMinValue)
             {
-                start = 0;
-                sweep = 0;
+                var h = total - ctx.StartValue;
+                rawStart = Math.Min(stackedValue, h) / h * ctx.CompleteAngle;
+                if (!ctx.IsClockWise)
+                    rawStart = ctx.CompleteAngle - rawStart - (Math.Min(stackedValue + point.Coordinate.PrimaryValue, h) / h * ctx.CompleteAngle - rawStart);
             }
             else
             {
-                // Clamp the stack so a value greater than the chart's effective range
-                // cannot produce a sweep larger than the chart's complete angle, which
-                // renders as a broken arc (issue #2131). The cap differs per branch
-                // because each one uses a different denominator for the angle math.
-                if (IsRelativeToMinValue)
+                rawStart = Math.Min(stackedValue, total) / total * ctx.CompleteAngle;
+                if (!ctx.IsClockWise)
                 {
-                    // when the series is relative to min value,
-                    // the start value is always the PieChart.MinValue
-                    // this is normally used on angular gauge series.
-                    var h = total - startValue;
-                    var clampedStackedValue = Math.Min(stackedValue, h);
-                    var clampedTop = Math.Min(stackedValue + coordinate.PrimaryValue, h);
-                    var h1 = clampedTop;
-                    start = clampedStackedValue / h * completeAngle;
-                    sweep = h1 / h * completeAngle - start;
-                    if (!isClockWise) start = completeAngle - start - sweep;
-                }
-                else
-                {
-                    var clampedStackedValue = Math.Min(stackedValue, total);
-                    var clampedTop = Math.Min(stackedValue + coordinate.PrimaryValue, total);
-                    var h = total - startValue;
-                    var h1 = clampedTop - startValue;
-                    start = clampedStackedValue / total * completeAngle;
-                    sweep = h1 / h * completeAngle - start;
-                    if (!isClockWise) start = completeAngle - start - sweep;
+                    var h = total - ctx.StartValue;
+                    var h1 = Math.Min(stackedValue + point.Coordinate.PrimaryValue, total) - ctx.StartValue;
+                    rawStart = ctx.CompleteAngle - rawStart - (h1 / h * ctx.CompleteAngle - rawStart);
                 }
             }
 
-            if (IsFillSeries)
-            {
-                start = 0;
-                sweep = completeAngle - 0.1f;
-            }
-
-            if (visual is null)
-            {
-                var p = new TVisual
-                {
-                    CenterX = cx,
-                    CenterY = cy,
-                    X = cx,
-                    Y = cy,
-                    Width = 0,
-                    Height = 0,
-                    StartAngle = (float)(isFirstDraw ? initialRotation : start + initialRotation),
-                    SweepAngle = 0,
-                    PushOut = 0,
-                    InnerRadius = 0,
-                    CornerRadius = 0
-                };
-
-                visual = p;
-                point.Context.Visual = visual;
-                OnPointCreated(point);
-
-                _ = everFetched.Add(point);
-            }
+            var visual = EnsureVisualForPoint(point, rawStart, in ctx);
 
             if (Fill is not null && Fill != Paint.Default)
                 Fill.AddGeometryToPaintTask(pieChart.Canvas, visual);
             if (Stroke is not null && Stroke != Paint.Default)
                 Stroke.AddGeometryToPaintTask(pieChart.Canvas, visual);
 
-            var dougnutGeometry = visual;
+            stackedInnerRadius += ctx.RelativeInnerRadius;
 
-            stackedInnerRadius += relativeInnerRadius;
+            var layout = MeasurePieLayout(point, stackedInnerRadius, i, in ctx);
 
-            var md = minDimension;
-            var stackedOuterRadius = md - (md - 2 * innerRadius) * (fetched.Length - i) / fetched.Length - relativeOuterRadius * 2;
-
-            dougnutGeometry.CenterX = cx;
-            dougnutGeometry.CenterY = cy;
-            dougnutGeometry.X = drawLocation.X + (drawMarginSize.Width - stackedOuterRadius) * 0.5f;
-            dougnutGeometry.Y = drawLocation.Y + (drawMarginSize.Height - stackedOuterRadius) * 0.5f;
-            dougnutGeometry.Width = stackedOuterRadius;
-            dougnutGeometry.Height = stackedOuterRadius;
-            dougnutGeometry.InnerRadius = stackedInnerRadius;
-            dougnutGeometry.PushOut = pushout;
-            dougnutGeometry.StartAngle = (float)(start + initialRotation);
-            dougnutGeometry.SweepAngle = (float)sweep;
-            dougnutGeometry.CornerRadius = cornerRadius;
-            dougnutGeometry.InvertedCornerRadius = InvertedCornerRadius;
-            dougnutGeometry.RemoveOnCompleted = false;
-
-            if (start + initialRotation == initialRotation && sweep == 360)
-                dougnutGeometry.SweepAngle = 359.99f;
+            visual.CenterX = layout.CenterX;
+            visual.CenterY = layout.CenterY;
+            visual.X = layout.X;
+            visual.Y = layout.Y;
+            visual.Width = layout.Width;
+            visual.Height = layout.Height;
+            visual.InnerRadius = layout.InnerRadius;
+            visual.PushOut = layout.PushOut;
+            visual.StartAngle = layout.StartAngle;
+            visual.SweepAngle = layout.SweepAngle;
+            visual.CornerRadius = layout.CornerRadius;
+            visual.InvertedCornerRadius = InvertedCornerRadius;
+            visual.RemoveOnCompleted = false;
 
             if (point.Context.HoverArea is not SemicircleHoverArea ha)
                 point.Context.HoverArea = ha = new SemicircleHoverArea();
 
             _ = ha.SetDimensions(
-                cx, cy, (float)(start + initialRotation), (float)(start + initialRotation + sweep),
-                stackedInnerRadius, stackedOuterRadius);
+                ctx.CenterX, ctx.CenterY,
+                layout.StartAngle,
+                layout.StartAngle + layout.SweepAngle,
+                stackedInnerRadius, layout.OuterRadius);
 
             pointsCleanup.Clean(point);
 
-            if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default && !IsFillSeries)
-            {
-                var label = (TLabel?)point.Context.Label;
-
-                var middleAngle = (float)(start + initialRotation + sweep * 0.5);
-
-                var actualRotation = r +
-                        (isTangent ? middleAngle - 90 : 0) +
-                        (isCotangent ? middleAngle : 0);
-
-                if ((isTangent || isCotangent) && ((actualRotation + 90) % 360) > 180)
-                    actualRotation += 180;
-
-                if (label is null)
-                {
-                    var l = new TLabel { X = cx, Y = cy, RotateTransform = actualRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                    l.Animate(
-                        GetAnimation(chart),
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty);
-                    label = l;
-                    point.Context.Label = l;
-                }
-
-                DataLabelsPaint.AddGeometryToPaintTask(pieChart.Canvas, label);
-
-                label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
-                label.TextSize = dls;
-                label.Padding = DataLabelsPadding;
-                label.RotateTransform = actualRotation;
-                label.Paint = DataLabelsPaint;
-
-                AlignLabel(label, (float)start, initialRotation, sweep);
-
-                if (isFirstDraw)
-                    label.CompleteTransition(
-                        BaseLabelGeometry.TextSizeProperty,
-                        BaseLabelGeometry.XProperty,
-                        BaseLabelGeometry.YProperty,
-                        BaseLabelGeometry.RotateTransformProperty);
-
-                var labelPosition = GetLabelPolarPosition(
-                    cx,
-                    cy,
-                    stackedInnerRadius,
-                    (stackedOuterRadius + relativeOuterRadius * 2) * 0.5f,
-                    (float)(start + initialRotation),
-                    (float)sweep,
-                    label.Measure(),
-                    DataLabelsPosition);
-
-                label.X = labelPosition.X;
-                label.Y = labelPosition.Y;
-            }
+            MeasureDataLabel(point, in layout, stackedInnerRadius, layout.OuterRadius,
+                baseRotation: r, isTangent: isTangent, isCotangent: isCotangent, in ctx);
 
             OnPointMeasured(point);
 
-            stackedInnerRadius = (stackedOuterRadius + relativeOuterRadius * 2) * 0.5f;
+            stackedInnerRadius = (layout.OuterRadius + ctx.RelativeOuterRadius * 2) * 0.5f;
             i++;
         }
 
@@ -503,23 +636,14 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     public override string? GetSecondaryToolTipText(ChartPoint point) =>
         LiveCharts.IgnoreToolTipLabel;
 
-    /// <summary>
-    /// GEts the stack group
-    /// </summary>
-    /// <returns></returns>
-    /// <inheritdoc />
-    public override int GetStackGroup() =>
-        0;
+    /// <summary>Gets the stack group.</summary>
+    public override int GetStackGroup() => 0;
 
     /// <inheritdoc cref="ChartElement.GetPaintTasks"/>
     protected internal override Paint?[] GetPaintTasks() =>
         [Fill, Stroke, DataLabelsPaint];
 
-    /// <summary>
-    /// Sets the default point transitions.
-    /// </summary>
-    /// <param name="chartPoint">The chart point.</param>
-    /// <exception cref="Exception">Unable to initialize the point instance.</exception>
+    /// <summary>Sets the default point transitions.</summary>
     protected override void SetDefaultPointTransitions(ChartPoint chartPoint)
     {
         if (IsFillSeries) return;
@@ -537,12 +661,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
                 BaseDoughnutGeometry.SweepAngleProperty);
     }
 
-    /// <summary>
-    /// Softs the delete point.
-    /// </summary>
-    /// <param name="point">The point.</param>
-    /// <param name="primaryScale">The primary scale.</param>
-    /// <param name="secondaryScale">The secondary scale.</param>
+    /// <summary>Softly deletes the point.</summary>
     protected virtual void SoftDeleteOrDisposePoint(ChartPoint point, Scaler primaryScale, Scaler secondaryScale)
     {
         var visual = (TVisual?)point.Context.Visual;
@@ -563,18 +682,7 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
         label.RemoveOnCompleted = true;
     }
 
-    /// <summary>
-    /// Gets the label polar position.
-    /// </summary>
-    /// <param name="centerX">The center x.</param>
-    /// <param name="centerY">The center y.</param>
-    /// <param name="innerRadius">The iner radius.</param>
-    /// <param name="outerRadius">The outer radius.</param>
-    /// <param name="startAngle">The start angle.</param>
-    /// <param name="sweepAngle">The sweep angle.</param>
-    /// <param name="labelSize">Size of the label.</param>
-    /// <param name="position">The position.</param>
-    /// <returns></returns>
+    /// <summary>Gets the label polar position.</summary>
     protected virtual LvcPoint GetLabelPolarPosition(
         float centerX,
         float centerY,
@@ -623,8 +731,6 @@ public abstract class CorePieSeries<TModel, TVisual, TLabel, TMiniatureGeometry>
     /// <summary>
     /// Softly deletes the all points from the chart.
     /// </summary>
-    /// <param name="chart"></param>
-    /// <inheritdoc cref="ISeries.SoftDeleteOrDispose" />
     public override void SoftDeleteOrDispose(IChartView chart)
     {
         var core = ((IPieChartView)chart).Core;

--- a/src/LiveChartsCore/PieLayout.cs
+++ b/src/LiveChartsCore/PieLayout.cs
@@ -1,0 +1,79 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Final per-frame geometry of a single pie slice, returned from
+/// <c>MeasurePieLayout</c>. Pie is angular (StartAngle / SweepAngle drive the
+/// arc) so the X/Y/Width/Height fields describe the bounding box used by the
+/// underlying doughnut geometry for centering rather than a literal slice rect.
+/// </summary>
+public readonly struct PieLayout
+{
+    /// <summary>Initializes a new instance of <see cref="PieLayout"/>.</summary>
+    public PieLayout(
+        float centerX, float centerY,
+        float x, float y, float width, float height,
+        float startAngle, float sweepAngle,
+        float pushOut, float innerRadius, float outerRadius,
+        float cornerRadius)
+    {
+        CenterX = centerX;
+        CenterY = centerY;
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+        StartAngle = startAngle;
+        SweepAngle = sweepAngle;
+        PushOut = pushOut;
+        InnerRadius = innerRadius;
+        OuterRadius = outerRadius;
+        CornerRadius = cornerRadius;
+    }
+
+    /// <summary>Chart-center X (slice geometric center).</summary>
+    public float CenterX { get; }
+    /// <summary>Chart-center Y.</summary>
+    public float CenterY { get; }
+    /// <summary>Doughnut bounding-box top-left X.</summary>
+    public float X { get; }
+    /// <summary>Doughnut bounding-box top-left Y.</summary>
+    public float Y { get; }
+    /// <summary>Doughnut bounding-box width (== outer-radius x2 in pixel space).</summary>
+    public float Width { get; }
+    /// <summary>Doughnut bounding-box height.</summary>
+    public float Height { get; }
+    /// <summary>Slice starting angle (degrees, after initial rotation + clockwise correction).</summary>
+    public float StartAngle { get; }
+    /// <summary>Slice sweep angle (degrees, possibly clamped to ~360 to avoid the broken-arc bug from issue #2131).</summary>
+    public float SweepAngle { get; }
+    /// <summary>Pushout offset for hover effect.</summary>
+    public float PushOut { get; }
+    /// <summary>Inner radius (for doughnut hole).</summary>
+    public float InnerRadius { get; }
+    /// <summary>Outer radius (for outer arc).</summary>
+    public float OuterRadius { get; }
+    /// <summary>Corner-radius for rounded slice corners.</summary>
+    public float CornerRadius { get; }
+}

--- a/src/LiveChartsCore/PieMeasureContext.cs
+++ b/src/LiveChartsCore/PieMeasureContext.cs
@@ -1,0 +1,123 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method
+/// orchestration on <see cref="CorePieSeries{TModel, TVisual, TLabel, TMiniatureGeometry}"/>
+/// and the per-slice hooks. Pie has no scale axes — the geometry is angular —
+/// so the context carries chart-center coordinates, available radial space, and
+/// rotation parameters instead.
+/// </summary>
+public readonly ref struct PieMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="PieMeasureContext"/>.</summary>
+    public PieMeasureContext(
+        PieChartEngine chart,
+        float centerX,
+        float centerY,
+        float minDimension,
+        float innerRadius,
+        float pushOut,
+        float relativeInnerRadius,
+        float relativeOuterRadius,
+        float cornerRadius,
+        float initialRotation,
+        float completeAngle,
+        double startValue,
+        double? chartTotal,
+        bool isClockWise,
+        StackPosition stacker,
+        int sliceCount,
+        bool isFirstDraw,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        float dataLabelsSize)
+    {
+        Chart = chart;
+        CenterX = centerX;
+        CenterY = centerY;
+        MinDimension = minDimension;
+        InnerRadius = innerRadius;
+        PushOut = pushOut;
+        RelativeInnerRadius = relativeInnerRadius;
+        RelativeOuterRadius = relativeOuterRadius;
+        CornerRadius = cornerRadius;
+        InitialRotation = initialRotation;
+        CompleteAngle = completeAngle;
+        StartValue = startValue;
+        ChartTotal = chartTotal;
+        IsClockWise = isClockWise;
+        Stacker = stacker;
+        SliceCount = sliceCount;
+        IsFirstDraw = isFirstDraw;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        DataLabelsSize = dataLabelsSize;
+    }
+
+    /// <summary>The pie chart engine.</summary>
+    public PieChartEngine Chart { get; }
+    /// <summary>Chart-center pixel X.</summary>
+    public float CenterX { get; }
+    /// <summary>Chart-center pixel Y.</summary>
+    public float CenterY { get; }
+    /// <summary>Available radial space (after stroke / pushout / outer-label correction).</summary>
+    public float MinDimension { get; }
+    /// <summary>Configured inner radius (doughnut hole).</summary>
+    public float InnerRadius { get; }
+    /// <summary>Configured pushout offset.</summary>
+    public float PushOut { get; }
+    /// <summary>Per-stack relative inner-radius padding (post-MaxRadialColumnWidth clamp).</summary>
+    public float RelativeInnerRadius { get; }
+    /// <summary>Per-stack relative outer-radius padding (post-MaxRadialColumnWidth clamp).</summary>
+    public float RelativeOuterRadius { get; }
+    /// <summary>Configured corner radius for rounded slices.</summary>
+    public float CornerRadius { get; }
+    /// <summary>Configured initial rotation (degrees) from the chart view.</summary>
+    public float InitialRotation { get; }
+    /// <summary>Total sweep range (degrees) configured on the chart view (typically 360).</summary>
+    public float CompleteAngle { get; }
+    /// <summary>Configured MinValue / starting value.</summary>
+    public double StartValue { get; }
+    /// <summary>Optional configured MaxValue (null = use the stacker's total).</summary>
+    public double? ChartTotal { get; }
+    /// <summary>Whether the chart is drawn clockwise (else counter-clockwise).</summary>
+    public bool IsClockWise { get; }
+    /// <summary>Stacker for this series (pre-resolved; pie series are always stacked).</summary>
+    public StackPosition Stacker { get; }
+    /// <summary>Number of visible slices in this series (drives the stacked-pie radial math).</summary>
+    public int SliceCount { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>Top-left of the draw margin region.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+}


### PR DESCRIPTION
> _Drafted by Claude on Beto's behalf — review the prose, not just the diff._

## Summary

Applies the template-method pattern to `CorePieSeries`. **Step 6 of 8** of the cross-series Invalidate refactor.

Pie is the most-different geometry so far — angular (StartAngle / SweepAngle / Pushout / InnerRadius) instead of rect, no scale axes, and a running `stackedInnerRadius` that mutates across slices for the stacked-pie math.

## What lands

Two new public top-level types:

- `PieMeasureContext` — per-frame state (chart center, available radial space after stroke / pushout / outer-label correction, rotation parameters, stacker, slice count, relative inner/outer-radius post-RadialAlign clamp, isFirstDraw)
- `PieLayout` — per-slice geometry (center, bounding rect, angular bounds, radii, pushOut, corner radius)

Four virtual hooks: `BeginMeasure`, `MeasurePieLayout`, `EnsureVisualForPoint`, `CollapseEmptyVisual`.

Two private helpers + one static (`AlignLabel`): `InitializePaints`, `MeasureDataLabel`.

## Behavior preservation

- **636 / 636** CoreTests pass — including `PieSeries_FirstDraw` and `PieSeries_DataChange` per-frame trajectories from PR #2268 that pin StartAngle / SweepAngle / PushOut / InnerRadius motion
- **142 / 142** SnapshotTests pass — including `PieChartTests` gauges (the issue #2131 broken-arc fix is preserved verbatim)
- Multi-target build clean

## Notable

- The running `stackedInnerRadius` and `sliceIndex` mutate across iterations of the per-point loop — kept explicit in the orchestration; passed to hooks as parameters
- Tangent / Cotangent rotation modifiers are flag bits on top of the numeric `DataLabelsRotation` — decoded once at the top of the loop, then passed to `MeasureDataLabel`
- Empty slices still advance the radial state so the next visible slice doesn't pile up — preserved exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)