### PR TITLE
fix(axis): rebuild subseparators when SubseparatorsCount changes (#2287)

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -588,8 +588,13 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
                 UpdateMode.UpdateAndComplete);
         }
         if (SubseparatorsPaint is not null && SubseparatorsPaint != Paint.Default && ShowSeparatorLines &&
-            (visualSeparator.Subseparators is null || visualSeparator.Subseparators.Length == 0))
+            (visualSeparator.Subseparators is null || visualSeparator.Subseparators.Length != SubseparatorsCount))
         {
+            // SubseparatorsCount can change at runtime; if the existing array length no longer
+            // matches the count we must detach the old geometries from the paint task and
+            // rebuild — otherwise UpdateSubseparators iterates `subseparators.Length` and just
+            // repositions the stale set via (j+1)/(count+1), producing gaps (issue #2287).
+            DetachSubseparators(visualSeparator, chart);
             InitializeSubseparators(visualSeparator, chart);
             UpdateSubseparators(
                 visualSeparator.Subseparators!, ctx.ActualScale, ctx.Step, xc + sxco, yc + syco, ctx.LeftX, ctx.RightX, ctx.TopY, ctx.BottomY,
@@ -601,8 +606,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             UpdateTick(visualSeparator.Tick!, _tickLength, xc + txco, yc + tyco, UpdateMode.UpdateAndComplete);
         }
         if (SubticksPaint is not null && SubticksPaint != Paint.Default && SubseparatorsCount > 0 &&
-            (visualSeparator.Subticks is null || visualSeparator.Subticks.Length == 0))
+            (visualSeparator.Subticks is null || visualSeparator.Subticks.Length != SubseparatorsCount))
         {
+            DetachSubticks(visualSeparator, chart);
             InitializeSubticks(visualSeparator, chart);
             UpdateSubticks(visualSeparator.Subticks!, ctx.ActualScale, ctx.Step, xc + txco, yc + tyco, UpdateMode.UpdateAndComplete);
         }
@@ -1297,6 +1303,20 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             visualSeparator.Subseparators[j] = subSeparator;
             InitializeTick(visualSeparator, cartesianChart, subSeparator);
         }
+    }
+
+    private void DetachSubseparators(AxisVisualSeprator visualSeparator, CartesianChartEngine cartesianChart)
+    {
+        if (visualSeparator.Subseparators is null || SubseparatorsPaint is null) return;
+        foreach (var sub in visualSeparator.Subseparators)
+            SubseparatorsPaint.RemoveGeometryFromPaintTask(cartesianChart.Canvas, sub);
+    }
+
+    private void DetachSubticks(AxisVisualSeprator visualSeparator, CartesianChartEngine cartesianChart)
+    {
+        if (visualSeparator.Subticks is null || SubticksPaint is null) return;
+        foreach (var sub in visualSeparator.Subticks)
+            SubticksPaint.RemoveGeometryFromPaintTask(cartesianChart.Canvas, sub);
     }
 
     private void InitializeLine(BaseLineGeometry lineGeometry, CartesianChartEngine cartesianChart) =>

