### PR TITLE
fix(maui): preserve chart handler across iOS TabbedPage switches (#2297)

### DIFF
--- a/samples/MauiSample/Test/Issue2297Repro/View.xaml
+++ b/samples/MauiSample/Test/Issue2297Repro/View.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="MauiSample.Test.Issue2297Repro.View"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Label Text="Issue 2297 host page" />
+</ContentPage>

--- a/samples/MauiSample/Test/Issue2297Repro/View.xaml.cs
+++ b/samples/MauiSample/Test/Issue2297Repro/View.xaml.cs
@@ -1,0 +1,49 @@
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Maui;
+
+namespace MauiSample.Test.Issue2297Repro;
+
+// Host page for the Factos regression test:
+// SharedUITests/DisposeTests.ChartHandlerSurvivesTabSwitch_Issue2297.
+//
+// The bug only manifests inside a real iOS UITabBarController, so the test
+// pushes a TabbedPage modally on top of this ContentPage. Building the
+// TabbedPage in code (rather than in XAML) keeps the chart instances directly
+// accessible — the test reads them back through GetChart to assert that their
+// MAUI Handler survives a tab switch's Unloaded event (the regression #2297).
+[XamlCompilation(XamlCompilationOptions.Compile)]
+public partial class View : ContentPage
+{
+    private TabbedPage? _tabbed;
+    private CartesianChart[]? _charts;
+
+    public View() => InitializeComponent();
+
+    public async Task PushTabbedPageAsync()
+    {
+        _charts =
+        [
+            new CartesianChart { Series = [new LineSeries<double> { Values = [2d, 5, 4, 6, 8, 3, 7] }] },
+            new CartesianChart { Series = [new ColumnSeries<double> { Values = [4d, 2, 6, 5, 8] }] },
+        ];
+
+        _tabbed = new TabbedPage
+        {
+            Children =
+            {
+                new ContentPage { Title = "A", Content = _charts[0] },
+                new ContentPage { Title = "B", Content = _charts[1] },
+            }
+        };
+
+        await Navigation.PushModalAsync(_tabbed);
+    }
+
+    public void SwitchToTab(int index) =>
+        _tabbed!.CurrentPage = _tabbed.Children.ElementAt(index);
+
+    public CartesianChart GetChart(int index) => _charts![index];
+
+    public Task PopTabbedPageAsync() => Navigation.PopModalAsync();
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenDrawnView.maui.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenDrawnView.maui.cs
@@ -76,7 +76,16 @@ public abstract partial class SourceGenDrawnView : ChartView
         // every chart removed from the visual tree (#1725). Other platforms
         // exhibit the same +=/-= pattern but don't leak in practice (no
         // equivalent native-peer pinning), so scope this to Apple.
-        Handler?.DisconnectHandler();
+        //
+        // Gate on Window == null: on a TabbedPage (iOS only) MAUI fires Unloaded
+        // for the inactive tab's chart even though the element is still mounted
+        // in the window — UITabBarController just hides the platform UIView.
+        // DisconnectHandler in that case nulls the handler and MAUI never raises
+        // Loaded again when the tab is reselected, so the chart goes permanently
+        // blank (#2297). Window is null only when the chart has truly detached
+        // from the window, which is the case we need to release the chain in.
+        if (Window is null)
+            Handler?.DisconnectHandler();
 #endif
     }
 }

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -117,6 +117,7 @@ public class DisposeTests
         }
     }
 
+#if MAUI_UI_TESTING
     // https://github.com/Live-Charts/LiveCharts2/issues/2297
     //
     // On iOS, MAUI's UITabBarController fires Unloaded for the chart on the tab
@@ -127,11 +128,11 @@ public class DisposeTests
     // chart went permanently blank. The fix gates the disconnect on Window ==
     // null, so transient tab-switch unloads no longer drop the handler.
     //
-    // This is a focused contract test: push a TabbedPage modally and verify the
-    // hidden tab's chart Handler stays alive after the switch. The buggy version
-    // failed the Handler null assertion on iOS (Window != null but
-    // DisconnectHandler still ran); on every other XAML platform the disconnect
-    // is gated by `#if IOS || MACCATALYST` so the assertion always holds.
+    // This is a MAUI-only contract test — TabbedPage and the Handler property
+    // are MAUI concepts, and the regression view (Issue2297Repro) lives only
+    // in MauiSample. On non-iOS MAUI targets the disconnect is gated by
+    // `#if IOS || MACCATALYST` so the assertion always holds; the test still
+    // runs there as a smoke check that the Window-null gate doesn't regress.
     [AppTestMethod]
     public async Task ChartHandlerSurvivesTabSwitch_Issue2297()
     {
@@ -151,5 +152,6 @@ public class DisposeTests
 
         await sut.PopTabbedPageAsync();
     }
