### PR TITLE
feat(treemap): platform view controls + shared source-gen glue

### DIFF
--- a/build/SharedLinks.Build.props
+++ b/build/SharedLinks.Build.props
@@ -41,5 +41,13 @@
     <Compile Update="SourceGenMapChart.*.cs">
       <DependentUpon>GeoMap.cs</DependentUpon>
     </Compile>
+
+    <Compile Include="..\_Shared\SourceGenTreemapChart.*.cs">
+      <Link>%(Filename).cs</Link>
+      <DependentUpon>TreemapChart.cs</DependentUpon>
+    </Compile>
+    <Compile Update="SourceGenTreemapChart.*.cs">
+      <DependentUpon>TreemapChart.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/build/WinUISharedLinks.Build.props
+++ b/build/WinUISharedLinks.Build.props
@@ -20,5 +20,9 @@
       <DependentUpon>GeoMap.cs</DependentUpon>
     </Compile>
 
+    <Compile Update="..\_Shared.WinUI\SourceGenTreemapChart.*.cs">
+      <DependentUpon>TreemapChart.cs</DependentUpon>
+    </Compile>
+
   </ItemGroup>
 </Project>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/TreemapChart.cs
@@ -1,0 +1,37 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.Avalonia;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView" />
+public class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WPF/TreemapChart.cs
@@ -1,0 +1,37 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.WPF;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView" />
+public partial class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.WinForms/TreemapChart.cs
@@ -1,0 +1,38 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.WinForms;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView" />
+[System.ComponentModel.DesignerCategory("")]
+public partial class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKTreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/LiveChartsGeneratedCode/SourceGenSKTreemapChart.cs
@@ -22,24 +22,16 @@
 
 using LiveChartsCore.Kernel.Sketches;
 
-namespace LiveChartsCore.SkiaSharpView.SKCharts;
+namespace LiveChartsGeneratedCode;
 
 // ==============================================================================
 //
-// use the LiveChartsGeneratedCode.SourceGenSKTreemapChart class to add Skia (image generation) specific
-// code, this class is just to expose the TreemapChart class in this namespace.
+// this file contains the Skia (image generation) specific code for the TreemapChart class,
+// the rest of the code can be found in the _Shared project.
 //
 // ==============================================================================
 
-/// <inheritdoc cref="ITreemapChartView"/>
-public class SKTreemapChart : LiveChartsGeneratedCode.SourceGenSKTreemapChart
-{
-    /// <summary>Initializes a new instance of the <see cref="SKTreemapChart"/> class.</summary>
-    public SKTreemapChart() : base(null) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKTreemapChart"/> class
-    /// from an existing chart view (theme + control size are reused).
-    /// </summary>
-    public SKTreemapChart(IChartView chartView) : base(chartView) { }
-}
+/// <inheritdoc cref="ITreemapChartView" />
+public partial class SourceGenSKTreemapChart(IChartView? chartView)
+    : SourceGenSKChart(chartView), ITreemapChartView
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Blazor/TreemapChart.cs
@@ -1,0 +1,38 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsGeneratedCode;
+
+namespace LiveChartsCore.SkiaSharpView.Blazor;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView"/>
+public partial class TreemapChart : SourceGenTreemapChart
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Eto/TreemapChart.cs
@@ -1,0 +1,37 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.Eto;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView" />
+public partial class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/TreemapChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/TreemapChart.cs
@@ -1,0 +1,37 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.Maui;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="ITreemapChartView"/>
+public partial class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/_Shared.WinUI/SourceGenTreemapChart.winui.cs
+++ b/src/skiasharp/_Shared.WinUI/SourceGenTreemapChart.winui.cs
@@ -22,24 +22,12 @@
 
 using LiveChartsCore.Kernel.Sketches;
 
-namespace LiveChartsCore.SkiaSharpView.SKCharts;
+namespace LiveChartsGeneratedCode;
 
-// ==============================================================================
-//
-// use the LiveChartsGeneratedCode.SourceGenSKTreemapChart class to add Skia (image generation) specific
-// code, this class is just to expose the TreemapChart class in this namespace.
-//
-// ==============================================================================
+// ===============================================
+// this file contains the WinUI/Uno specific code
+// ===============================================
 
