### PR TITLE
ci(ios): rename _DeviceName MSBuildArg to Device for iOS SDK 26.2 [v2.0.x backport]

### DIFF
--- a/tests/UITests/Program.cs
+++ b/tests/UITests/Program.cs
@@ -68,7 +68,11 @@ MSBuildArg tf_n462 = new("TestBuildTargetFramework", "net462");
 MSBuildArg isTest = new("IsTestBuild", "true");
 MSBuildArg[] iphoneBuild = [
     ..msBuildArgs,
-    new("_DeviceName", "[device]"),
+    // iOS SDK 26.2 renamed the device-selection MSBuild property from `_DeviceName`
+    // to `Device` (see Microsoft.Sdk.Mobile.targets: `DeviceName="$(Device)"`).
+    // Without it, mlaunch defaults to "iPhone 4s" (MT1207). With it, the
+    // `:v2:udid=<UDID>` mlaunch syntax still works and is required.
+    new("Device", "[device]"),
     new("MTouchUseLlvm", "false"),
     new("MtouchLink", "SdkOnly"),
     new("RunAOTCompilation", "false"),


### PR DESCRIPTION
## Summary
- Backport of #2289 to `release/v2.0.x`.
- iOS SDK 26.2 (.NET 10 / Xcode 26.2) renamed the device-selection MSBuild property from `_DeviceName` to `Device` (see `Microsoft.Sdk.Mobile.targets`: `DeviceName="$(Device)"`). Without it, mlaunch defaults to "iPhone 4s" (MT1207).
- One-line rename in `tests/UITests/Program.cs`, plus a comment explaining the rationale. The `:v2:udid=<UDID>` value is unchanged.

## Why this is the right backport shape
The original PR had two dead-end commits (a misnamed `DeviceName` rename and a `simctl delete` simulator-pruning step) before landing on the correct fix. On `release/v2.0.x` neither of those intermediate states ever existed, so the net diff vs. v2.0.x is just the Program.cs rename. Cherry-pick of the merge commit (`4908c802b`, `-m 1`) gives exactly that.

## Test plan
- [ ] `test-ios (avalonia-ios, ios)` and `test-ios (maui-ios, net10.0-ios, maui)` go green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)