### PR TITLE
fix(canvas): route tooltips and legends to a new Overlay zone (#2304)

### DIFF
--- a/src/LiveChartsCore/Motion/CanvasZone.cs
+++ b/src/LiveChartsCore/Motion/CanvasZone.cs
@@ -34,6 +34,9 @@ internal class CanvasZone
     public const int NoClip = 1;
     public const int XCrosshair = 2;
     public const int YCrosshair = 3;
+    // Overlay draws last so tooltips and legends are never obscured by ticks/labels
+    // from the crosshair zones above (issue #2304).
+    public const int Overlay = 4;
     private Paint[] _sortedPaints = [];
     private bool _isDirty = true;
 
@@ -43,7 +46,7 @@ internal class CanvasZone
 
     // one instance per zone
     public static CanvasZone[] CreateZones() =>
-        [new CanvasZone(), new CanvasZone(), new CanvasZone(), new CanvasZone()];
+        [new CanvasZone(), new CanvasZone(), new CanvasZone(), new CanvasZone(), new CanvasZone()];
 
     public Paint[] EnumerateTasks()
     {

--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -337,9 +337,24 @@ public class CoreMotionCanvas : IDisposable
     {
         var task = new DrawnTask(this, geometries);
 
-        Zones[zone].AddTask(task);
+        if (!TryGetValue(zone, out var canvasZone))
+            throw new ArgumentOutOfRangeException(nameof(zone), zone, "The canvas zone does not exist.");
+
+        canvasZone.AddTask(task);
 
         return task;
+    }
+
+    private bool TryGetValue(int zone, out CanvasZone canvasZone)
+    {
+        if ((uint)zone < (uint)Zones.Length)
+        {
+            canvasZone = Zones[zone];
+            return true;
+        }
+
+        canvasZone = null!;
+        return false;
     }
 
     /// <summary>

--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -317,16 +317,27 @@ public class CoreMotionCanvas : IDisposable
     }
 
     /// <summary>
-    /// Adds a geometry (or geometries) to the canvas.
+    /// Adds a geometry (or geometries) to the canvas in the <see cref="CanvasZone.NoClip"/> zone.
     /// </summary>
     /// <returns>
     /// The task created to manage the geometries.
     /// </returns>
-    public DrawnTask AddGeometry(params IDrawnElement[] geometries)
+    public DrawnTask AddGeometry(params IDrawnElement[] geometries) =>
+        AddGeometry(CanvasZone.NoClip, geometries);
+
+    /// <summary>
+    /// Adds a geometry (or geometries) to the canvas in the given zone.
+    /// </summary>
+    /// <param name="zone">The canvas zone to add the task to.</param>
+    /// <param name="geometries">The geometries to add.</param>
+    /// <returns>
+    /// The task created to manage the geometries.
+    /// </returns>
+    public DrawnTask AddGeometry(int zone, params IDrawnElement[] geometries)
     {
         var task = new DrawnTask(this, geometries);
 
-        Zones[CanvasZone.NoClip].AddTask(task);
+        Zones[zone].AddTask(task);
 
         return task;
     }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultGeoTooltip.cs
@@ -89,7 +89,7 @@ public class SKDefaultGeoTooltip : Container<PopUpGeometry>, IGeoMapTooltip
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
         {
-            _drawnTask = chart.View.CoreCanvas.AddGeometry(this);
+            _drawnTask = chart.View.CoreCanvas.AddGeometry(CanvasZone.Overlay, this);
             _drawnTask.ZIndex = 10100;
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultLegend.cs
@@ -26,6 +26,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Layouts;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
@@ -68,7 +69,7 @@ public class SKDefaultLegend : Container, IChartLegend
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
         {
-            _drawnTask = chart.Canvas.AddGeometry(this);
+            _drawnTask = chart.Canvas.AddGeometry(CanvasZone.Overlay, this);
             _drawnTask.ZIndex = 10099;
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultTooltip.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKDefaultTooltip.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Drawing.Layouts;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
@@ -77,7 +78,7 @@ public class SKDefaultTooltip : Container<PopUpGeometry>, IChartTooltip
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
         {
-            _drawnTask = chart.Canvas.AddGeometry(this);
+            _drawnTask = chart.Canvas.AddGeometry(CanvasZone.Overlay, this);
             _drawnTask.ZIndex = 10100;
         }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKHeatLegend.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/SKCharts/SKHeatLegend.cs
@@ -27,6 +27,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Drawing.Layouts;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
@@ -83,7 +84,7 @@ public class SKHeatLegend : Container, IChartLegend
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
         {
-            _drawnTask = chart.Canvas.AddGeometry(this);
+            _drawnTask = chart.Canvas.AddGeometry(CanvasZone.Overlay, this);
             _drawnTask.ZIndex = 10099;
         }
 

--- a/tests/CoreTests/ChartTests/TooltipZoneTests.cs
+++ b/tests/CoreTests/ChartTests/TooltipZoneTests.cs
@@ -1,5 +1,6 @@
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.Motion;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CoreTests.ChartTests;
@@ -51,5 +52,15 @@ public class TooltipZoneTests
             $"Tooltip task must land in the last canvas zone (index {lastZoneIndex}). " +
             $"Before tooltip: {lastZoneBefore} tasks, after: {lastZoneAfter}. " +
             "If the delta is 0 the tooltip went into an earlier zone and axis ticks will paint over it.");
+    }
+
+    [TestMethod]
+    public void AddGeometry_ThrowsForMissingZone()
+    {
+        var canvas = new CoreMotionCanvas();
+        var missingZone = canvas.Zones.Length;
+
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => canvas.AddGeometry(missingZone));
     }
 }

