### PR TITLE
Backport #2309 to release/v2.0.x — preserve chart handler across iOS TabbedPage switches (#2297)

### DIFF
--- a/samples/MauiSample/Test/Issue2297Repro/View.xaml
+++ b/samples/MauiSample/Test/Issue2297Repro/View.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="MauiSample.Test.Issue2297Repro.View"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Label Text="Issue 2297 host page" />
+</ContentPage>

--- a/samples/MauiSample/Test/Issue2297Repro/View.xaml.cs
+++ b/samples/MauiSample/Test/Issue2297Repro/View.xaml.cs
@@ -1,0 +1,49 @@
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Maui;
+
+namespace MauiSample.Test.Issue2297Repro;
+
+// Host page for the Factos regression test:
+// SharedUITests/DisposeTests.ChartHandlerSurvivesTabSwitch_Issue2297.
+//
+// The bug only manifests inside a real iOS UITabBarController, so the test
+// pushes a TabbedPage modally on top of this ContentPage. Building the
+// TabbedPage in code (rather than in XAML) keeps the chart instances directly
+// accessible — the test reads them back through GetChart to assert that their
+// MAUI Handler survives a tab switch's Unloaded event (the regression #2297).
+[XamlCompilation(XamlCompilationOptions.Compile)]
+public partial class View : ContentPage
+{
+    private TabbedPage? _tabbed;
+    private CartesianChart[]? _charts;
+
+    public View() => InitializeComponent();
+
+    public async Task PushTabbedPageAsync()
+    {
+        _charts =
+        [
+            new CartesianChart { Series = [new LineSeries<double> { Values = [2d, 5, 4, 6, 8, 3, 7] }] },
+            new CartesianChart { Series = [new ColumnSeries<double> { Values = [4d, 2, 6, 5, 8] }] },
+        ];
+
+        _tabbed = new TabbedPage
+        {
+            Children =
+            {
+                new ContentPage { Title = "A", Content = _charts[0] },
+                new ContentPage { Title = "B", Content = _charts[1] },
+            }
+        };
+
+        await Navigation.PushModalAsync(_tabbed);
+    }
+
+    public void SwitchToTab(int index) =>
+        _tabbed!.CurrentPage = _tabbed.Children.ElementAt(index);
+
+    public CartesianChart GetChart(int index) => _charts![index];
+
+    public Task PopTabbedPageAsync() => Navigation.PopModalAsync();
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenChart.cs
@@ -102,7 +102,16 @@ public abstract partial class SourceGenChart : ChartView, IChartView
         // every chart removed from the visual tree (#1725). Other platforms
         // exhibit the same +=/-= pattern but don't leak in practice (no
         // equivalent native-peer pinning), so scope this to Apple.
-        Handler?.DisconnectHandler();
+        //
+        // Gate on Window == null: on a TabbedPage (iOS only) MAUI fires Unloaded
+        // for the inactive tab's chart even though the element is still mounted
+        // in the window — UITabBarController just hides the platform UIView.
+        // DisconnectHandler in that case nulls the handler and MAUI never raises
+        // Loaded again when the tab is reselected, so the chart goes permanently
+        // blank (#2297). Window is null only when the chart has truly detached
+        // from the window, which is the case we need to release the chain in.
+        if (Window is null)
+            Handler?.DisconnectHandler();
 #endif
     }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Maui/SourceGenMapChart.maui.cs
@@ -68,8 +68,9 @@ public abstract partial class SourceGenMapChart : ChartView, IGeoMapView
     {
         CoreChart?.Unload();
 #if IOS || MACCATALYST
-        // See SourceGenChart.OnUnloaded for the rationale (#1725).
-        Handler?.DisconnectHandler();
+        // See SourceGenChart.OnUnloaded for the rationale (#1725 and #2297).
+        if (Window is null)
+            Handler?.DisconnectHandler();
 #endif
     }
 

--- a/tests/SharedUITests/DisposeTests.cs
+++ b/tests/SharedUITests/DisposeTests.cs
@@ -102,5 +102,42 @@ public class DisposeTests
             await Task.Delay(500);
         }
     }
