### PR TITLE
feat(paint): animate PathEffect & ImageFilter on the motion rail

### DIFF
--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -135,11 +135,21 @@ public abstract class MotionProperty<T>(T defaultValue) : IMotionProperty
             (Animation.RepeatTimes == int.MaxValue || Animation.RepeatTimes > Animation.RepeatCount))
         {
             var cycles = (int)((globalTime - _startTime) / deltaTime); // floor (elapsed is positive)
-            Animation.RepeatCount += cycles;
+
+            if (Animation.RepeatTimes != int.MaxValue)
+            {
+                // Never fast-forward past the remaining repeats: a long frame stall must still
+                // complete on time, not run forever. (Infinite repeats skip the counter to avoid
+                // RepeatCount overflowing over a long-running animation.)
+                var remaining = Animation.RepeatTimes - Animation.RepeatCount;
+                if (cycles > remaining) cycles = remaining;
+                Animation.RepeatCount += cycles;
+            }
+
             _startTime += cycles * deltaTime;
             _endTime = _startTime + Animation.Duration;
             deltaTime = _endTime - _startTime;
-            p = (globalTime - _startTime) / deltaTime;
+            p = (globalTime - _startTime) / deltaTime; // > 1 if it should complete (cycles was clamped)
         }
 
         if (deltaTime <= 0 || p > 1)

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -127,6 +127,21 @@ public abstract class MotionProperty<T>(T defaultValue) : IMotionProperty
         var deltaTime = _endTime - _startTime;
         var p = (globalTime - _startTime) / deltaTime;
 
+        // A repeating animation usually OVERSHOOTS its end (real frames rarely land exactly on a
+        // cycle boundary, so p jumps past 1). Advance the window by the whole elapsed cycles so the
+        // loop stays seamless and phase-continuous, instead of completing. RepeatTimes defaults to 0,
+        // so one-shot animations skip this; the exact p == 1 boundary is still handled below unchanged.
+        if (deltaTime > 0 && p > 1 &&
+            (Animation.RepeatTimes == int.MaxValue || Animation.RepeatTimes > Animation.RepeatCount))
+        {
+            var cycles = (int)((globalTime - _startTime) / deltaTime); // floor (elapsed is positive)
+            Animation.RepeatCount += cycles;
+            _startTime += cycles * deltaTime;
+            _endTime = _startTime + Animation.Duration;
+            deltaTime = _endTime - _startTime;
+            p = (globalTime - _startTime) / deltaTime;
+        }
+
         if (deltaTime <= 0 || p > 1)
         {
             // when deltaTime is <= 0:

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using System.Collections.Generic;
+using LiveChartsCore.Drawing;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Painting.Effects;
@@ -35,7 +36,18 @@ public abstract class PathEffect(object key)
     {
         { DashEffect.s_key, new DashEffect([1, 0], 0) }
     };
-    internal SKPathEffect? _sKPathEffect;
+    // protected internal: the owning SkiaPaint (same assembly) reads it via internal, while a
+    // PathEffect subclass in another assembly sets it from its CreateEffect override via protected.
+    protected internal SKPathEffect? _sKPathEffect;
+
+    /// <summary>
+    /// An optional animation that drives this effect on the motion rail. <see langword="null"/>
+    /// (the default) means the effect is static — created once and cached, exactly as before.
+    /// A self-animating effect assigns one (e.g. with <see cref="Animation.RepeatTimes"/> =
+    /// <see cref="int.MaxValue"/>) so it animates indefinitely; the looping/"not finished"
+    /// reporting then lives entirely in the effect, not on the paint.
+    /// </summary>
+    public Animation? Animation { get; set; }
 
     /// <summary>
     /// Creates a new object that is a copy of the current instance.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -84,12 +84,13 @@ public abstract class PathEffect(object key)
 
         var key = (from ?? to)!._key;
 
-        // use the default filter when the transition is to a null reference
-        // for example in the case of a shadow, the default filter is a transparent shadow
-        from ??= s_defaultEffects[key];
-        to ??= s_defaultEffects[key];
+        // Transition a null endpoint to/from the effect's registered no-op default (e.g. a dash
+        // fades to "no dash"). An effect without a registered default — e.g. a custom self-animating
+        // effect — falls back to the present endpoint instead of throwing.
+        from ??= s_defaultEffects.TryGetValue(key, out var dFrom) ? dFrom : to;
+        to ??= s_defaultEffects.TryGetValue(key, out var dTo) ? dTo : from;
 
-        return from.Transitionate(progress, to);
+        return from!.Transitionate(progress, to);
     }
 
     internal virtual void Dispose()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