-/// <inheritdoc cref="ITreemapChartView"/>
-public class SKTreemapChart : LiveChartsGeneratedCode.SourceGenSKTreemapChart
-{
-    /// <summary>Initializes a new instance of the <see cref="SKTreemapChart"/> class.</summary>
-    public SKTreemapChart() : base(null) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKTreemapChart"/> class
-    /// from an existing chart view (theme + control size are reused).
-    /// </summary>
-    public SKTreemapChart(IChartView chartView) : base(chartView) { }
-}
+/// <inheritdoc cref="IChartView" />
+public partial class SourceGenTreemapChart : SourceGenChart, ITreemapChartView
+{ }

--- a/src/skiasharp/_Shared.WinUI/TreemapChart.cs
+++ b/src/skiasharp/_Shared.WinUI/TreemapChart.cs
@@ -1,0 +1,37 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.SkiaSharpView.WinUI;
+
+// ==============================================================================
+// this file exposes the control at this namespace.
+// to see the code expand this file in the solution explorer, it will include 3 files:
+//    - *.uiFramework.cs:   The UI framework specific code
+//    - *.shared.cs:        shared code between all UI frameworks
+//    - *.sgp.cs:           the source generated properties
+// ==============================================================================
+
+/// <inheritdoc cref="IChartView" />
+public sealed partial class TreemapChart : LiveChartsGeneratedCode.SourceGenTreemapChart
+{ }

--- a/src/skiasharp/_Shared.WinUI/_Shared.WinUI.projitems
+++ b/src/skiasharp/_Shared.WinUI/_Shared.WinUI.projitems
@@ -21,6 +21,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenMapChart.winui.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenPieChart.winui.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenPolarChart.winui.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SourceGenTreemapChart.winui.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TreemapChart.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ThemeListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XamlSeries.cs" />
   </ItemGroup>

--- a/src/skiasharp/_Shared/SourceGenTreemapChart.sgp.cs
+++ b/src/skiasharp/_Shared/SourceGenTreemapChart.sgp.cs
@@ -20,26 +20,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using LiveChartsCore.Kernel.Sketches;
+namespace LiveChartsGeneratedCode;
 
-namespace LiveChartsCore.SkiaSharpView.SKCharts;
+// Treemap currently has no chart-level UIProperty markers — every configurable
+// property lives on the series (Padding, CornerRadius, Fill, Stroke, etc).
+// The empty partial keeps the file shape consistent with the other chart
+// families so the source generator + projitems list stays uniform. When
+// chart-level DPs get added in the future, mirror SourceGenPieChart.sgp.cs:
+// add `static UIProperty<T>` markers + an Avalonia OnPropertyChanged override
+// that calls OnXamlPropertyChanged (the generator emits the latter from the
+// presence of UIProperty markers).
 
