### PR TITLE
fix(drawing): per-instance clearCanvasOnNewFrame (#2303)

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
@@ -44,7 +44,6 @@ public class MotionCanvas : UserControl
 
     static MotionCanvas()
     {
-        SkiaSharpDrawingContext.s_clearCanvasOnNewFrame = false;
         _ = LiveChartsSkiaSharp.EnsureInitialized();
     }
 
@@ -119,7 +118,8 @@ public class MotionCanvas : UserControl
             using var lease = leaseFeature.Lease();
 
             motionCanvas.DrawFrame(
-                new SkiaSharpDrawingContext(motionCanvas, lease.SkCanvas, background));
+                new SkiaSharpDrawingContext(
+                    motionCanvas, lease.SkCanvas, background, clearCanvasOnNewFrame: false));
         }
 
         public void Dispose() { }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -38,11 +38,26 @@ namespace LiveChartsCore.SkiaSharpView.Drawing;
 /// <param name="canvas">The canvas.</param>
 /// <param name="background">The background color.</param>
 /// <param name="clearBlendMode">The blend mode to use when clearing the canvas. Default is <see cref="SKBlendMode.SrcIn"/>.</param>
+/// <param name="clearCanvasOnNewFrame">
+/// Whether the canvas should be cleared at the beginning of each frame.
+/// Avalonia and Uno-Skia hosts clear the surface themselves before invoking
+/// <see cref="DrawingContext.OnBeginDraw"/>, so they pass <c>false</c>. Default
+/// <c>true</c> for hosts where SkiaSharp owns the surface and must clear it
+/// explicitly (WPF, MAUI, WinForms, Blazor, in-memory).
+/// </param>
 public class SkiaSharpDrawingContext(
-    CoreMotionCanvas motionCanvas, SKCanvas canvas, SKColor background, SKBlendMode clearBlendMode = SKBlendMode.SrcIn)
+    CoreMotionCanvas motionCanvas,
+    SKCanvas canvas,
+    SKColor background,
+    SKBlendMode clearBlendMode = SKBlendMode.SrcIn,
+    bool clearCanvasOnNewFrame = true)
         : DrawingContext
 {
-    internal static bool s_clearCanvasOnNewFrame = true;
+    /// <summary>
+    /// Gets a value indicating whether the canvas is cleared at the beginning of
+    /// each frame. See the constructor parameter of the same name.
+    /// </summary>
+    public bool ClearCanvasOnNewFrame { get; } = clearCanvasOnNewFrame;
 
     /// <summary>
     /// Gets or sets the motion canvas.
@@ -112,7 +127,7 @@ public class SkiaSharpDrawingContext(
 
     internal override void OnBeginDraw()
     {
-        if (!s_clearCanvasOnNewFrame)
+        if (!ClearCanvasOnNewFrame)
             return;
 
         // clear the canvas with the background color if it's fully opaque

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
@@ -47,11 +47,6 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
         Children.Add(_renderMode);
     }
 
-    static SkiaRenderMode()
-    {
-        SkiaSharpDrawingContext.s_clearCanvasOnNewFrame = false;
-    }
-
     public event CoreMotionCanvas.FrameRequestHandler FrameRequest
     {
         add => _renderMode.FrameRequest += value;
@@ -95,7 +90,8 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
         protected override void RenderOverride(SKCanvas canvas, Size area)
         {
             FrameRequest?.Invoke(
-                new SkiaSharpDrawingContext(_canvas, canvas, GetBackground()));
+                new SkiaSharpDrawingContext(
+                    _canvas, canvas, GetBackground(), clearCanvasOnNewFrame: false));
         }
 
         private SKColor GetBackground() =>

--- a/tests/CoreTests/OtherTests/SkiaSharpDrawingContextTests.cs
+++ b/tests/CoreTests/OtherTests/SkiaSharpDrawingContextTests.cs
@@ -1,0 +1,75 @@
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class SkiaSharpDrawingContextTests
+{
+    // Regression for #2303. When an application hosts a LiveCharts chart from both
+    // Avalonia and WPF (or any other backend) in the same process, the Avalonia
+    // chart used to "poison" the WPF chart so that animation frames stacked on top
+    // of each other instead of clearing. Root cause: clearCanvasOnNewFrame used to
+    // be a process-static field, and Avalonia/Uno-Skia static initializers flipped
+    // it to false because their host clears the surface before invoking Render.
+    // Once flipped, every other SkiaSharpDrawingContext in the process (WPF, MAUI,
+    // WinForms, Blazor, in-memory) silently skipped its own clear too.
+    //
+    // The fix moved the flag onto the instance via a constructor parameter. This
+    // test pins that contract: constructing an opt-out context must not affect a
+    // sibling default-constructed context. Verified by pre-filling a surface with
+    // a known colour, constructing an opt-out context (the Avalonia/Uno-Skia
+    // path), then constructing a default context and calling OnBeginDraw on it —
+    // the surface pixel must be the default context's Background, not the
+    // pre-fill colour.
+    [TestMethod]
+    public void OnBeginDraw_OnDefaultContext_ClearsCanvas_EvenWhenAnotherContextOptedOut()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+        var motion = new CoreMotionCanvas();
+
+        // mimic the Avalonia / Uno-Skia call site that opts out of clearing
+        _ = new SkiaSharpDrawingContext(
+            motion, surface.Canvas, SKColor.Empty, clearCanvasOnNewFrame: false);
+
+        // pre-fill with a colour distinct from the upcoming Background
+        surface.Canvas.Clear(SKColors.Blue);
+
+        // a default-construct context (WPF / MAUI / WinForms / Blazor) MUST still clear
+        var defaultCtx = new SkiaSharpDrawingContext(motion, surface.Canvas, SKColors.Red);
+        defaultCtx.OnBeginDraw();
+
+        using var snapshot = surface.Snapshot();
+        using var pixmap = snapshot.PeekPixels();
+
+        Assert.AreEqual(
+            SKColors.Red,
+            pixmap.GetPixelColor(5, 5),
+            "Avalonia/Uno-Skia opt-out from clearCanvasOnNewFrame must be per-instance " +
+            "— a default context in the same process must still clear on OnBeginDraw.");
+    }
+
+    [TestMethod]
+    public void OnBeginDraw_OnOptedOutContext_DoesNotClearCanvas()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+        var motion = new CoreMotionCanvas();
+
+        surface.Canvas.Clear(SKColors.Blue);
+
+        var optedOut = new SkiaSharpDrawingContext(
+            motion, surface.Canvas, SKColors.Red, clearCanvasOnNewFrame: false);
+        optedOut.OnBeginDraw();
+
+        using var snapshot = surface.Snapshot();
+        using var pixmap = snapshot.PeekPixels();
+
+        Assert.AreEqual(
+            SKColors.Blue,
+            pixmap.GetPixelColor(5, 5),
+            "A context constructed with clearCanvasOnNewFrame:false must not touch " +
+            "the canvas in OnBeginDraw — the host is responsible for clearing.");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #2303 — bad drawings when an Avalonia LiveCharts chart and any other backend (WPF, MAUI, WinForms, Blazor) coexist in the same process.
- Moves `SkiaSharpDrawingContext.s_clearCanvasOnNewFrame` from a process-static field to a constructor parameter / instance property.
- Avalonia and Uno-Skia call sites now pass `clearCanvasOnNewFrame: false`; their (now-empty) static initializers are removed.

## Why

`SkiaSharpDrawingContext.s_clearCanvasOnNewFrame` was a single process-static flag. Avalonia's `static MotionCanvas()` and Uno-Skia's `static SkiaRenderMode()` flipped it to `false` because their hosts clear the surface themselves before invoking `Render`. That opt-out was global: once flipped, **every other** `SkiaSharpDrawingContext` in the process (WPF, MAUI, WinForms, Blazor, in-memory) silently stopped clearing too.

Reporter's setup was exactly this — an Avalonia main window with a `CartesianChart`, plus a separately-opened WPF window also hosting a `CartesianChart`. Whichever chart belonged to the backend that owned the SkiaSharp surface (WPF here) stopped clearing between frames, so every animation step stacked on top of the prior one — the streaking visible in the issue's "Livecharts version 2.0.4 (bad drawings)" screenshot.

The fix moves the flag onto the instance. Default `true`. Avalonia (`MotionCanvas.cs:121`) and Uno-Skia (`SkiaRenderMode.cs:93`) pass `false` at construction. There is no shared state to corrupt anymore.

The regression was introduced by #1984 (commit `983155cda`, Feb 2026), which moved the opt-out from the rendering context into Avalonia's static initializer — fine in isolation, broken when another backend coexists in-process.

## Test plan

- [x] New regression test in `tests/CoreTests/OtherTests/SkiaSharpDrawingContextTests.cs`:
  - `OnBeginDraw_OnDefaultContext_ClearsCanvas_EvenWhenAnotherContextOptedOut` — pixel-level proof that the WPF/MAUI/WinForms/Blazor path still clears when an Avalonia/Uno-Skia opt-out context exists.
  - `OnBeginDraw_OnOptedOutContext_DoesNotClearCanvas` — pins the host-clears contract.
- [x] Test verified to fail by reintroducing a process-static written only by opt-out constructors (`clearCanvasOnNewFrame || (s_brokenStatic = false)`); first test caught the regression with the wrong pixel colour. Fix restored, both pass.
- [x] Full `dotnet test tests/CoreTests/` — 725/725 pass.
- [x] Full `dotnet test tests/SnapshotTests/` — 165/165 pass.
- [x] `dotnet build` on core SkiaSharpView, Avalonia view, and WPF view — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)