### PR TITLE
feat(kernel): ISeriesRenderOverride provider hook for performance backends

### DIFF
--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -119,7 +119,7 @@ public class CartesianChartEngine(
 
         return VisibleSeries
             .Where(series => series.IsHoverable)
-            .SelectMany(series => series.FindHitPoints(this, pointerPosition, actualStrategy, FindPointFor.HoverEvent));
+            .SelectMany(series => HitTestSeries(series, pointerPosition, actualStrategy, FindPointFor.HoverEvent));
     }
 
     /// <summary>
@@ -444,7 +444,14 @@ public class CartesianChartEngine(
             var xAxis = GetXAxis(series);
             var yAxis = GetYAxis(series);
 
-            var seriesBounds = series.GetBounds(this, xAxis, yAxis).Bounds;
+            // A provider render override may also supply bounds without the per-point
+            // fetch (e.g. a level-of-detail backend reads them from a pyramid), which
+            // avoids the O(N) GetBounds walk that would otherwise dominate at scale.
+            var seriesBounds =
+                LiveCharts.DefaultSettings.GetProvider().GetRenderOverride(series) is { } boundsOverride &&
+                boundsOverride.TryGetBounds(series, this, xAxis, yAxis, out var overrideBounds)
+                    ? overrideBounds.Bounds
+                    : series.GetBounds(this, xAxis, yAxis).Bounds;
             if (seriesBounds.IsEmpty)
             {
                 ce._isInternalSet = false;

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -341,7 +341,7 @@ public abstract class Chart
             strategy = Series.GetFindingStrategy();
 
         return Series.SelectMany(series =>
-            series.FindHitPoints(this, new(point), strategy, FindPointFor.HoverEvent));
+            HitTestSeries(series, new(point), strategy, FindPointFor.HoverEvent));
     }
 
     /// <inheritdoc cref="IChartView.GetVisualsAt(LvcPointD)"/>
@@ -422,14 +422,14 @@ public abstract class Chart
             {
                 if (!series.RequiresFindClosestOnPointerDown) continue;
 
-                var points = series.FindHitPoints(this, point, strategy, FindPointFor.PointerDownEvent);
+                var points = HitTestSeries(series, point, strategy, FindPointFor.PointerDownEvent);
                 if (!points.Any()) continue;
 
                 series.OnDataPointerDown(View, points, point);
             }
 
             // fire the chart event.
-            var iterablePoints = VisibleSeries.SelectMany(x => x.FindHitPoints(this, point, strategy, FindPointFor.PointerDownEvent));
+            var iterablePoints = VisibleSeries.SelectMany(x => HitTestSeries(x, point, strategy, FindPointFor.PointerDownEvent));
             View.OnDataPointerDown(iterablePoints, point);
 
             // fire the visual elements event.
@@ -635,9 +635,30 @@ public abstract class Chart
     /// <summary>
     /// Adds a visual element to the chart.
     /// </summary>