@@ -1,0 +1,49 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Motion;
+
+namespace LiveChartsCore.SkiaSharpView.Painting.Effects;
+
+/// <summary>
+/// A motion property that animates a <see cref="PathEffect"/>, interpolating between two effects
+/// with <see cref="PathEffect.Transitionate(float, PathEffect)"/> — the same way
+/// <see cref="PaintMotionProperty"/> animates whole paints. Assigning a new effect can soft-
+/// transition; a self-animating effect (one carrying a looping <see cref="PathEffect.Animation"/>)
+/// keeps the rail running indefinitely, so the paint never needs an "is animating" flag.
+/// </summary>
+/// <param name="defaultValue">The default effect.</param>
+public class PathEffectMotionProperty(PathEffect? defaultValue = null)
+    : MotionProperty<PathEffect?>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    // A single assigned effect can animate against itself (it maps progress → its own shape,
+    // e.g. a dash phase), so a non-null target alone is enough.
+    protected override bool CanTransitionate => (FromValue ?? ToValue) is not null;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)"/>
+    protected override PathEffect? OnGetMovement(float progress)
+    {
+        var from = FromValue ?? ToValue;
+        return from?.Transitionate(progress, ToValue);
+    }
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
@@ -41,9 +41,8 @@ public class PathEffectMotionProperty(PathEffect? defaultValue = null)
     protected override bool CanTransitionate => (FromValue ?? ToValue) is not null;
 
     /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)"/>
-    protected override PathEffect? OnGetMovement(float progress)
-    {
-        var from = FromValue ?? ToValue;
-        return from?.Transitionate(progress, ToValue);
-    }
+    // Go through the assembly-internal static Transitionate (like ImageFilterMotionProperty) so the
+    // null-endpoint → default-effect handling is consistent across both rails.
+    protected override PathEffect? OnGetMovement(float progress) =>
+        PathEffect.Transitionate(FromValue ?? ToValue, ToValue, progress);
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -88,11 +88,12 @@ public abstract class ImageFilter(object key)
         var key = (from ?? to)!._key;
 
         // use the default filter when the transition is to a null reference
-        // for example in the case of a shadow, the default filter is a transparent shadow
-        from ??= s_defaultFilters[key];
-        to ??= s_defaultFilters[key];
+        // for example in the case of a shadow, the default filter is a transparent shadow.
+        // A filter without a registered default falls back to the present endpoint instead of throwing.
+        from ??= s_defaultFilters.TryGetValue(key, out var dFrom) ? dFrom : to;
+        to ??= s_defaultFilters.TryGetValue(key, out var dTo) ? dTo : from;
 
-        return from.Transitionate(progress, to);
+        return from!.Transitionate(progress, to!);
     }
 
     internal virtual void Dispose()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using System.Collections.Generic;
+using LiveChartsCore.Drawing;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
@@ -40,7 +41,18 @@ public abstract class ImageFilter(object key)
         { DropShadow.s_key, new DropShadow(0,0,0,0, SKColors.Transparent) },
         { Blur.s_key, new Blur(0,0) }
     };
-    internal SKImageFilter? _sKImageFilter;
+    // protected internal: the owning SkiaPaint (same assembly) reads it via internal, while an
+    // ImageFilter subclass in another assembly sets it from its CreateFilter override via protected.
+    protected internal SKImageFilter? _sKImageFilter;
+
+    /// <summary>
+    /// An optional animation that drives this filter on the motion rail. <see langword="null"/>
+    /// (the default) means the filter is static — created once and cached, exactly as before. A
+    /// self-animating filter assigns one (e.g. <see cref="Animation.RepeatTimes"/> =
+    /// <see cref="int.MaxValue"/>) so it animates indefinitely; the looping lives in the filter,
+    /// not the paint — mirrors <see cref="Effects.PathEffect.Animation"/>.
+    /// </summary>
+    public Animation? Animation { get; set; }
 
     /// <summary>
     /// Creates the image filter.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilterMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilterMotionProperty.cs
