### PR TITLE
docs(skill): document animation-baseline tests in repro-and-fix

### DIFF
--- a/.claude/skills/repro-and-fix/SKILL.md
+++ b/.claude/skills/repro-and-fix/SKILL.md
@@ -256,6 +256,26 @@ Test choice depends on the bug nature:
   assert. Gate by `#if <PLATFORM>_UI_TESTING` if platform-specific (most
   XAML-platform-quirk bugs are).
 - **Pixel-perfect rendering**: snapshot test in `tests/SnapshotTests/`.
+- **Animation trajectory** (the bug is in per-frame interpolation, not the
+  final value — a bar pops to target instead of growing, a slice doesn't
+  sweep, a transition runs at the wrong speed, a refactor risks changing the
+  motion shape of an existing series): JSON animation baseline under
+  `tests/CoreTests/AnimationBaselines/` driven by
+  `tests/CoreTests/Helpers/SeriesAnimationCapture.cs`. The helper steps
+  `CoreMotionCanvas.DebugElapsedMilliseconds`, captures the visual's geometry
+  at each sample timestamp, and `AssertTrajectoryMatches` compares the
+  trajectory to a committed `.json`. First run writes the new trajectory to
+  `AnimationBaselinesNew/` and fails with a "review and commit" message —
+  inspect the file, then move it into `AnimationBaselines/`. Re-baseline the
+  same way: delete the JSON, re-run, move from `New/` back. On mismatch the
+  helper also drops `[EXPECTED]`/`[RESULT]` files into
+  `AnimationBaselinesDiff/` so you can diff them directly. Caller must use
+  `EasingFunctions.Lineal` + fixed `MinLimit`/`MaxLimit` so interpolation is
+  deterministic; the existing `tests/CoreTests/SeriesTests/*AnimationTests.cs`
+  files are the templates. Prefer this over a plain MSTest whenever the
+  observable is "how the value changes between two states" — a single
+  before/after assertion can't catch a regression that only mis-paints the
+  intermediate frames.
 - **Pure C# logic** (chart engine, motion, math): MSTest in
   `tests/CoreTests/`.
 


### PR DESCRIPTION
## Summary

- Adds a fourth bullet to step 7 ("Write the regression test first") of the `repro-and-fix` skill covering `tests/CoreTests/AnimationBaselines/` and `SeriesAnimationCapture`
- Explains when to reach for an animation-baseline trajectory over a plain MSTest: when the bug shape is *per-frame interpolation*, not a before/after value
- Documents the commit/diff workflow (`AnimationBaselinesNew/` for first runs and re-baselines, `AnimationBaselinesDiff/` for `[EXPECTED]`/`[RESULT]` files on mismatch), the `EasingFunctions.Lineal` + fixed-limits prerequisites, and points at `tests/CoreTests/SeriesTests/*AnimationTests.cs` as the templates

## Why

The skill already lists Factos, SnapshotTests, and CoreTests MSTest as regression-test options, but the animation-baseline infrastructure (added with the earlier *AnimationTests batch) wasn't mentioned anywhere. It's a real gap when the bug is in the motion shape between two states — a single MSTest assertion on the final value won't catch a transition that pops instead of growing, sweeps at the wrong speed, or skips frames.

Docs-only change; no source code or test code is touched.

## Test plan

- [x] Read the updated SKILL.md end-to-end — flow still makes sense with the new bullet
- [x] Verified the referenced paths exist: `tests/CoreTests/AnimationBaselines/`, `tests/CoreTests/Helpers/SeriesAnimationCapture.cs`, `tests/CoreTests/SeriesTests/*AnimationTests.cs`
- [x] No build/test impact since this is a `.claude/skills/` doc file

🤖 Generated with [Claude Code](https://claude.com/claude-code)