### PR TITLE
ci(ios): rename _DeviceName MSBuildArg to Device for iOS SDK 26.2

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -130,29 +130,6 @@ runs:
         done
         # Extra 5s buffer for the 'installd' daemon to wake up
         sleep 5
-    - name: Prune extra iOS simulators
-      shell: bash
-      if: ${{ inputs.test-type == 'factos-ios' }}
-      run: |
-        # iOS SDK 26.2's `ComputeAvailableDevices` MSBuild target returns *every*
-        # simulator matching the build's RuntimeIdentifier (boot state is ignored),
-        # and macos-26 ships ~33 pre-created iPhone/iPad simulators. With multiple
-        # candidates, dotnet/sdk's RunCommandSelector refuses to auto-pick and
-        # demands `--device <UDID>` — which is a top-level `dotnet run` CLI flag,
-        # not an MSBuild property, so Factos can't pass it.
-        #
-        # Workaround: delete every simulator except the one futureware-tech just
-        # booted. devices.Count == 1 makes dotnet run auto-pick (see
-        # https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs).
-        KEEP="${{ steps.launch_ios_simulator.outputs.udid }}"
-        echo "Keeping only $KEEP; deleting all other simulators..."
-        xcrun simctl list devices -j \
-          | jq -r --arg keep "$KEEP" '.devices | to_entries[].value[] | select(.udid != $keep) | .udid' \
-          | while read -r udid; do
-            xcrun simctl delete "$udid" >/dev/null 2>&1 || true
-          done
-        echo "Remaining simulators:"
-        xcrun simctl list devices | grep -E '\([A-F0-9-]{36}\)' || true
     - name: Run UI tests
       uses: nick-fields/retry@v3.0.2
       if : ${{ inputs.test-type == 'factos-ios' }}
@@ -161,7 +138,7 @@ runs:
         max_attempts: 3
         shell: bash
         command: |
-          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }}
+          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }} device=:v2:udid=${{ steps.launch_ios_simulator.outputs.udid }}
 
     - name: Run core tests
       uses: nick-fields/retry@v3.0.2

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -138,7 +138,7 @@ runs:
         max_attempts: 3
         shell: bash
         command: |
-          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }} device=:v2:udid=${{ steps.launch_ios_simulator.outputs.udid }}
+          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }} device=${{ steps.launch_ios_simulator.outputs.udid }}
 
     - name: Run core tests
       uses: nick-fields/retry@v3.0.2

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -130,6 +130,29 @@ runs:
         done
         # Extra 5s buffer for the 'installd' daemon to wake up
         sleep 5
+    - name: Prune extra iOS simulators
+      shell: bash
+      if: ${{ inputs.test-type == 'factos-ios' }}
+      run: |
+        # iOS SDK 26.2's `ComputeAvailableDevices` MSBuild target returns *every*
+        # simulator matching the build's RuntimeIdentifier (boot state is ignored),
+        # and macos-26 ships ~33 pre-created iPhone/iPad simulators. With multiple
+        # candidates, dotnet/sdk's RunCommandSelector refuses to auto-pick and
+        # demands `--device <UDID>` — which is a top-level `dotnet run` CLI flag,
+        # not an MSBuild property, so Factos can't pass it.
+        #
+        # Workaround: delete every simulator except the one futureware-tech just
+        # booted. devices.Count == 1 makes dotnet run auto-pick (see
+        # https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Run/RunCommandSelector.cs).
+        KEEP="${{ steps.launch_ios_simulator.outputs.udid }}"
+        echo "Keeping only $KEEP; deleting all other simulators..."
+        xcrun simctl list devices -j \
+          | jq -r --arg keep "$KEEP" '.devices | to_entries[].value[] | select(.udid != $keep) | .udid' \
+          | while read -r udid; do
+            xcrun simctl delete "$udid" >/dev/null 2>&1 || true
+          done
+        echo "Remaining simulators:"
+        xcrun simctl list devices | grep -E '\([A-F0-9-]{36}\)' || true
     - name: Run UI tests
       uses: nick-fields/retry@v3.0.2
       if : ${{ inputs.test-type == 'factos-ios' }}
@@ -138,7 +161,7 @@ runs:
         max_attempts: 3
         shell: bash
         command: |
-          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }} device=${{ steps.launch_ios_simulator.outputs.udid }}
+          dotnet run --project tests/UITests -c Release --report-trx --report-trx-filename results.trx --no-progress --select ${{ inputs.test-id }} --test-env tf=${{ inputs.target-framework }} lvcversionsuffix=-${{ inputs.livecharts-suffix }}
 
     - name: Run core tests
       uses: nick-fields/retry@v3.0.2