@@ -1,0 +1,46 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Motion;
+
+namespace LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
+
+/// <summary>
+/// A motion property that animates an <see cref="ImageFilter"/>, interpolating between two filters
+/// with <see cref="ImageFilter.Transitionate(ImageFilter?, ImageFilter?, float)"/> — the image-filter
+/// counterpart of <see cref="Effects.PathEffectMotionProperty"/>. Assigning a new filter can soft-
+/// transition; a self-animating filter (one carrying a looping <see cref="ImageFilter.Animation"/>)
+/// keeps the rail running indefinitely, so the paint never needs an "is animating" flag.
+/// </summary>
+/// <param name="defaultValue">The default filter.</param>
+public class ImageFilterMotionProperty(ImageFilter? defaultValue = null)
+    : MotionProperty<ImageFilter?>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    protected override bool CanTransitionate => (FromValue ?? ToValue) is not null;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)"/>
+    // The instance Transitionate is protected, so go through the assembly-internal static one
+    // (it also handles the default-filter fallback when an endpoint is null).
+    protected override ImageFilter? OnGetMovement(float progress) =>
+        ImageFilter.Transitionate(FromValue ?? ToValue, ToValue, progress);
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
@@ -105,21 +105,48 @@ public abstract class SkiaPaint(float strokeThickness = 1f, float strokeMiter = 
     /// </value>
     public SKStrokeJoin StrokeJoin { get; set; }
 
+    private readonly PathEffectMotionProperty _pathEffectMotion = new();
+
     /// <summary>
-    /// Gets or sets the path effect.
+    /// Gets or sets the path effect. Backed by a motion property so the effect can animate on
+    /// the rail: assigning a new effect can soft-transition, and a self-animating effect (one
+    /// carrying a looping <see cref="PathEffect.Animation"/>) marches indefinitely — the looping
+    /// lives in the effect, the paint just reads the current value each frame.
     /// </summary>
     /// <value>
     /// The path effect.
     /// </value>
-    public PathEffect? PathEffect { get; set; }
+    public PathEffect? PathEffect
+    {
+        get => _pathEffectMotion.GetMovement(this);
+        set
+        {
+            // The effect owns its animation (null = static, no transition). The motion uses it,
+            // so an effect with a looping animation keeps re-evaluating + invalidating forever.
+            _pathEffectMotion.Animation = value?.Animation;
+            _pathEffectMotion.SetMovement(value, this);
+        }
+    }
+
+    private readonly ImageFilterMotionProperty _imageFilterMotion = new();
 
     /// <summary>
-    /// Gets or sets the image filer.
+    /// Gets or sets the image filer. Backed by a motion property (like <see cref="PathEffect"/>)
+    /// so a self-animating filter (one carrying a looping <see cref="ImageFilters.ImageFilter.Animation"/>)
+    /// animates on the rail; the paint just reads the current value each frame.
     /// </summary>
     /// <value>
     /// The image filer.
     /// </value>
-    public ImageFilter? ImageFilter { get; set; }
+    public ImageFilter? ImageFilter
+    {
+        get => _imageFilterMotion.GetMovement(this);
+        set
+        {
+            _imageFilterMotion.Animation = value?.Animation;
+            _imageFilterMotion.SetMovement(value, this);
+        }
+    }
 
     /// <summary>
     /// Configures the SkiaSharp font manually.
@@ -186,22 +213,27 @@ public abstract class SkiaPaint(float strokeThickness = 1f, float strokeMiter = 
         paint.StrokeMiter = StrokeMiter;
         paint.StrokeWidth = StrokeThickness;
 
-        if (PathEffect is not null)
+        // Read the effect ONCE: when animating, the motion returns a fresh interpolated effect
+        // per call, so re-reading would build a different instance each access.
+        var pathEffect = PathEffect;
+        if (pathEffect is not null)
         {
-            // path effects are immutable, so we create it only once.
-            if (PathEffect._sKPathEffect is null)
-                PathEffect.CreateEffect();
+            // A fresh animated effect arrives each frame with no native effect yet → build it.
+            // A static effect is built once and cached, exactly as before.
+            if (pathEffect._sKPathEffect is null)
+                pathEffect.CreateEffect();
 
-            paint.PathEffect = PathEffect._sKPathEffect;
+            paint.PathEffect = pathEffect._sKPathEffect;
         }
 
-        if (ImageFilter is not null)
+        // Read once (the motion returns a fresh interpolated filter per call while animating).
+        var imageFilter = ImageFilter;
+        if (imageFilter is not null)
         {
-            // image filters are immutable, so we create it only once.
-            if (ImageFilter._sKImageFilter is null)
-                ImageFilter.CreateFilter();
+            if (imageFilter._sKImageFilter is null)
+                imageFilter.CreateFilter();
 
-            paint.ImageFilter = ImageFilter._sKImageFilter;
+            paint.ImageFilter = imageFilter._sKImageFilter;
         }
 
         if (drawnElement is not null)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
@@ -131,12 +131,12 @@ public abstract class SkiaPaint(float strokeThickness = 1f, float strokeMiter = 
     private readonly ImageFilterMotionProperty _imageFilterMotion = new();
 
     /// <summary>
-    /// Gets or sets the image filer. Backed by a motion property (like <see cref="PathEffect"/>)
+    /// Gets or sets the image filter. Backed by a motion property (like <see cref="PathEffect"/>)
     /// so a self-animating filter (one carrying a looping <see cref="ImageFilters.ImageFilter.Animation"/>)
     /// animates on the rail; the paint just reads the current value each frame.
     /// </summary>
     /// <value>
-    /// The image filer.
+    /// The image filter.
     /// </value>
     public ImageFilter? ImageFilter
     {
@@ -234,6 +234,10 @@ public abstract class SkiaPaint(float strokeThickness = 1f, float strokeMiter = 
                 imageFilter.CreateFilter();
 
             paint.ImageFilter = imageFilter._sKImageFilter;
+        }
+        else
+        {
+            paint.ImageFilter = null; // filter removed → clear it from the cached/reused SKPaint
         }
 
         if (drawnElement is not null)

--- a/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
@@ -1,0 +1,112 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.Effects;
+using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// SkiaPaint.PathEffect and SkiaPaint.ImageFilter are motion-backed: an effect/filter that
+// carries a looping Animation animates on the rail (the paint reads the interpolated value each
+// frame, stays invalid so the canvas keeps drawing, and loops past the end). Static effects
+// (Animation == null) keep their previous create-once behavior — covered by the existing tests.
+[TestClass]
+public class AnimatedPaintEffectsTests
+{
+    // A minimal self-animating path effect: Transitionate maps progress straight to a "phase"
+    // so the test can read the interpolated value. No native SKPathEffect needed (we don't draw).
+    private sealed class TestEffect : PathEffect
+    {
+        private static readonly object s_key = new();
+        public float Phase { get; }
+        public TestEffect(float phase, Animation? animation) : base(s_key)
+        {
+            Phase = phase;
+            Animation = animation;
+        }
+        public override PathEffect Clone() => new TestEffect(Phase, Animation);
+        public override void CreateEffect() { }
+        public override PathEffect Transitionate(float progress, PathEffect? target) => new TestEffect(progress, Animation);
+    }
+
+    private sealed class TestFilter : ImageFilter
+    {
+        private static readonly object s_key = new();
+        public float Radius { get; }
+        public TestFilter(float radius, Animation? animation) : base(s_key)
+        {
+            Radius = radius;
+            Animation = animation;
+        }
+        public override ImageFilter Clone() => new TestFilter(Radius, Animation);
+        public override void CreateFilter() { }
+        protected override ImageFilter Transitionate(float progress, ImageFilter target) => new TestFilter(progress, Animation);
+    }
+
+    [TestMethod]
+    public void PathEffect_AnimatesOnTheRail_AndLoops()
+    {
+        var loop = new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1), int.MaxValue);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        var paint = new SolidColorPaint(SKColors.Blue) { PathEffect = new TestEffect(0, loop) };
+
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 250;
+        Assert.AreEqual(0.25f, ((TestEffect)paint.PathEffect!).Phase, 1e-4f, "should interpolate to 25% of the cycle");
+        Assert.IsFalse(paint.IsValid, "an animating effect must keep the paint invalid (continuous frames)");
+
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 750;
+        Assert.AreEqual(0.75f, ((TestEffect)paint.PathEffect!).Phase, 1e-4f);
+
+        // Overshoot a cycle boundary (real frames don't land exactly on it): must loop, not stop.
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 1300;
+        Assert.AreEqual(0.30f, ((TestEffect)paint.PathEffect!).Phase, 1e-3f, "must wrap to 30% of the next cycle");
+        Assert.IsFalse(paint.IsValid, "an infinite animation never settles");
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+    }
+
+    [TestMethod]
+    public void ImageFilter_AnimatesOnTheRail_AndLoops()
+    {
+        var loop = new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1), int.MaxValue);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        var paint = new SolidColorPaint(SKColors.Red) { ImageFilter = new TestFilter(0, loop) };
+
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 400;
+        Assert.AreEqual(0.40f, ((TestFilter)paint.ImageFilter!).Radius, 1e-4f);
+        Assert.IsFalse(paint.IsValid);
+
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 1700; // 1.7 cycles → wraps to 70%
+        Assert.AreEqual(0.70f, ((TestFilter)paint.ImageFilter!).Radius, 1e-3f);
+        Assert.IsFalse(paint.IsValid);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+    }
+
+    [TestMethod]
+    public void StaticEffect_DoesNotAnimateOrInvalidate()
+    {
+        // No Animation → the motion has nothing to run: the value is returned as-is and the paint
+        // is left settled (the create-once behavior every existing effect relies on).
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        var paint = new SolidColorPaint(SKColors.Green) { PathEffect = new TestEffect(0.5f, animation: null) };
+
+        paint.IsValid = true;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+        Assert.AreEqual(0.5f, ((TestEffect)paint.PathEffect!).Phase, 1e-4f, "a static effect returns its assigned value unchanged");
+        Assert.IsTrue(paint.IsValid, "a static effect must not keep invalidating the canvas");
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
@@ -17,6 +17,11 @@ namespace CoreTests.CoreObjectsTests;
 [TestClass]
 public class AnimatedPaintEffectsTests
 {
+    // Guarantees the shared debug clock is restored even if an assertion throws, so a failure
+    // can't leak driven time into other tests.
+    [TestCleanup]
+    public void ResetClock() => CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+
     // A minimal self-animating path effect: Transitionate maps progress straight to a "phase"
     // so the test can read the interpolated value. No native SKPathEffect needed (we don't draw).
     private sealed class TestEffect : PathEffect


### PR DESCRIPTION
> 🤖 Note: this PR was drafted by Claude Code (AI) on Beto's behalf — please review.

## What

Makes a paint's **`PathEffect`** and **`ImageFilter`** animatable on the existing motion rail, so effects/filters can transition and (when they opt in) animate indefinitely — e.g. a marching-ants dashed stroke or a pulsing blur — with no timer and no per-frame user code.

## Why it wasn't possible before

- `SkiaPaint.PathEffect` / `ImageFilter` were plain `{ get; set; }`, so they never ran through the animation system, even though `PathEffect.Transitionate` / `ImageFilter.Transitionate` already existed.
- `Animation.RepeatTimes` was effectively dead code: `MotionProperty.GetMovement` returned "complete" as soon as `p > 1`, *before* the repeat branch (which only fired at exactly `p == 1` — never hit at real frame rates). So an `int.MaxValue` repeat completed after one cycle instead of looping.

## Changes

1. **`fix(motion)`** — when a repeating animation overshoots its end (`p > 1`), re-arm the window by the whole elapsed cycles (phase-continuous modulo) before the completion check. `RepeatTimes` defaults to `0`, so one-shot animations are untouched, and the exact `p == 1` path (the only one `InfiniteAnimation` exercises) is unchanged.
2. **`feat(paint)`** — motion-back `PathEffect` and `ImageFilter` via new `PathEffectMotionProperty` / `ImageFilterMotionProperty` (mirroring `PaintMotionProperty`). The effect/filter carries its own `Animation` (null = static, create-once-and-cache, **no behavior change**); a looping one animates on the rail. The native `_sK*` field is now `protected internal` so an effect/filter subclass in another assembly can supply it and declare its own animation (enabling self-animating effects).
3. **`test(motion)`** — `AnimatedPaintEffectsTests`: interpolation over time, paint stays invalid while animating, overshoot wraps, static effect doesn't animate/invalidate.

## Testing

- `tests/CoreTests` green: **757 passed** (incl. the existing `InfiniteAnimation` and the 3 new tests).
- Verified live in a WPF app: a plain `LineSeries` with `Stroke = new SolidColorPaint(color, 3) { PathEffect = <marching dash> }` marches indefinitely (and propagates to legend/tooltip miniatures); a second line with an `ImageFilter = <pulsing blur>` breathes sharp↔blurry. The concrete animated effects live in a downstream package; only the enabling primitive is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)