+#endif
 #endif
 }

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -116,5 +116,40 @@ public class DisposeTests
             await Task.Delay(500);
         }
     }
+
+    // https://github.com/Live-Charts/LiveCharts2/issues/2297
+    //
+    // On iOS, MAUI's UITabBarController fires Unloaded for the chart on the tab
+    // the user just switched AWAY from, even though the chart's element is still
+    // mounted in the window — UIKit just hides the platform UIView. The #1725
+    // Apple-side handler-disconnect ran on that Unloaded and set Handler=null;
+    // MAUI then never raised Loaded when the user returned to the tab and the
+    // chart went permanently blank. The fix gates the disconnect on Window ==
+    // null, so transient tab-switch unloads no longer drop the handler.
+    //
+    // This is a focused contract test: push a TabbedPage modally and verify the
+    // hidden tab's chart Handler stays alive after the switch. The buggy version
+    // failed the Handler null assertion on iOS (Window != null but
+    // DisconnectHandler still ran); on every other XAML platform the disconnect
+    // is gated by `#if IOS || MACCATALYST` so the assertion always holds.
+    [AppTestMethod]
+    public async Task ChartHandlerSurvivesTabSwitch_Issue2297()
+    {
+        var sut = await App.NavigateTo<Samples.Test.Issue2297Repro.View>();
+        await Task.Delay(1000);
+
+        await sut.PushTabbedPageAsync();
+        await Task.Delay(1500);
+
+        var hiddenTabChart = sut.GetChart(0);
+        Assert.NotNull(hiddenTabChart.Handler);
+
+        sut.SwitchToTab(1);
+        await Task.Delay(1500);
+
+        Assert.NotNull(hiddenTabChart.Handler);
+
+        await sut.PopTabbedPageAsync();
+    }
 #endif
 }


### PR DESCRIPTION
## Summary

- Closes #2297 — on iOS, charts inside a MAUI `TabbedPage` go permanently blank after the first tab switch and only recover after an app restart.
- One-line gate in `SourceGenDrawnView.OnDrawnViewUnloadedInternal`: only call `Handler?.DisconnectHandler()` when `Window is null` (chart has truly detached). Tab-switch unloads no longer drop the handler.
- Adds Factos regression test `ChartHandlerSurvivesTabSwitch_Issue2297` that pushes a `TabbedPage` modally and asserts the hidden tab's chart still has a live MAUI `Handler` after the switch.

## Why

iOS's `UITabBarController` removes the inactive tab's platform `UIView` from the screen but keeps the MAUI element mounted in the window. MAUI fires `Unloaded` for that element anyway. The Apple-side handler-disconnect added for #1725 ran on every `Unloaded` and nulled the handler — at which point MAUI never raised `Loaded` again when the user returned to the tab, so the chart had no platform peer to repaint into and stayed blank for the rest of the app session.

Tracing on iPhone 17 Pro / iOS 26.1 sim showed `Unloaded` fires with `Window != null` only in the tab-switch case; the #1725 canary scenario (`Test/Dispose.ChangeContent`, which truly removes a chart's ancestor from the visual tree) fires `Unloaded` with `Window == null`. Gating the disconnect on that flag preserves both behaviors: tab switches keep the handler, real removals still release the UIKit gesture-recognizer chain so the chart can be GC'd.

The underlying MAUI bug (no clean affordance for "release native-peer state without losing handler reuse") is reported upstream at [dotnet/maui#35627](https://github.com/dotnet/maui/issues/35627); the `Window`-check we use here is a workaround until one of the proposed framework primitives lands.

## Test plan

- [x] Manual visual repro on iPhone 17 Pro (iOS 26.1) sim — `TabbedPage` with three `CartesianChart` children, tabs cycle every 3 s; before fix every return visit is blank, after fix every return visit re-renders.
- [x] Build succeeds for `samples/MauiSample` on `net10.0-ios` / `iossimulator-arm64`.
- [x] Full `maui-ios` Factos suite (18 tests) passes locally on iOS 26.1 sim, including `UnloadedChartsShouldBeCollectable_Issue1725` (the #1725 GC canary — proves the leak fix is preserved), `ChartShouldSurviveReattachOfSameInstance_Issue1725`, and the new `ChartHandlerSurvivesTabSwitch_Issue2297`.
- [ ] CI `test-ios / maui-ios` job confirms the same on GitHub-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)