+    /// <summary>
+    /// Hit-tests a series, giving a provider render override (e.g. a level-of-detail
+    /// backend) the chance to answer from its decimated data instead of the per-point
+    /// fetch. Falls back to the series' own hit-test.
+    /// </summary>
+    internal IEnumerable<ChartPoint> HitTestSeries(
+        ISeries series, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
+        => LiveCharts.DefaultSettings.GetProvider().GetRenderOverride(series)
+               ?.TryFindHitPoints(series, this, pointerPosition, strategy, findPointFor)
+           ?? series.FindHitPoints(this, pointerPosition, strategy, findPointFor);
+
     public void AddVisual(IChartElement element)
     {
-        element.Invalidate(this);
+        // A provider may supply a render override for a series (e.g. the batched
+        // level-of-detail renderer in performance backends), taking over drawing
+        // and bypassing the per-point Invalidate. TryRender returns false when it
+        // declines (e.g. a density gate), in which case the series renders itself.
+        if (element is not ISeries s ||
+            LiveCharts.DefaultSettings.GetProvider().GetRenderOverride(s) is not { } renderOverride ||
+            !renderOverride.TryRender(s, this))
+        {
+            element.Invalidate(this);
+        }
+
         element.RemoveOldPaints(View);
         _ = _everMeasuredElements.Add(element);
         _ = _toDeleteElements.Remove(element);
@@ -721,6 +742,10 @@ public abstract class Chart
         {
             if (visual is ISeries series)
             {
+                // Let a provider render override release any resources it allocated
+                // for this series before the series itself is disposed.
+                LiveCharts.DefaultSettings.GetProvider().GetRenderOverride(series)?.OnRemoved(View, series);
+
                 // series delete softly and animate as they leave the UI.
                 // UPDATE
                 // actually series are not even removed sofly.. this is only disposing things

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -341,7 +341,7 @@ public abstract class Chart
             strategy = Series.GetFindingStrategy();
 
         return Series.SelectMany(series =>
-            HitTestSeries(series, new(point), strategy, FindPointFor.HoverEvent));
+            HitTestSeries(series, new(point), strategy, findPointFor));
     }
 
     /// <inheritdoc cref="IChartView.GetVisualsAt(LvcPointD)"/>
@@ -633,9 +633,6 @@ public abstract class Chart
         _toDeleteElements = [.. _everMeasuredElements];
 
     /// <summary>
-    /// Adds a visual element to the chart.
-    /// </summary>
-    /// <summary>
     /// Hit-tests a series, giving a provider render override (e.g. a level-of-detail
     /// backend) the chance to answer from its decimated data instead of the per-point
     /// fetch. Falls back to the series' own hit-test.
@@ -646,6 +643,9 @@ public abstract class Chart
                ?.TryFindHitPoints(series, this, pointerPosition, strategy, findPointFor)
            ?? series.FindHitPoints(this, pointerPosition, strategy, findPointFor);
 
+    /// <summary>
+    /// Adds a visual element to the chart.
+    /// </summary>
     public void AddVisual(IChartElement element)
     {
         // A provider may supply a render override for a series (e.g. the batched

--- a/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
@@ -39,6 +39,14 @@ public abstract class ChartEngine
     public virtual DataFactory<TModel> GetDefaultDataFactory<TModel>() => new();
 
     /// <summary>
+    /// Optionally returns a renderer that takes over drawing the given
+    /// <paramref name="series"/> (bypassing its per-point Invalidate) — e.g. a
+    /// batched level-of-detail renderer. Returns <see langword="null"/> (the
+    /// default) to let the series render itself. Consulted once per measure pass.
+    /// </summary>
+    public virtual ISeriesRenderOverride? GetRenderOverride(ISeries series) => null;
+
+    /// <summary>
     /// Gets a new instance of the default map factory.
     /// </summary>
     /// <returns></returns>

--- a/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
@@ -39,10 +39,16 @@ public abstract class ChartEngine
     public virtual DataFactory<TModel> GetDefaultDataFactory<TModel>() => new();
 
     /// <summary>
-    /// Optionally returns a renderer that takes over drawing the given
-    /// <paramref name="series"/> (bypassing its per-point Invalidate) — e.g. a
-    /// batched level-of-detail renderer. Returns <see langword="null"/> (the
-    /// default) to let the series render itself. Consulted once per measure pass.
+    /// Optionally returns an override that takes over drawing, bounds and hit-testing
+    /// for the given <paramref name="series"/> (bypassing its per-point pipeline) —
+    /// e.g. a batched level-of-detail renderer. Returns <see langword="null"/> (the
+    /// default) to let the series handle itself.
+    /// <para>
+    /// Consulted frequently — once per measure pass for rendering and bounds, and
+    /// again on every pointer move/down for hit-testing, plus on series removal — and
+    /// not cached by the engine. Implementations should make this cheap (e.g. a
+    /// dictionary keyed by series) rather than allocating per call.
+    /// </para>
     /// </summary>
     public virtual ISeriesRenderOverride? GetRenderOverride(ISeries series) => null;
 

--- a/src/LiveChartsCore/Kernel/Providers/ISeriesRenderOverride.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ISeriesRenderOverride.cs
@@ -1,0 +1,75 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+
+namespace LiveChartsCore.Kernel.Providers;
+
+/// <summary>
+/// An optional hook a <see cref="ChartEngine"/> can supply to take over the
+/// rendering of a series, bypassing its per-point <see cref="IChartElement.Invalidate(Chart)"/>.
+/// High-performance backends (e.g. a batched level-of-detail renderer) use this to
+/// swap in a faster draw path with no user code change. The default OSS engine
+/// returns none, so the series renders itself.
+/// </summary>
+public interface ISeriesRenderOverride
+{
+    /// <summary>
+    /// Renders <paramref name="series"/> for the current measure pass. Return
+    /// <see langword="true"/> if the override took over rendering; return
+    /// <see langword="false"/> to fall back to the series' own
+    /// <see cref="IChartElement.Invalidate(Chart)"/> (e.g. when a density gate
+    /// decides the series is small enough to draw normally).
+    /// </summary>
+    bool TryRender(ISeries series, Chart chart);
+
+    /// <summary>
+    /// Optionally supplies the series' bounds without the per-point fetch — e.g. a
+    /// level-of-detail backend reads them from an aggregation pyramid in O(budget)
+    /// instead of walking every point. Return <see langword="true"/> with
+    /// <paramref name="bounds"/> set to take over; <see langword="false"/> to let the
+    /// series compute its own <see cref="ICartesianSeries.GetBounds(Chart, ICartesianAxis, ICartesianAxis)"/>.
+    /// </summary>
+    bool TryGetBounds(
+        ISeries series, Chart chart, ICartesianAxis secondaryAxis, ICartesianAxis primaryAxis,
+        out SeriesBounds bounds);
+
+    /// <summary>
+    /// Optionally hit-tests the series without the per-point fetch — a level-of-detail
+    /// backend finds the nearest decimated point in O(budget) instead of walking every
+    /// point on each pointer move. Return the hit points to take over; return
+    /// <see langword="null"/> to fall back to
+    /// <see cref="ISeries.FindHitPoints(Chart, LvcPoint, FindingStrategy, FindPointFor)"/>.
+    /// </summary>
+    IEnumerable<ChartPoint>? TryFindHitPoints(
+        ISeries series, Chart chart, LvcPoint pointerPosition,
+        FindingStrategy strategy, FindPointFor findPointFor);
+
+    /// <summary>
+    /// Called when <paramref name="series"/> is removed from the chart, so the
+    /// override can release any resources it allocated for it.
+    /// </summary>
+    void OnRemoved(IChartView view, ISeries series);
+}

--- a/src/skiasharp/_Shared/SourceGenChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenChart.shared.cs
@@ -113,11 +113,9 @@ public partial class SourceGenChart : IChartView
         FindingStrategy strategy = FindingStrategy.Automatic,
         FindPointFor findPointFor = FindPointFor.HoverEvent)
     {
-        if (strategy == FindingStrategy.Automatic)
-            strategy = CoreChart.Series.GetFindingStrategy();
-
-        return CoreChart.Series.SelectMany(series =>
-            series.FindHitPoints(CoreChart, new(point), strategy, FindPointFor.HoverEvent));
+        // Delegate to the core so a provider render override (e.g. transparent LOD)
+        // can hit-test from its decimated data instead of walking every point.
+        return CoreChart.GetPointsAt(point, strategy, findPointFor);
     }
 
     /// <inheritdoc cref="IChartView.GetVisualsAt(LvcPointD)"/>

--- a/tests/CoreTests/ChartTests/SeriesRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/SeriesRenderOverrideTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Kernel.Providers;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+// Guards the ISeriesRenderOverride provider seam: a provider's override must be
+// consulted on all three data paths (render, bounds, hit-test) and on removal, and
+// the chart must fall back to the series itself when the override declines.
+[TestClass]
+public class SeriesRenderOverrideTests
+{
+    private sealed class RecordingOverride : ISeriesRenderOverride
+    {
+        public bool RenderConsulted, BoundsConsulted, HitTestConsulted, Removed;
+
+        // Record then DECLINE on every path → the chart falls back to the series,
+        // so it renders exactly like OSS while we assert the seam was wired.
+        public bool TryRender(ISeries series, Chart chart) { RenderConsulted = true; return false; }
+
+        public bool TryGetBounds(
+            ISeries series, Chart chart, ICartesianAxis secondaryAxis, ICartesianAxis primaryAxis,
+            out SeriesBounds bounds)
+        {
+            BoundsConsulted = true;
+            bounds = default;
+            return false;
+        }
+
+        public IEnumerable<ChartPoint>? TryFindHitPoints(
+            ISeries series, Chart chart, LvcPoint pointerPosition, FindingStrategy strategy, FindPointFor findPointFor)
+        {
+            HitTestConsulted = true;
+            return null;
+        }
+
+        public void OnRemoved(IChartView view, ISeries series) => Removed = true;
+    }
+
+    private sealed class FakeEngine(RecordingOverride over) : SkiaSharpProvider
+    {
+        // Passthrough SkiaSharp engine that only adds the override (for any series),
+        // so configuring it globally for the test doesn't change anything else.
+        public override ISeriesRenderOverride? GetRenderOverride(ISeries series) => over;
+    }
+
+    [TestMethod]
+    public void Override_IsConsultedOnAllPaths_AndChartFallsBack()
+    {
+        var over = new RecordingOverride();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(over)));
+
+            var series = new LineSeries<double> { Values = [1, 2, 3, 4], GeometrySize = 0 };
+            var chart = new SKCartesianChart
+            {
+                Width = 600,
+                Height = 400,
+                Series = [series],
+                XAxes = [new Axis()],
+                YAxes = [new Axis()]
+            };
+
+            // Measure: rendering (AddVisual) + bounds (Measure) consult the override.
+            var image = chart.GetImage();
+            Assert.IsNotNull(image, "chart must still render via the fallback when the override declines");
+            Assert.IsTrue(over.RenderConsulted, "TryRender must be consulted during measure");
+            Assert.IsTrue(over.BoundsConsulted, "TryGetBounds must be consulted during measure");
+
+            // Hit-test path consults the override (enumerate — GetPointsAt is lazy).
+            _ = chart.GetPointsAt(new LvcPointD(300, 200), FindingStrategy.CompareAll).ToArray();
+            Assert.IsTrue(over.HitTestConsulted, "TryFindHitPoints must be consulted on hit-test");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+}


### PR DESCRIPTION
> 🤖 Drafted by Claude Code (AI) on Beto's behalf — please review before treating as my own words.

## What

Adds an optional, **no-op-by-default** seam that lets a `ChartEngine` provider take over a series' **rendering, bounds and hit-testing** — bypassing the per-point pipeline. This lets a high-performance backend (e.g. a batched level-of-detail renderer in the backers package) make large charts fast with **no consumer code change** beyond calling `AddBackersPackage()`.

**OSS behaviour is unchanged**: the default `GetRenderOverride` returns `null`, and every consult falls back to the series itself.

## Surface

- `ISeriesRenderOverride { TryRender, TryGetBounds, TryFindHitPoints, OnRemoved }`
- `ChartEngine.GetRenderOverride(ISeries) => null` (default)
- `Chart.AddVisual` consults it for rendering; `CollectVisuals` calls `OnRemoved` on removal
- `CartesianChartEngine` consults it for bounds (`Measure`) and hover (`FindHoveredPointsBy`)
- `Chart.HitTestSeries` centralizes the hit-test consult; the view `GetPointsAt` now delegates to the core `GetPointsAt` so it routes through the same path

## Why all three paths

Each of render, bounds and hit-test independently walks every point in the OSS pipeline, so a backend must intercept all three or a large series falls back to O(N) on some interaction (e.g. hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)