--- a/tests/CoreTests/CoreObjectsTests/SubseparatorsCountTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/SubseparatorsCountTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+[TestClass]
+public class SubseparatorsCountTests
+{
+    // Regression for issue #2287: changing SubseparatorsCount at runtime kept the
+    // existing subseparator array length, so old geometries were repositioned via
+    // the (j+1)/(count+1) divisor but no new lines were added — leaving gaps.
+    [TestMethod]
+    public void ChangingSubseparatorsCountRebuildsGeometryArray()
+    {
+        var subseparatorsPaint = new SolidColorPaint(SKColors.Blue);
+        var yAxis = new Axis
+        {
+            SeparatorsPaint = new SolidColorPaint(SKColors.Red),
+            SubseparatorsPaint = subseparatorsPaint,
+            SubseparatorsCount = 1,
+        };
+
+        var chart = new SKCartesianChart
+        {
+            Series = [new LineSeries<double>([4, 7, 5, 8, 6, 9, 5, 7])],
+            XAxes = [new Axis()],
+            YAxes = [yAxis],
+        };
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        var initialCount = subseparatorsPaint.GetGeometries(chart.CoreCanvas).Count;
+        Assert.IsTrue(initialCount > 0, "Expected subseparators after the first measure.");
+
+        yAxis.SubseparatorsCount = 2;
+        _ = ChangingPaintTasks.DrawChart(chart);
+        var doubledCount = subseparatorsPaint.GetGeometries(chart.CoreCanvas).Count;
+
+        yAxis.SubseparatorsCount = 3;
+        _ = ChangingPaintTasks.DrawChart(chart);
+        var tripledCount = subseparatorsPaint.GetGeometries(chart.CoreCanvas).Count;
+
+        // Major-separator count stayed constant across the three measures (same
+        // data + same bounds), so the subseparator count must scale linearly with
+        // SubseparatorsCount.
+        var majorCount = initialCount; // 1 subseparator per major slot at count=1
+        Assert.AreEqual(2 * majorCount, doubledCount, "SubseparatorsCount=2 should produce 2x the geometries");
+        Assert.AreEqual(3 * majorCount, tripledCount, "SubseparatorsCount=3 should produce 3x the geometries");
+    }
+
+    [TestMethod]
+    public void ShrinkingSubseparatorsCountDetachesExtraGeometries()
+    {
+        var subseparatorsPaint = new SolidColorPaint(SKColors.Blue);
+        var yAxis = new Axis
+        {
+            SeparatorsPaint = new SolidColorPaint(SKColors.Red),
+            SubseparatorsPaint = subseparatorsPaint,
+            SubseparatorsCount = 3,
+        };
+
+        var chart = new SKCartesianChart
+        {
+            Series = [new LineSeries<double>([4, 7, 5, 8, 6, 9, 5, 7])],
+            XAxes = [new Axis()],
+            YAxes = [yAxis],
+        };
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        var initial = subseparatorsPaint.GetGeometries(chart.CoreCanvas).Count;
+
+        yAxis.SubseparatorsCount = 1;
+        _ = ChangingPaintTasks.DrawChart(chart);
+        var shrunk = subseparatorsPaint.GetGeometries(chart.CoreCanvas).Count;
+
+        Assert.AreEqual(initial / 3, shrunk, "Shrinking SubseparatorsCount must detach the extra geometries");
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #2287
- `SubseparatorsCount` changes at runtime now rebuild the per-major subseparator array instead of repositioning a stale-length set
- Same treatment for `Subticks`

## Why
`CoreAxis.cs` only entered the subseparator init branch when the array was null or empty:

```csharp
if (... && (visualSeparator.Subseparators is null || visualSeparator.Subseparators.Length == 0))
```

So bumping `SubseparatorsCount` from 1 → 2 at runtime never reinitialized the array. `UpdateSubseparators` then iterated `subseparators.Length` (still 1) and repositioned each existing line via `(j+1)/(count+1)` — the lines slid leftward but no new lines filled in, producing the gaps in the reporter's screenshots.

Fix: compare array length against the current `SubseparatorsCount`; on mismatch, detach the old geometries from the paint task and rebuild. Shrinking the count similarly detaches the now-extra geometries.

## Test plan
- [x] Two new `CoreTests` (`SubseparatorsCountTests`) — grow 1→2→3 and shrink 3→1; both fail on master before the fix and pass after.
- [x] Full `tests/CoreTests/` suite: 725/725 pass.
- [x] Full `tests/SnapshotTests/` suite: 165/165 pass.
- [x] Avalonia repro (`VisualTest/Issue2287Repro`) — before/after captures confirm the gaps close at `SubseparatorsCount=2` (1 blue line per cell → 2 blue lines per cell).

> Note: drafted with assistance from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)