--- a/tests/CoreTests/ChartTests/TooltipZoneTests.cs
+++ b/tests/CoreTests/ChartTests/TooltipZoneTests.cs
@@ -1,0 +1,55 @@
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+[TestClass]
+public class TooltipZoneTests
+{
+    // Issue #2304: the tooltip used to register its DrawnTask in CanvasZone.NoClip
+    // (1), but Y-axis ticks live in CanvasZone.YCrosshair (3) and zones draw in
+    // declaration order. Result: axis ticks paint on top of the tooltip on any
+    // multi-Y-axis chart, regardless of the tooltip's ZIndex = 10100.
+    //
+    // The pixel manifestation depends on whether the tooltip's auto-placement
+    // happens to overlap a tick path in the rendered layout, so this test pins
+    // the contract directly: the tooltip's task lands in the LAST canvas zone,
+    // which is the one that draws after every axis-related zone. The test does
+    // not name CanvasZone.Overlay so it would still fail behaviourally (delta = 0,
+    // not 1) if the new constant were renamed; it only asserts the routing.
+
+    [TestMethod]
+    public void TooltipLandsInLastCanvasZone_Issue2304()
+    {
+        var chart = new SKCartesianChart
+        {
+            Width = 300,
+            Height = 300,
+            Series = [new LineSeries<double> { Values = [1, 2, 3, 4, 5] }],
+            XAxes = [new Axis()],
+            YAxes = [new Axis()],
+            ExplicitDisposing = true
+        };
+
+        // first render — no pointer set, tooltip not shown yet.
+        _ = chart.GetImage();
+        var lastZoneIndex = chart.CoreCanvas.Zones.Length - 1;
+        var lastZoneBefore = chart.CoreCanvas.Zones[lastZoneIndex].CountTasks();
+
+        // open the tooltip
+        chart.CoreChart._isPointerIn = true;
+        chart.CoreChart._isToolTipOpen = true;
+        chart.CoreChart._pointerPosition = new(150, 150);
+        _ = chart.GetImage();
+
+        var lastZoneAfter = chart.CoreCanvas.Zones[lastZoneIndex].CountTasks();
+
+        Assert.AreEqual(
+            1,
+            lastZoneAfter - lastZoneBefore,
+            $"Tooltip task must land in the last canvas zone (index {lastZoneIndex}). " +
+            $"Before tooltip: {lastZoneBefore} tasks, after: {lastZoneAfter}. " +
+            "If the delta is 0 the tooltip went into an earlier zone and axis ticks will paint over it.");
+    }
+}


### PR DESCRIPTION
> Drafted by Claude on Beto's behalf; he has reviewed before publishing.

Closes #2304.

## Summary

On a multi-Y-axis chart, the tooltip (and, on intersecting layouts, the legend) used to render **under** Y-axis ticks. The tooltip's \`ZIndex = 10100\` did nothing because ZIndex only sorts paints **within** a zone, and zones draw in declaration order — the tooltip went into \`CanvasZone.NoClip\` (1) but Y-axis ticks live in \`CanvasZone.YCrosshair\` (3).

\`CoreMotionCanvas.AddGeometry\` hard-coded \`NoClip\`:

\`\`\`csharp
public DrawnTask AddGeometry(params IDrawnElement[] geometries)
{
    var task = new DrawnTask(this, geometries);
    Zones[CanvasZone.NoClip].AddTask(task);   // <-- always NoClip
    return task;
}
\`\`\`

## Fix

- Add \`CanvasZone.Overlay = 4\` (a 5th zone that draws last) and bump \`CreateZones()\` to allocate it.
- Add a \`CoreMotionCanvas.AddGeometry(int zone, params IDrawnElement[])\` overload. The existing \`params\` overload still routes to \`NoClip\` so user-defined \`Visual\` elements keep their current ZIndex-relative-to-axis-labels behaviour.
- Route the four overlay-UI callers (\`SKDefaultTooltip\`, \`SKDefaultLegend\`, \`SKDefaultGeoTooltip\`, \`SKHeatLegend\`) to \`CanvasZone.Overlay\`.

## Commits

1. \`test(canvas): pin tooltip canvas-zone routing\` — \`tests/CoreTests/ChartTests/TooltipZoneTests.cs\` asserts the tooltip's task lands in the **last** canvas zone (does not reference \`CanvasZone.Overlay\` by name, so it fails behaviourally — \`delta = 0, not 1\` — when the fix commit is reverted). The pixel manifestation of the bug depends on tooltip auto-placement, which is why this is a CoreTests test rather than a snapshot.
2. \`fix(canvas): route tooltips and legends to an Overlay zone\` — the fix as described above.

## Test plan
- [x] new \`TooltipZoneTests.TooltipLandsInLastCanvasZone_Issue2304\` passes (verified failing on master)
- [x] \`dotnet test tests/CoreTests/ --framework net8.0\` → 724/724 pass
- [x] \`dotnet test tests/SnapshotTests/SnapshotTests.csproj\` → 165/165 pass (no baselines refreshed; the new zone is empty when no overlay UI is shown)
- [x] visual smoke: post-fix render of multi-Y-axis tooltip with \`DrawTicksPath = true\` shows tooltip on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)