+
+#if MAUI_UI_TESTING
+    // https://github.com/Live-Charts/LiveCharts2/issues/2297
+    //
+    // On iOS, MAUI's UITabBarController fires Unloaded for the chart on the tab
+    // the user just switched AWAY from, even though the chart's element is still
+    // mounted in the window — UIKit just hides the platform UIView. The #1725
+    // Apple-side handler-disconnect ran on that Unloaded and set Handler=null;
+    // MAUI then never raised Loaded when the user returned to the tab and the
+    // chart went permanently blank. The fix gates the disconnect on Window ==
+    // null, so transient tab-switch unloads no longer drop the handler.
+    //
+    // This is a MAUI-only contract test — TabbedPage and the Handler property
+    // are MAUI concepts, and the regression view (Issue2297Repro) lives only
+    // in MauiSample. On non-iOS MAUI targets the disconnect is gated by
+    // `#if IOS || MACCATALYST` so the assertion always holds; the test still
+    // runs there as a smoke check that the Window-null gate doesn't regress.
+    [AppTestMethod]
+    public async Task ChartHandlerSurvivesTabSwitch_Issue2297()
+    {
+        var sut = await App.NavigateTo<Samples.Test.Issue2297Repro.View>();
+        await Task.Delay(1000);
+
+        await sut.PushTabbedPageAsync();
+        await Task.Delay(1500);
+
+        var hiddenTabChart = sut.GetChart(0);
+        Assert.NotNull(hiddenTabChart.Handler);
+
+        sut.SwitchToTab(1);
+        await Task.Delay(1500);
+
+        Assert.NotNull(hiddenTabChart.Handler);
+
+        await sut.PopTabbedPageAsync();
+    }
+#endif
 #endif
 }


### PR DESCRIPTION
Backport of #2309 to `release/v2.0.x`. Closes #2297 on the 2.0.x line.

## Summary

- Cherry-pick from master adapted: on `release/v2.0.x` the Apple-side handler-disconnect added for #1725 lives directly in `SourceGenChart.OnUnloaded` and `SourceGenMapChart.OnUnloaded` (the master refactor that consolidated this into `SourceGenDrawnView.maui.cs` hasn't landed on this branch). Gate at both call sites with `if (Window is null)`.
- Regression test `ChartHandlerSurvivesTabSwitch_Issue2297` added to `tests/SharedUITests/DisposeTests.cs`, gated `#if MAUI_UI_TESTING` from the start (folding upstream's follow-up `5ae7debd8` into the test commit).
- Adds `samples/MauiSample/Test/Issue2297Repro/View` host page for the test to navigate to.

## Why

iOS's `UITabBarController` removes the inactive tab's platform `UIView` from the screen but keeps the MAUI element mounted in the window. MAUI fires `Unloaded` for that element anyway. The Apple-side handler-disconnect from #1725 ran on every `Unloaded` and nulled the handler — at which point MAUI never raised `Loaded` again when the user returned to the tab, so the chart had no platform peer to repaint into and stayed blank for the rest of the app session.

`Window is null` is true only when the element has truly detached from any window, which is the exact case that needs the gesture-recognizer chain released for #1725. Both behaviors are preserved.

See upstream PR #2309 and the underlying MAUI report [dotnet/maui#35627](https://github.com/dotnet/maui/issues/35627) for the full diagnosis.

## Diff vs upstream #2309

- Fix lives in `SourceGenChart.cs` + `SourceGenMapChart.maui.cs` (release/v2.0.x layout) rather than `SourceGenDrawnView.maui.cs` (master layout). Same gate, same comment block, identical runtime behavior.
- Two upstream commits collapsed into one test commit: regression test is MAUI-gated from the first push, so non-MAUI XAML targets never need a follow-up fix.

## Test plan

- [x] `dotnet build src/skiasharp/LiveChartsCore.SkiaSharpView.Maui -f net10.0-ios` — 0 errors.
- [x] `dotnet build samples/MauiSample -f net10.0-ios -p:UITesting=true` — 0 errors with shared UI test linked in.
- [ ] CI `test-ios / maui-ios` Factos run on this PR confirms the regression test passes against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)