### PR TITLE
fix(ci): suffix test-results artifact with run_attempt

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -202,6 +202,6 @@ runs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-          name: test-results-${{ inputs.test-id }}-${{ github.job }}-${{ inputs.target-framework }}-attempt-${{ github.run_attempt }}
-          retention-days: 30
-          path: "**/*.trx"
+        name: test-results-${{ inputs.test-id }}-${{ github.job }}-${{ inputs.target-framework }}-attempt-${{ github.run_attempt }}
+        retention-days: 30
+        path: "**/*.trx"

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -195,11 +195,13 @@ runs:
         path: "**/*.coverage"
         overwrite: true
 
+    # Suffix with run_attempt so re-runs upload to a fresh artifact instead of
+    # racing the previous attempt's blob during overwrite finalization. The
+    # PR Comment workflow looks up the matching attempt via workflow_run.run_attempt.
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-          name: test-results-${{ inputs.test-id }}-${{ github.job }}-${{ inputs.target-framework }}
+          name: test-results-${{ inputs.test-id }}-${{ github.job }}-${{ inputs.target-framework }}-attempt-${{ github.run_attempt }}
           retention-days: 30
           path: "**/*.trx"
-          overwrite: true

--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -24,7 +24,9 @@ const SECTIONS = {
 
 // Platform groupings rendered inside the Tests <details>. Each entry must
 // match exactly one matrix variant from the LiveCharts workflow:
-//   - testId / jobName / tf -> the artifact name `test-results-{testId}-{jobName}-{tf}`
+//   - testId / jobName / tf -> the artifact name
+//     `test-results-{testId}-{jobName}-{tf}-attempt-{runAttempt}` (the
+//     run_attempt suffix is appended by buildTestsBlock at lookup time).
 //   - matrix -> values that must prefix-match the parenthesised matrix part of
 //     the corresponding job's display name (declaration order, id-first).
 const PLATFORMS = [
@@ -124,7 +126,7 @@ function artifactUrl(owner, repo, runId, artifact) {
   return `https://github.com/${owner}/${repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
 }
 
-function buildTestsBlock({ jobs, artifacts, runId, owner, repo }) {
+function buildTestsBlock({ jobs, artifacts, runId, runAttempt, owner, repo }) {
   const groups = [];
   const overall = [];
   for (const platform of PLATFORMS) {
@@ -135,7 +137,7 @@ function buildTestsBlock({ jobs, artifacts, runId, owner, repo }) {
       const status = statusOf(job);
       if (status === 'missing') continue; // matrix entry was not included in this run
       groupStatuses.push(status);
-      const artifactName = `test-results-${e.testId}-${e.jobName}-${e.tf}`;
+      const artifactName = `test-results-${e.testId}-${e.jobName}-${e.tf}-attempt-${runAttempt}`;
       const artifact = artifacts.find(a => a.name === artifactName && !a.expired);
       const link = artifact ? `[trx](${artifactUrl(owner, repo, runId, artifact)})` : '_no trx_';
       lines.push(`  - ${e.label} ${emoji(status)} — ${link}`);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
@@ -63,6 +64,7 @@ jobs:
             const repo = context.repo.repo;
             const runId = Number(process.env.RUN_ID);
             const runNumber = process.env.RUN_NUMBER;
+            const runAttempt = Number(process.env.RUN_ATTEMPT);
 
             const { prNumber } = await lib.resolvePr({
               github, context,
@@ -94,7 +96,7 @@ jobs:
               : `#### Packing ${lib.emoji(packStatus)}\n\nNuGet packages were not produced.`;
 
             // ---- Tests (collapsed details, grouped by platform)
-            const testsBlock = lib.buildTestsBlock({ jobs, artifacts, runId, owner, repo });
+            const testsBlock = lib.buildTestsBlock({ jobs, artifacts, runId, runAttempt, owner, repo });
 
             // ---- Coverage (only when both core & snapshot passed and the artifact landed)
             let coverageBlock = '';


### PR DESCRIPTION
## Summary

On a workflow re-run, `actions/upload-artifact@v6.0.0` writes to the same
artifact name as the previous attempt (`test-results-{id}-{job}-{tf}`), then
deletes the prior blob to honour `overwrite: true`. Finalize occasionally
races on the artifact service — when that happens the upload step exits
non-zero AFTER tests have already passed on a retry, marking the parent
step (and the whole job) red over a green test run.

Seen in PR #2305 (run [#26456500893](https://github.com/Live-Charts/LiveCharts2/actions/runs/26456500893/job/77908186347)),
`test-windows (uno, net10.0-windows10.0.19041.0)`:
- Attempt 1 + 2 of `nick-fields/retry` failed (flaky `ShouldUnloadAndReload`)
- Attempt 3 passed, retry reported `Code: 0` + `Command completed after 3 attempt(s).`
- `Upload test results` logged `Finalizing artifact upload` and exited silently — the
  expected `successfully finalized / successfully uploaded` lines never appeared
  and the artifact is missing from the run's artifact list
- Step `Run UI tests` was marked failure

This was `run_attempt: 3`; the upload step's earlier log line
`Artifact 'test-results-...' (ID: 7219162704) deleted` confirms it raced
against the leftover blob from a prior workflow attempt.

## Change

- Suffix the artifact name with `-attempt-${{ github.run_attempt }}` in
  `.github/actions/run-tests/action.yml`, and drop `overwrite: true` since
  each attempt now writes to a unique name
- Mirror the suffix in `.github/scripts/pr-comment.js` (the only other
  consumer) and thread `workflow_run.run_attempt` through
  `.github/workflows/pr-comment.yml` so the PR comment finds the trx for the
  most recent attempt

The underlying Uno-Windows10 `ShouldUnloadAndReload` flake is a separate
concern and not fixed here — but the retry will now correctly carry the
job to green when it covers the flake.

## Test plan

- [ ] CI green on this PR (single attempt; new artifact name pattern present in logs)
- [ ] After merge, re-run a flaky workflow once and confirm the second
      attempt's `Upload test results` step uploads cleanly and the PR
      comment links to the latest trx

🤖 Generated with [Claude Code](https://claude.com/claude-code)