### PR TITLE
refactor(line): Invalidate template + virtual hooks

### DIFF
--- a/src/LiveChartsCore/CoreLineSeries.cs
+++ b/src/LiveChartsCore/CoreLineSeries.cs
@@ -120,36 +120,30 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
         }
     } = Paint.Default;
 
-    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
-    public override void Invalidate(Chart chart)
+    // ---- template method ----------------------------------------------------
+
+    /// <summary>
+    /// Builds a per-frame measure context from the chart. Subclasses may override
+    /// to refine context construction (e.g. additional pre-computed per-frame values).
+    /// </summary>
+    protected virtual LineMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
-        var cartesianChart = (CartesianChartEngine)chart;
-        _ = GetAnimation(cartesianChart);
+        var primaryAxis = chart.GetYAxis(this);
+        var secondaryAxis = chart.GetXAxis(this);
 
-        var primaryAxis = cartesianChart.GetYAxis(this);
-        var secondaryAxis = cartesianChart.GetXAxis(this);
+        var drawLocation = chart.DrawMarginLocation;
+        var drawMarginSize = chart.DrawMarginSize;
+        var secondaryScale = secondaryAxis.GetNextScaler(chart);
+        var primaryScale = primaryAxis.GetNextScaler(chart);
 
-        var drawLocation = cartesianChart.DrawMarginLocation;
-        var drawMarginSize = cartesianChart.DrawMarginSize;
-        var secondaryScale = secondaryAxis.GetNextScaler(cartesianChart);
-        var primaryScale = primaryAxis.GetNextScaler(cartesianChart);
-        var actualSecondaryScale = secondaryAxis.GetActualScaler(cartesianChart);
-        var actualPrimaryScale = primaryAxis.GetActualScaler(cartesianChart);
+        // GetActualScaler is called purely for its cache/registration side-effect on
+        // the axis (matches the original Invalidate body, where the locals were never
+        // read). Dropping the call would change the axis state on the first frame.
+        _ = secondaryAxis.GetActualScaler(chart);
+        _ = primaryAxis.GetActualScaler(chart);
 
-        var gs = _geometrySize;
-        var hgs = gs / 2f;
-        var sw = Stroke?.StrokeThickness ?? 0;
-        var p = primaryScale.ToPixels(pivot);
-
-        // Note #240222
-        // the following cases probably have a similar performance impact
-        // this options were necessary at some older point when _enableNullSplitting = false could improve performance
-        // ToDo: Check this out, maybe this is unnecessary now and we should just go for the first approach all the times.
-        var segments = EnableNullSplitting
-            ? Fetch(cartesianChart).SplitByNullGaps(point => DeleteNullPoint(point, secondaryScale, primaryScale)) // calling this method is probably as expensive as the line bellow
-            : [Fetch(cartesianChart)];
         var stacker = (SeriesProperties & SeriesProperties.Stacked) == SeriesProperties.Stacked
-            ? cartesianChart.SeriesContext.GetStackPosition(this, GetStackGroup())
+            ? chart.SeriesContext.GetStackPosition(this, GetStackGroup())
             : null;
 
         // #1923: anchor a default-ZIndex stacked area at the largest SeriesId in
@@ -166,8 +160,320 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
                 ? stacker.Stacker.MaxSeriesId - stacker.Position
                 : ((ISeries)this).SeriesId;
 