-// ==============================================================================
-//
-// use the LiveChartsGeneratedCode.SourceGenSKTreemapChart class to add Skia (image generation) specific
-// code, this class is just to expose the TreemapChart class in this namespace.
-//
-// ==============================================================================
-
-/// <inheritdoc cref="ITreemapChartView"/>
-public class SKTreemapChart : LiveChartsGeneratedCode.SourceGenSKTreemapChart
+#if SKIA_IMAGE_LVC
+public partial class SourceGenSKTreemapChart
+#else
+public partial class SourceGenTreemapChart
+#endif
 {
-    /// <summary>Initializes a new instance of the <see cref="SKTreemapChart"/> class.</summary>
-    public SKTreemapChart() : base(null) { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SKTreemapChart"/> class
-    /// from an existing chart view (theme + control size are reused).
-    /// </summary>
-    public SKTreemapChart(IChartView chartView) : base(chartView) { }
 }

--- a/src/skiasharp/_Shared/SourceGenTreemapChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenTreemapChart.shared.cs
@@ -1,0 +1,66 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore;
+using System.Collections.ObjectModel;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Kernel.Sketches;
+
+#if SKIA_IMAGE_LVC
+using SGChart = LiveChartsGeneratedCode.SourceGenSKChart;
+#else
+using SGChart = LiveChartsGeneratedCode.SourceGenChart;
+#endif
+
+namespace LiveChartsGeneratedCode;
+
+// ==============================================================
+// this file contains the shared code between all UI frameworks
+// ==============================================================
+
+/// <inheritdoc cref="ITreemapChartView" />
+#if SKIA_IMAGE_LVC
+public partial class SourceGenSKTreemapChart : SGChart, ITreemapChartView
+#else
+public partial class SourceGenTreemapChart : SGChart, ITreemapChartView
+#endif
+{
+    TreemapChartEngine ITreemapChartView.Core => (TreemapChartEngine)CoreChart;
+
+    /// <inheritdoc cref="SGChart.CreateCoreChart"/>
+    protected override Chart CreateCoreChart() =>
+         new TreemapChartEngine(this, CoreCanvas);
+
+    /// <inheritdoc cref="SGChart.InitializeObservedProperties"/>
+    protected override void InitializeObservedProperties()
+    {
+        SyncContext = new object();
+#if !WPF_LVC
+        // WPF lazy-inits these in the property getter via SetCurrentValue
+        // (issue #1981) so this constructor-time SetValue would block the
+        // FrameworkElementFactory binding. Other platforms pre-init here so
+        // `chart.Series.Add(...)` works pre-Loaded.
+        Series = new ObservableCollection<ISeries>();
+        VisualElements = new ObservableCollection<IChartElement>();
+#endif
+    }
+}

--- a/src/skiasharp/_Shared/_Shared.projitems
+++ b/src/skiasharp/_Shared/_Shared.projitems
@@ -16,5 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenPieChart.sgp.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenPolarChart.shared.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SourceGenPolarChart.sgp.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SourceGenTreemapChart.shared.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SourceGenTreemapChart.sgp.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adds `TreemapChart` view controls for all 7 supported platforms. Each per-platform file is a one-line subclass of the source-generated `SourceGenTreemapChart` base — the heavy lifting (Series collection observation, theme propagation, platform-native DPs, core engine hookup) is done by the shared partial + source generator that already powers `PieChart`.

## Stacking
Stacked on **#2293** (engine + series + headless SK chart). Merge order: #2293 first, then this PR.

## Foundation refactor (1st commit)
- `_Shared/SourceGenTreemapChart.shared.cs` + `.sgp.cs` — shared partial with `CreateCoreChart` + `InitializeObservedProperties`. `#if SKIA_IMAGE_LVC` switches class name (`SourceGenSKTreemapChart` for headless, `SourceGenTreemapChart` for per-platform).
- `_Shared.WinUI/SourceGenTreemapChart.winui.cs` — WinUI/Uno-specific partial mirroring `SourceGenPieChart.winui.cs`.
- `SKCharts/LiveChartsGeneratedCode/SourceGenSKTreemapChart.cs` — SK headless base mirroring `SourceGenSKPieChart.cs`.
- `SKTreemapChart.cs` — slimmed to a two-constructor wrapper; the IChartView impl previously inlined here moved into the shared partial (functional equivalent — 147/147 snapshots still pass).
- Wiring: `_Shared.projitems`, `_Shared.WinUI.projitems`, `SharedLinks.Build.props`, `WinUISharedLinks.Build.props`.

## Per-platform controls (2nd commit)
One file per platform, each ~5 LOC body:
- WPF: `LiveChartsCore.SkiaSharp.WPF/TreemapChart.cs`
- Avalonia: `LiveChartsCore.SkiaSharp.Avalonia/TreemapChart.cs`
- MAUI: `LiveChartsCore.SkiaSharpView.Maui/TreemapChart.cs`
- Blazor: `LiveChartsCore.SkiaSharpView.Blazor/TreemapChart.cs`
- WinForms: `LiveChartsCore.SkiaSharp.WinForms/TreemapChart.cs`
- Eto: `LiveChartsCore.SkiaSharpView.Eto/TreemapChart.cs`
- WinUI + Uno: `_Shared.WinUI/TreemapChart.cs` (single file, linked into both projects)

## Out of scope (follow-up PRs)
- `XamlTreemapSeries<,,>` MVVM wrapper exposing `ValueMapper`/`ChildrenMapper`/`LabelMapper`/`Fill`/etc. as bindable DPs (separate `[XamlClass]` generator pass — different review concern).
- Per-tile hit-testing, animation baselines, theme registration, tooltips, samples (carry over from #2293's deferred list).

## Test plan
- [x] Build each platform — clean (WPF, Avalonia, MAUI, Blazor, WinForms, WinUI, Uno-WinUI, Eto + SK headless)
- [x] `dotnet test tests/SnapshotTests/` — 147/147 (no regressions from SK refactor)
- [ ] Factos UI test matrix runs per-platform on CI
- [ ] Eyeball one platform sample (next session — would need a sample app wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)