--- a/tests/UITests/Program.cs
+++ b/tests/UITests/Program.cs
@@ -68,11 +68,11 @@ MSBuildArg tf_n462 = new("TestBuildTargetFramework", "net462");
 MSBuildArg isTest = new("IsTestBuild", "true");
 MSBuildArg[] iphoneBuild = [
     ..msBuildArgs,
-    // iOS SDK 26.2 (.NET 10 / Xcode 26.2) replaced the legacy `_DeviceName=:v2:udid=<UDID>`
-    // selector with a top-level `DeviceName=<UDID>` (bare UDID) honored by `dotnet run`'s
-    // ComputeAvailableDevices target — see dotnet/macios#24279. The legacy property is no
-    // longer authoritative when multiple simulators of the same model exist on the runner.
-    new("DeviceName", "[device]"),
+    // No device selector here on purpose: in iOS SDK 26.2+ device selection is a
+    // top-level `dotnet run --device <UDID>` CLI flag, not an MSBuild property.
+    // Factos drives `dotnet run` from MSBuildArg pairs, so we can't inject `--device`
+    // here. The CI workflow instead prunes the runner's simulator pool to a single
+    // entry, which lets `dotnet run`'s RunCommandSelector auto-pick (devices.Count == 1).
     new("MTouchUseLlvm", "false"),
     new("MtouchLink", "SdkOnly"),
     new("RunAOTCompilation", "false"),

--- a/tests/UITests/Program.cs
+++ b/tests/UITests/Program.cs
@@ -68,11 +68,11 @@ MSBuildArg tf_n462 = new("TestBuildTargetFramework", "net462");
 MSBuildArg isTest = new("IsTestBuild", "true");
 MSBuildArg[] iphoneBuild = [
     ..msBuildArgs,
-    // No device selector here on purpose: in iOS SDK 26.2+ device selection is a
-    // top-level `dotnet run --device <UDID>` CLI flag, not an MSBuild property.
-    // Factos drives `dotnet run` from MSBuildArg pairs, so we can't inject `--device`
-    // here. The CI workflow instead prunes the runner's simulator pool to a single
-    // entry, which lets `dotnet run`'s RunCommandSelector auto-pick (devices.Count == 1).
+    // iOS SDK 26.2 renamed the device-selection MSBuild property from `_DeviceName`
+    // to `Device` (see Microsoft.Sdk.Mobile.targets: `DeviceName="$(Device)"`).
+    // Without it, mlaunch defaults to "iPhone 4s" (MT1207). With it, the
+    // `:v2:udid=<UDID>` mlaunch syntax still works and is required.
+    new("Device", "[device]"),
     new("MTouchUseLlvm", "false"),
     new("MtouchLink", "SdkOnly"),
     new("RunAOTCompilation", "false"),

--- a/tests/UITests/Program.cs
+++ b/tests/UITests/Program.cs
@@ -68,7 +68,11 @@ MSBuildArg tf_n462 = new("TestBuildTargetFramework", "net462");
 MSBuildArg isTest = new("IsTestBuild", "true");
 MSBuildArg[] iphoneBuild = [
     ..msBuildArgs,
-    new("_DeviceName", "[device]"),
+    // iOS SDK 26.2 (.NET 10 / Xcode 26.2) replaced the legacy `_DeviceName=:v2:udid=<UDID>`
+    // selector with a top-level `DeviceName=<UDID>` (bare UDID) honored by `dotnet run`'s
+    // ComputeAvailableDevices target — see dotnet/macios#24279. The legacy property is no
+    // longer authoritative when multiple simulators of the same model exist on the runner.
+    new("DeviceName", "[device]"),
     new("MTouchUseLlvm", "false"),
     new("MtouchLink", "SdkOnly"),
     new("RunAOTCompilation", "false"),


### PR DESCRIPTION
## Summary

iOS SDK 26.2.10217 (.NET 10 / Xcode 26.2) reads the device-selection MSBuild property from `$(Device)`, not `$(_DeviceName)`. From `Microsoft.Sdk.Mobile.targets`:

\`\`\`xml
<GetMlaunchArguments
  ...
  DeviceName=\"$(Device)\"
  ...
\`\`\`

Without it, mlaunch defaults to the long-gone *iPhone 4s* (`MT1207: Could not find the simulator device type 'iPhone 4s'`). The `:v2:udid=<UDID>` mlaunch syntax stays the same as the legacy property — only the MSBuild property name changed.

## Why this is the right fix

Setting `-p:Device=:v2:udid=<UDID>` does two things at once:

1. **dotnet/sdk** sees Device pre-specified in globalProperties and skips `TrySelectDevice` entirely ([RunCommand.cs:269-275](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Commands/Run/RunCommand.cs)), bypassing the *\"Unable to run this project because multiple devices are available\"* error on macos-26 runners that ship ~33 pre-created simulators.
2. **macios mlaunch** reads `$(Device)` in `_ComputeMlaunchRunArguments`, so the actual app launch targets the right UDID instead of the iPhone 4s default.

## Local verification (macOS 26.1 + iOS SDK 26.2.10217)

\`\`\`bash
dotnet new ios -n devicetest -o /tmp/devicetest
cd /tmp/devicetest && dotnet build -c Release ...
dotnet run -c Release ... -p:Device=:v2:udid=4D778DA7-... --no-build
# → simctl listapps shows com.companyname.devicetest installed on iPhone 16e
\`\`\`

## Test plan
- [ ] `test-ios (avalonia-ios, ios)` and `test-ios (maui-ios, net10.0-ios, maui)` go green

## What didn't work (for the record)
- ❌ Earlier `MSBuildArg(\"DeviceName\")` — still ignored by mlaunch.
- ❌ `simctl delete` non-target sims — bypassed the multi-device error but mlaunch then fell back to \"iPhone 4s\" because no `$(Device)` was set.
- ✅ `MSBuildArg(\"Device\", ...)` with `:v2:udid=<UDID>` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)