-        var dls = (float)DataLabelsSize;
+        var gs = _geometrySize;
+        var hgs = gs / 2f;
+        var pivotPx = primaryScale.ToPixels(pivot);
+
+        var uwx = secondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
+        if (uwx < gs) uwx = gs;
+
+        var hasSvg = this.HasVariableSvgGeometry();
+        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
+
+        return new LineMeasureContext(
+            chart, primaryAxis, secondaryAxis,
+            primaryScale, secondaryScale,
+            drawLocation, drawMarginSize,
+            actualZIndex: actualZIndex,
+            pivotPx: pivotPx,
+            unitWidthX: uwx,
+            geometrySize: gs,
+            halfGeometrySize: hgs,
+            dataLabelsSize: (float)DataLabelsSize,
+            isFirstDraw: isFirstDraw,
+            hasSvg: hasSvg,
+            stacker: stacker);
+    }
+
+    /// <summary>
+    /// Ensures the visual + any additional visuals (error bars) exist for the
+    /// point and seeds them at the data point with zero size so the marker
+    /// animates from a point. On creation, the cubic segment is also seeded at
+    /// the pivot baseline; see issue #2132 for why this seed must run for every
+    /// new visual rather than just on first draw.
+    /// </summary>
+    protected virtual CubicSegmentVisualPoint EnsureLineVisualForPoint(ChartPoint point, BezierData data, in LineMeasureContext ctx)
+    {
+        var coordinate = point.Coordinate;
+        var v = new CubicSegmentVisualPoint(new TVisual());
+
+        if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
+        {
+            v.YError = new TErrorGeometry();
+            v.XError = new TErrorGeometry();
+
+            v.YError.X = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+            v.YError.X1 = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+            v.YError.Y = ctx.PivotPx;
+            v.YError.Y1 = ctx.PivotPx;
+
+            v.XError.X = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+            v.XError.X1 = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+            v.XError.Y = ctx.PivotPx;
+            v.XError.Y1 = ctx.PivotPx;
+        }
+
+        // Seed motion state so the real-value setter below animates from a
+        // sensible place instead of the default (0, 0). Runs for every new
+        // visual — not just isFirstDraw — because a mid-life new visual that
+        // happens to be the first point of a brand-new sub-segment path will
+        // skip Follows() in AddConsecutiveSegment (list.Last is null), and
+        // without this init the segment would swoop in from the top-left
+        // corner (#2132). For non-first points in a sub-segment, Follows()
+        // overrides these values with the previous tail, so the "grow from
+        // previous" animation is preserved.
+        v.Geometry.X = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+        v.Geometry.Y = ctx.PivotPx;
+        v.Geometry.Width = 0;
+        v.Geometry.Height = 0;
+
+        v.Segment.Xi = ctx.SecondaryScale.ToPixels(data.X0);
+        v.Segment.Xm = ctx.SecondaryScale.ToPixels(data.X1);
+        v.Segment.Xj = ctx.SecondaryScale.ToPixels(data.X2);
+        v.Segment.Yi = ctx.PivotPx;
+        v.Segment.Ym = ctx.PivotPx;
+        v.Segment.Yj = ctx.PivotPx;
+
+        point.Context.Visual = v.Geometry;
+        point.Context.AdditionalVisuals = v;
+        OnPointCreated(point);
+
+        return v;
+    }
+
+    /// <summary>
+    /// Collapses the point's visual and segment commands to the pivot baseline
+    /// when the series becomes invisible, and removes the visual / label from
+    /// the point so future paints don't redraw them.
+    /// </summary>
+    protected virtual void CollapseInvisibleLinePoint(ChartPoint point, BezierData data, in LineMeasureContext ctx)
+    {
+        if (point.Context.AdditionalVisuals is CubicSegmentVisualPoint visual)
+        {
+            var coordinate = point.Coordinate;
+
+            visual.Geometry.X = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+            visual.Geometry.Y = ctx.PivotPx;
+            visual.Geometry.Opacity = 0;
+            visual.Geometry.RemoveOnCompleted = true;
+
+            visual.Segment.Xi = ctx.SecondaryScale.ToPixels(data.X0);
+            visual.Segment.Xm = ctx.SecondaryScale.ToPixels(data.X1);
+            visual.Segment.Xj = ctx.SecondaryScale.ToPixels(data.X2);
+            visual.Segment.Yi = ctx.PivotPx;
+            visual.Segment.Ym = ctx.PivotPx;
+            visual.Segment.Yj = ctx.PivotPx;
+
+            point.Context.Visual = null;
+            point.Context.AdditionalVisuals = null;
+        }
+
+        if (point.Context.Label is TLabel label)
+        {
+            label.X = ctx.SecondaryScale.ToPixels(point.Coordinate.SecondaryValue);
+            label.Y = ctx.PivotPx;
+            label.Opacity = 0;
+            label.RemoveOnCompleted = true;
+
+            point.Context.Label = null;
+        }
+    }
+
+    /// <summary>
+    /// Per-frame error-bar geometry update. No-op when the series carries no
+    /// error visuals or no point error data.
+    /// </summary>
+    protected virtual void MeasureLineErrorBars(CubicSegmentVisualPoint visual, BezierData data, in LineMeasureContext ctx)
+    {
+        var coordinate = data.TargetPoint.Coordinate;
+        if (coordinate.PointError.IsEmpty) return;
+        if (!ShowError || ErrorPaint is null || ErrorPaint == Paint.Default) return;
+
+        var e = coordinate.PointError;
+
+        visual.YError!.X = ctx.SecondaryScale.ToPixels(data.X2);
+        visual.YError.X1 = ctx.SecondaryScale.ToPixels(data.X2);
+        visual.YError.Y = ctx.PrimaryScale.ToPixels(data.Y2 + e.Yi);
+        visual.YError.Y1 = ctx.PrimaryScale.ToPixels(data.Y2 - e.Yj);
+        visual.YError.RemoveOnCompleted = false;
+
+        visual.XError!.X = ctx.SecondaryScale.ToPixels(data.X2 - e.Xi);
+        visual.XError.X1 = ctx.SecondaryScale.ToPixels(data.X2 + e.Xj);
+        visual.XError.Y = ctx.PrimaryScale.ToPixels(data.Y2);
+        visual.XError.Y1 = ctx.PrimaryScale.ToPixels(data.Y2);
+        visual.XError.RemoveOnCompleted = false;
+    }
+
+    /// <summary>
+    /// Registers per-segment fill / stroke paths on the chart canvas, sets their
+    /// Z-index and pivot, animates if newly-created, and returns fresh vector
+    /// managers wrapping their command lists. Called once per segment when the
+    /// first point in that segment is encountered.
+    /// </summary>
+    private void AttachSegmentPaths(
+        int segmentI,
+        List<TPathGeometry> fillContainer,
+        List<TPathGeometry> strokeContainer,
+        in LineMeasureContext ctx,
+        out VectorManager fillVector,
+        out VectorManager strokeVector)
+    {
+        var fillLookup = GetSegmentVisual(segmentI, fillContainer, VectorClosingMethod.CloseToPivot);
+        var strokeLookup = GetSegmentVisual(segmentI, strokeContainer, VectorClosingMethod.NotClosed);
+
+        // The previous "Count == 1 && !IsNextEmpty" branch tried to discard a
+        // stale single-segment path left behind when this slot used to host a
+        // one-point sub-segment. Its implementation called container.RemoveAt(segmentI)
+        // and then re-fetched the path, which shifted every subsequent sub-segment
+        // onto the WRONG path in the container — the root of #2132's resize/yellow-region
+        // regression. VectorManager.TrimTail now drops stale remnants without touching
+        // the container, so this cleanup is no longer necessary.
+
+        var isNew = fillLookup.IsNew || strokeLookup.IsNew;
+        var fillPath = fillLookup.Path;
+        var strokePath = strokeLookup.Path;
+
+        strokeVector = new VectorManager(strokePath.Commands);
+        fillVector = new VectorManager(fillPath.Commands);
+
+        var chart = ctx.Chart;
+
+        if (Fill is not null && Fill != Paint.Default)
+        {
+            Fill.AddGeometryToPaintTask(chart.Canvas, fillPath);
+            chart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
+            Fill.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesFillZIndexOffset;
+            fillPath.Pivot = ctx.PivotPx;
+            if (isNew) fillPath.Animate(GetAnimation(chart));
+        }
+
+        if (Stroke is not null && Stroke != Paint.Default)
+        {
+            Stroke.AddGeometryToPaintTask(chart.Canvas, strokePath);
+            chart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
+            Stroke.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
+            strokePath.Pivot = ctx.PivotPx;
+            if (isNew) strokePath.Animate(GetAnimation(chart));
+        }
+
+        strokePath.Opacity = IsVisible ? 1 : 0;
+        fillPath.Opacity = IsVisible ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Removes per-canvas segment paths that are no longer referenced by any
+    /// active sub-segment (i.e. their index sits at or above the count of
+    /// segments produced this frame). Mirrors the original tail-cleanup loop.
+    /// </summary>
+    private void CleanupOrphanSegmentPaths(
+        int segmentI,
+        List<TPathGeometry> fillContainer,
+        List<TPathGeometry> strokeContainer,
+        CartesianChartEngine chart)
+    {
+        var maxSegment = fillContainer.Count > strokeContainer.Count
+            ? fillContainer.Count
+            : strokeContainer.Count;
+
+        for (var i = maxSegment - 1; i >= segmentI; i--)
+        {
+            if (i < fillContainer.Count)
+            {
+                var segmentFill = fillContainer[i];
+                Fill?.RemoveGeometryFromPaintTask(chart.Canvas, segmentFill);
+                segmentFill.Commands.Clear();
+                fillContainer.RemoveAt(i);
+            }
+
+            if (i < strokeContainer.Count)
+            {
+                var segmentStroke = strokeContainer[i];
+                Stroke?.RemoveGeometryFromPaintTask(chart.Canvas, segmentStroke);
+                segmentStroke.Commands.Clear();
+                strokeContainer.RemoveAt(i);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates the data label visual if it doesn't exist yet (animation-sourced from
+    /// the marker's top-left at the pivot baseline), updates its text + style, and
+    /// positions it via <c>GetLabelPosition</c>. No-op when the series has no
+    /// data-label paint configured.
+    /// </summary>
+    private void MeasureDataLabel(ChartPoint point, float x, float y, in LineMeasureContext ctx)
+    {
+        if (!ShowDataLabels || DataLabelsPaint is null || DataLabelsPaint == Paint.Default) return;
+
+        var coordinate = point.Coordinate;
+        var hgs = ctx.HalfGeometrySize;
+        var gs = ctx.GeometrySize;
+        var chart = ctx.Chart;
+        var label = (TLabel?)point.Context.Label;
+
+        if (label is null)
+        {
+            var l = new TLabel
+            {
+                X = x - hgs,
+                Y = ctx.PivotPx - hgs,
+                RotateTransform = (float)DataLabelsRotation,
+                MaxWidth = (float)DataLabelsMaxWidth
+            };
+            l.Animate(
+                GetAnimation(chart),
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty);
+            label = l;
+            point.Context.Label = l;
+        }
+
+        DataLabelsPaint.AddGeometryToPaintTask(chart.Canvas, label);
+        label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(point));
+        label.TextSize = ctx.DataLabelsSize;
+        label.Padding = DataLabelsPadding;
+        label.Paint = DataLabelsPaint;
+
+        if (ctx.IsFirstDraw)
+            label.CompleteTransition(
+                BaseLabelGeometry.TextSizeProperty,
+                BaseLabelGeometry.XProperty,
+                BaseLabelGeometry.YProperty,
+                BaseLabelGeometry.RotateTransformProperty);
+
+        var m = label.Measure();
+        var labelPosition = GetLabelPosition(
+            x - hgs, y - hgs, gs, gs, m, DataLabelsPosition,
+            SeriesProperties, coordinate.PrimaryValue > Pivot, ctx.DrawLocation, ctx.DrawMarginSize);
+        if (DataLabelsTranslate is not null)
+            label.TranslateTransform = new LvcPoint(
+                m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
+
+        label.X = labelPosition.X;
+        label.Y = labelPosition.Y;
+    }
+
+    /// <inheritdoc cref="ChartElement.Invalidate(Chart)"/>
+    public sealed override void Invalidate(Chart chart)
+    {
+        var cartesianChart = (CartesianChartEngine)chart;
+        _ = GetAnimation(cartesianChart);
+
+        var ctx = BeginMeasure(cartesianChart);
         var pointsCleanup = ChartPointCleanupContext.For(everFetched);
+
+        // Lifted out of the ref-struct context so the lambda below can close over
+        // the scales — ref locals can't be captured by an anonymous method.
+        var secondaryScale = ctx.SecondaryScale;
+        var primaryScale = ctx.PrimaryScale;
+
+        // Note #240222
+        // the following cases probably have a similar performance impact
+        // this options were necessary at some older point when _enableNullSplitting = false could improve performance
+        // ToDo: Check this out, maybe this is unnecessary now and we should just go for the first approach all the times.
+        var segments = EnableNullSplitting
+            ? Fetch(cartesianChart).SplitByNullGaps(point => DeleteNullPoint(point, secondaryScale, primaryScale))
+            : [Fetch(cartesianChart)];
 
         if (!_strokePathHelperDictionary.TryGetValue(chart.Canvas.Sync, out var strokePathHelperContainer))
         {
@@ -181,14 +487,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             _fillPathHelperDictionary[chart.Canvas.Sync] = fillPathHelperContainer;
         }
 
-        var uwx = secondaryScale.MeasureInPixels(secondaryAxis.UnitWidth);
-        uwx = uwx < gs ? gs : uwx;
-        var tooltipPositon = chart.TooltipPosition;
-
         var segmentI = 0;
-        var hasSvg = this.HasVariableSvgGeometry();
-
-        var isFirstDraw = !chart.IsDrawn(((ISeries)this).SeriesId);
 
         foreach (var segment in segments)
         {
@@ -196,64 +495,20 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             var isSegmentEmpty = true;
             VectorManager? strokeVector = null, fillVector = null;
 
-            foreach (var data in GetSpline(segment, stacker))
+            foreach (var data in GetSpline(segment, ctx.Stacker))
             {
                 if (!hasPaths)
                 {
                     hasPaths = true;
-
-                    var fillLookup = GetSegmentVisual(segmentI, fillPathHelperContainer, VectorClosingMethod.CloseToPivot);
-                    var strokeLookup = GetSegmentVisual(segmentI, strokePathHelperContainer, VectorClosingMethod.NotClosed);
-
-                    // The previous "Count == 1 && !IsNextEmpty" branch tried to discard a
-                    // stale single-segment path left behind when this slot used to host a
-                    // one-point sub-segment. Its implementation called
-                    // container.RemoveAt(segmentI) and then re-fetched the path, which
-                    // shifted every subsequent sub-segment onto the WRONG path in the
-                    // container — the root of #2132's resize/yellow-region regression.
-                    // VectorManager.TrimTail now drops stale remnants without touching
-                    // the container, so this cleanup is no longer necessary.
-
-                    var isNew = fillLookup.IsNew || strokeLookup.IsNew;
-                    var fillPath = fillLookup.Path;
-                    var strokePath = strokeLookup.Path;
-
-                    strokeVector = new VectorManager(strokePath.Commands);
-                    fillVector = new VectorManager(fillPath.Commands);
-
-                    if (Fill is not null && Fill != Paint.Default)
-                    {
-                        Fill.AddGeometryToPaintTask(cartesianChart.Canvas, fillPath);
-                        cartesianChart.Canvas.AddDrawableTask(Fill, zone: CanvasZone.DrawMargin);
-                        Fill.ZIndex = actualZIndex + PaintConstants.SeriesFillZIndexOffset;
-                        fillPath.Pivot = p;
-                        if (isNew)
-                        {
-                            fillPath.Animate(GetAnimation(cartesianChart));
-                        }
-                    }
-                    if (Stroke is not null && Stroke != Paint.Default)
-                    {
-                        Stroke.AddGeometryToPaintTask(cartesianChart.Canvas, strokePath);
-                        cartesianChart.Canvas.AddDrawableTask(Stroke, zone: CanvasZone.DrawMargin);
-                        Stroke.ZIndex = actualZIndex + PaintConstants.SeriesStrokeZIndexOffset;
-                        strokePath.Pivot = p;
-                        if (isNew)
-                        {
-                            strokePath.Animate(GetAnimation(cartesianChart));
-                        }
-                    }
-
-                    strokePath.Opacity = IsVisible ? 1 : 0;
-                    fillPath.Opacity = IsVisible ? 1 : 0;
+                    AttachSegmentPaths(
+                        segmentI, fillPathHelperContainer, strokePathHelperContainer, in ctx,
+                        out fillVector, out strokeVector);
                 }
 
-                var coordinate = data.TargetPoint.Coordinate;
-
                 isSegmentEmpty = false;
-                var s = 0d;
-                if (stacker is not null)
-                    s = stacker.GetStack(data.TargetPoint).CumulativeStart;
+
+                var coordinate = data.TargetPoint.Coordinate;
+                var s = ctx.Stacker?.GetStack(data.TargetPoint).CumulativeStart ?? 0d;
 
                 var visual = (CubicSegmentVisualPoint?)data.TargetPoint.Context.AdditionalVisuals;
                 // Captured before the null check reassigns. Drives AddConsecutiveSegment's
@@ -263,92 +518,15 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
 
                 if (!IsVisible)
                 {
-                    if (visual is not null)
-                    {
-                        visual.Geometry.X = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        visual.Geometry.Y = p;
-                        visual.Geometry.Opacity = 0;
-                        visual.Geometry.RemoveOnCompleted = true;
-
-                        visual.Segment.Xi = secondaryScale.ToPixels(data.X0);
-                        visual.Segment.Xm = secondaryScale.ToPixels(data.X1);
-                        visual.Segment.Xj = secondaryScale.ToPixels(data.X2);
-                        visual.Segment.Yi = p;
-                        visual.Segment.Ym = p;
-                        visual.Segment.Yj = p;
-
-                        data.TargetPoint.Context.Visual = null;
-                        data.TargetPoint.Context.AdditionalVisuals = null;
-                    }
-
-                    if (data.TargetPoint.Context.Label is not null)
-                    {
-                        var label = (TLabel)data.TargetPoint.Context.Label;
-
-                        label.X = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        label.Y = p;
-                        label.Opacity = 0;
-                        label.RemoveOnCompleted = true;
-
-                        data.TargetPoint.Context.Label = null;
-                    }
-
+                    CollapseInvisibleLinePoint(data.TargetPoint, data, in ctx);
                     pointsCleanup.Clean(data.TargetPoint);
-
                     continue;
                 }
 
-                if (visual is null)
-                {
-                    var v = new CubicSegmentVisualPoint(new TVisual());
-
-                    if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
-                    {
-                        v.YError = new TErrorGeometry();
-                        v.XError = new TErrorGeometry();
-
-                        v.YError.X = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        v.YError.X1 = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        v.YError.Y = p;
-                        v.YError.Y1 = p;
-
-                        v.XError.X = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        v.XError.X1 = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                        v.XError.Y = p;
-                        v.XError.Y1 = p;
-                    }
-
-                    visual = v;
-
-                    // Seed motion state so the real-value setter below animates from a
-                    // sensible place instead of the default (0, 0). Runs for every new
-                    // visual — not just isFirstDraw — because a mid-life new visual that
-                    // happens to be the first point of a brand-new sub-segment path will
-                    // skip Follows() in AddConsecutiveSegment (list.Last is null), and
-                    // without this init the segment would swoop in from the top-left
-                    // corner (#2132). For non-first points in a sub-segment, Follows()
-                    // overrides these values with the previous tail, so the "grow from
-                    // previous" animation is preserved.
-                    v.Geometry.X = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                    v.Geometry.Y = p;
-                    v.Geometry.Width = 0;
-                    v.Geometry.Height = 0;
-
-                    v.Segment.Xi = secondaryScale.ToPixels(data.X0);
-                    v.Segment.Xm = secondaryScale.ToPixels(data.X1);
-                    v.Segment.Xj = secondaryScale.ToPixels(data.X2);
-                    v.Segment.Yi = p;
-                    v.Segment.Ym = p;
-                    v.Segment.Yj = p;
-
-                    data.TargetPoint.Context.Visual = v.Geometry;
-                    data.TargetPoint.Context.AdditionalVisuals = v;
-                    OnPointCreated(data.TargetPoint);
-                }
-
+                visual ??= EnsureLineVisualForPoint(data.TargetPoint, data, in ctx);
                 visual.Geometry.Opacity = 1;
 
-                if (hasSvg)
+                if (ctx.HasSvg)
                 {
                     var svgVisual = (IVariableSvgPath)visual.Geometry;
                     if (_geometrySvgChanged || svgVisual.SVGPath is null)
@@ -369,54 +547,36 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
 
                 visual.Segment.Id = data.TargetPoint.Context.Entity.MetaData!.EntityIndex;
 
-                if (Fill is not null) fillVector!.AddConsecutiveSegment(visual.Segment, isVisualNew && !isFirstDraw);
-                if (Stroke is not null) strokeVector!.AddConsecutiveSegment(visual.Segment, isVisualNew && !isFirstDraw);
+                if (Fill is not null) fillVector!.AddConsecutiveSegment(visual.Segment, isVisualNew && !ctx.IsFirstDraw);
+                if (Stroke is not null) strokeVector!.AddConsecutiveSegment(visual.Segment, isVisualNew && !ctx.IsFirstDraw);
 
-                visual.Segment.Xi = secondaryScale.ToPixels(data.X0);
-                visual.Segment.Xm = secondaryScale.ToPixels(data.X1);
-                visual.Segment.Xj = secondaryScale.ToPixels(data.X2);
-                visual.Segment.Yi = primaryScale.ToPixels(data.Y0);
-                visual.Segment.Ym = primaryScale.ToPixels(data.Y1);
-                visual.Segment.Yj = primaryScale.ToPixels(data.Y2);
+                visual.Segment.Xi = ctx.SecondaryScale.ToPixels(data.X0);
+                visual.Segment.Xm = ctx.SecondaryScale.ToPixels(data.X1);
+                visual.Segment.Xj = ctx.SecondaryScale.ToPixels(data.X2);
+                visual.Segment.Yi = ctx.PrimaryScale.ToPixels(data.Y0);
+                visual.Segment.Ym = ctx.PrimaryScale.ToPixels(data.Y1);
+                visual.Segment.Yj = ctx.PrimaryScale.ToPixels(data.Y2);
 
-                var x = secondaryScale.ToPixels(coordinate.SecondaryValue);
-                var y = primaryScale.ToPixels(coordinate.PrimaryValue + s);
+                var x = ctx.SecondaryScale.ToPixels(coordinate.SecondaryValue);
+                var y = ctx.PrimaryScale.ToPixels(coordinate.PrimaryValue + s);
 
                 DrawnGeometry.XProperty.GetMotion(visual.Geometry)!
                     .CopyFrom(Segment.XjProperty.GetMotion(visual.Segment)!);
                 DrawnGeometry.YProperty.GetMotion(visual.Geometry)!
                     .CopyFrom(Segment.YjProperty.GetMotion(visual.Segment)!);
 
-                visual.Geometry.TranslateTransform = new LvcPoint(-hgs, -hgs);
-
-                visual.Geometry.Width = gs;
-                visual.Geometry.Height = gs;
+                visual.Geometry.TranslateTransform = new LvcPoint(-ctx.HalfGeometrySize, -ctx.HalfGeometrySize);
+                visual.Geometry.Width = ctx.GeometrySize;
+                visual.Geometry.Height = ctx.GeometrySize;
                 visual.Geometry.RemoveOnCompleted = false;
 
-                if (!coordinate.PointError.IsEmpty && ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
-                {
-                    var e = coordinate.PointError;
-
-                    visual.YError!.X = secondaryScale.ToPixels(data.X2);
-                    visual.YError.X1 = secondaryScale.ToPixels(data.X2);
-                    visual.YError.Y = primaryScale.ToPixels(data.Y2 + e.Yi);
-                    visual.YError.Y1 = primaryScale.ToPixels(data.Y2 - e.Yj);
-                    visual.YError.RemoveOnCompleted = false;
-
-                    visual.XError!.X = secondaryScale.ToPixels(data.X2 - e.Xi);
-                    visual.XError.X1 = secondaryScale.ToPixels(data.X2 + e.Xj);
-                    visual.XError.Y = primaryScale.ToPixels(data.Y2);
-                    visual.XError.Y1 = primaryScale.ToPixels(data.Y2);
-                    visual.XError.RemoveOnCompleted = false;
-                }
-
-                var hags = gs < 8 ? 8 : gs;
+                MeasureLineErrorBars(visual, data, in ctx);
 
                 if (data.TargetPoint.Context.HoverArea is not RectangleHoverArea ha)
                     data.TargetPoint.Context.HoverArea = ha = new RectangleHoverArea();
 
                 _ = ha
-                    .SetDimensions(x - uwx * 0.5f, y - hgs, uwx, gs)
+                    .SetDimensions(x - ctx.UnitWidthX * 0.5f, y - ctx.HalfGeometrySize, ctx.UnitWidthX, ctx.GeometrySize)
                     .CenterXToolTip();
 
                 _ = coordinate.PrimaryValue >= pivot
@@ -425,44 +585,7 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
 
                 pointsCleanup.Clean(data.TargetPoint);
 
-                if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
-                {
-                    var label = (TLabel?)data.TargetPoint.Context.Label;
-
-                    if (label is null)
-                    {
-                        var l = new TLabel { X = x - hgs, Y = p - hgs, RotateTransform = (float)DataLabelsRotation, MaxWidth = (float)DataLabelsMaxWidth };
-                        l.Animate(
-                            GetAnimation(cartesianChart),
-                            BaseLabelGeometry.XProperty,
-                            BaseLabelGeometry.YProperty);
-                        label = l;
-                        data.TargetPoint.Context.Label = l;
-                    }
-
-                    DataLabelsPaint.AddGeometryToPaintTask(cartesianChart.Canvas, label);
-                    label.Text = DataLabelsFormatter(new ChartPoint<TModel, TVisual, TLabel>(data.TargetPoint));
-                    label.TextSize = dls;
-                    label.Padding = DataLabelsPadding;
-                    label.Paint = DataLabelsPaint;
-
-                    if (isFirstDraw)
-                        label.CompleteTransition(
-                            BaseLabelGeometry.TextSizeProperty,
-                            BaseLabelGeometry.XProperty,
-                            BaseLabelGeometry.YProperty,
-                            BaseLabelGeometry.RotateTransformProperty);
-
-                    var m = label.Measure();
-                    var labelPosition = GetLabelPosition(
-                        x - hgs, y - hgs, gs, gs, m, DataLabelsPosition,
-                        SeriesProperties, coordinate.PrimaryValue > Pivot, drawLocation, drawMarginSize);
-                    if (DataLabelsTranslate is not null) label.TranslateTransform =
-                        new LvcPoint(m.Width * DataLabelsTranslate.Value.X, m.Height * DataLabelsTranslate.Value.Y);
-
-                    label.X = labelPosition.X;
-                    label.Y = labelPosition.Y;
-                }
+                MeasureDataLabel(data.TargetPoint, x, y, in ctx);
 
                 OnPointMeasured(data.TargetPoint);
             }
@@ -470,12 +593,12 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             if (GeometryFill is not null && GeometryFill != Paint.Default)
             {
                 cartesianChart.Canvas.AddDrawableTask(GeometryFill, zone: CanvasZone.DrawMargin);
-                GeometryFill.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
+                GeometryFill.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
             }
             if (GeometryStroke is not null && GeometryStroke != Paint.Default)
             {
                 cartesianChart.Canvas.AddDrawableTask(GeometryStroke, zone: CanvasZone.DrawMargin);
-                GeometryStroke.ZIndex = actualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
+                GeometryStroke.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesGeometryStrokeZIndexOffset;
             }
 
             if (!isSegmentEmpty) segmentI++;
@@ -484,42 +607,21 @@ public abstract class CoreLineSeries<TModel, TVisual, TLabel, TPathGeometry, TEr
             strokeVector?.TrimTail();
         }
 
-        var maxSegment = fillPathHelperContainer.Count > strokePathHelperContainer.Count
-            ? fillPathHelperContainer.Count
-            : strokePathHelperContainer.Count;
-
-        for (var i = maxSegment - 1; i >= segmentI; i--)
-        {
-            if (i < fillPathHelperContainer.Count)
-            {
-                var segmentFill = fillPathHelperContainer[i];
-                Fill?.RemoveGeometryFromPaintTask(cartesianChart.Canvas, segmentFill);
-                segmentFill.Commands.Clear();
-                fillPathHelperContainer.RemoveAt(i);
-            }
-
-            if (i < strokePathHelperContainer.Count)
-            {
-                var segmentStroke = strokePathHelperContainer[i];
-                Stroke?.RemoveGeometryFromPaintTask(cartesianChart.Canvas, segmentStroke);
-                segmentStroke.Commands.Clear();
-                strokePathHelperContainer.RemoveAt(i);
-            }
-        }
+        CleanupOrphanSegmentPaths(segmentI, fillPathHelperContainer, strokePathHelperContainer, cartesianChart);
 
         if (ShowDataLabels && DataLabelsPaint is not null && DataLabelsPaint != Paint.Default)
         {
             cartesianChart.Canvas.AddDrawableTask(DataLabelsPaint, zone: CanvasZone.DrawMargin);
-            DataLabelsPaint.ZIndex = actualZIndex + PaintConstants.SeriesDataLabelsZIndexOffset;
+            DataLabelsPaint.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesDataLabelsZIndexOffset;
         }
         if (ShowError && ErrorPaint is not null && ErrorPaint != Paint.Default)
         {
             cartesianChart.Canvas.AddDrawableTask(ErrorPaint, zone: CanvasZone.DrawMargin);
-            ErrorPaint.ZIndex = actualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
+            ErrorPaint.ZIndex = ctx.ActualZIndex + PaintConstants.SeriesGeometryFillZIndexOffset;
         }
 
         pointsCleanup.CollectPoints(
-            everFetched, cartesianChart.View, primaryScale, secondaryScale, SoftDeleteOrDisposePoint);
+            everFetched, cartesianChart.View, ctx.PrimaryScale, ctx.SecondaryScale, SoftDeleteOrDisposePoint);
 
         _geometrySvgChanged = false;
     }

--- a/src/LiveChartsCore/LineMeasureContext.cs
+++ b/src/LiveChartsCore/LineMeasureContext.cs
@@ -1,0 +1,106 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore;
+
+/// <summary>
+/// Bundle of per-Invalidate state shared between the template-method
+/// orchestration on <see cref="CoreLineSeries{TModel, TVisual, TLabel, TPathGeometry, TErrorGeometry}"/>
+/// and the per-point hooks. Ref struct so passing it by <c>in</c> to hooks costs
+/// nothing and the contents cannot escape into a longer-lived closure.
+/// </summary>
+public readonly ref struct LineMeasureContext
+{
+    /// <summary>Initializes a new instance of <see cref="LineMeasureContext"/>.</summary>
+    public LineMeasureContext(
+        CartesianChartEngine chart,
+        ICartesianAxis primaryAxis,
+        ICartesianAxis secondaryAxis,
+        Scaler primaryScale,
+        Scaler secondaryScale,
+        LvcPoint drawLocation,
+        LvcSize drawMarginSize,
+        int actualZIndex,
+        float pivotPx,
+        float unitWidthX,
+        float geometrySize,
+        float halfGeometrySize,
+        float dataLabelsSize,
+        bool isFirstDraw,
+        bool hasSvg,
+        StackPosition? stacker)
+    {
+        Chart = chart;
+        PrimaryAxis = primaryAxis;
+        SecondaryAxis = secondaryAxis;
+        PrimaryScale = primaryScale;
+        SecondaryScale = secondaryScale;
+        DrawLocation = drawLocation;
+        DrawMarginSize = drawMarginSize;
+        ActualZIndex = actualZIndex;
+        PivotPx = pivotPx;
+        UnitWidthX = unitWidthX;
+        GeometrySize = geometrySize;
+        HalfGeometrySize = halfGeometrySize;
+        DataLabelsSize = dataLabelsSize;
+        IsFirstDraw = isFirstDraw;
+        HasSvg = hasSvg;
+        Stacker = stacker;
+    }
+
+    /// <summary>The chart engine.</summary>
+    public CartesianChartEngine Chart { get; }
+    /// <summary>Primary (Y) axis.</summary>
+    public ICartesianAxis PrimaryAxis { get; }
+    /// <summary>Secondary (X) axis.</summary>
+    public ICartesianAxis SecondaryAxis { get; }
+    /// <summary>Primary (Y) pixel scaler.</summary>
+    public Scaler PrimaryScale { get; }
+    /// <summary>Secondary (X) pixel scaler.</summary>
+    public Scaler SecondaryScale { get; }
+    /// <summary>Top-left of the draw margin region in chart pixel coordinates.</summary>
+    public LvcPoint DrawLocation { get; }
+    /// <summary>Size of the draw margin region.</summary>
+    public LvcSize DrawMarginSize { get; }
+    /// <summary>Resolved Z-index for this series (honors user override and stacked-area anchor from issue #1923).</summary>
+    public int ActualZIndex { get; }
+    /// <summary>Pivot value rendered in pixel space (used as the collapse baseline on hide/empty).</summary>
+    public float PivotPx { get; }
+    /// <summary>Unit-width on the secondary axis, in pixels (clamped to GeometrySize floor so hover areas never go below marker size).</summary>
+    public float UnitWidthX { get; }
+    /// <summary>Configured geometry (marker) size in pixels.</summary>
+    public float GeometrySize { get; }
+    /// <summary>Half of <see cref="GeometrySize"/> (precomputed for marker centering).</summary>
+    public float HalfGeometrySize { get; }
+    /// <summary>Pre-cast data-label text size.</summary>
+    public float DataLabelsSize { get; }
+    /// <summary>True if this is the first draw of the series.</summary>
+    public bool IsFirstDraw { get; }
+    /// <summary>True if the marker visual carries a variable SVG path.</summary>
+    public bool HasSvg { get; }
+    /// <summary>Stacker for this series, or null when the series is not stacked.</summary>
+    public StackPosition? Stacker { get; }
+}


### PR DESCRIPTION
## Summary

Eighth and second-to-last installment of the cross-series refactor (after bars, scatter, financial, box, pie, heat, geomap-heatland). Applies the same template-method extraction to `CoreLineSeries.Invalidate`:

- Introduces `LineMeasureContext` ref struct bundling per-Invalidate state (scales, draw margin, Z-index, pivot, unit-width, geometry size, isFirstDraw, stacker, etc.)
- Seals `Invalidate(Chart)` and extracts virtual hooks:
  - `BeginMeasure(chart) -> LineMeasureContext`
  - `EnsureLineVisualForPoint(point, data, ctx)` — creates the `CubicSegmentVisualPoint`, error visuals, and seeds motion state at the pivot baseline (preserves #2132 fix)
  - `CollapseInvisibleLinePoint(point, data, ctx)` — collapses both visual and segment commands to the pivot when the series goes invisible
  - `MeasureLineErrorBars(visual, data, ctx)` — per-frame error-bar geometry
- Extracts private helpers:
  - `AttachSegmentPaths(...)` — wraps per-segment fill/stroke path lookup + paint registration + animate-if-new
  - `CleanupOrphanSegmentPaths(...)` — tail-cleanup loop for stale segment paths
  - `MeasureDataLabel(point, x, y, ctx)` — label create/update/position
- The outer segment loop and inner-point loop stay in `Invalidate` — the nesting is unique to the line family and doesn't compress into a single per-point hook without losing readability

`actualSecondaryScale` / `actualPrimaryScale` are still fetched (now in `BeginMeasure`) for their side effects, as in the original.

Behavior is bit-identical: the per-segment Fill/Stroke path Z-index writes, the segment-end `GeometryFill`/`GeometryStroke` `AddDrawableTask` calls, and the `pivotPx` collapse baseline all run at the same call sites.

## Test plan
- [x] `dotnet test tests/CoreTests/CoreTests.csproj -f net8.0` — 636/636 passing (includes animation trajectory tests pinning per-frame intermediate states)
- [x] `dotnet test tests/SnapshotTests/SnapshotTests.csproj -f net10.0` — 142/142 passing
- [ ] CI green across all platform matrix jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)