### PR TITLE
docs(paint): XML-document the protected-internal native effect fields

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -37,10 +37,13 @@ public abstract class PathEffect(object key)
         { DashEffect.s_key, new DashEffect([1, 0], 0) }
     };
     /// <summary>
-    /// The native skia path effect produced by <see cref="CreateEffect"/>. protected internal: the
-    /// owning <see cref="SkiaPaint"/> (same assembly) reads it, while a <see cref="PathEffect"/>
-    /// subclass in another assembly sets it from its <see cref="CreateEffect"/> override.
+    /// The native Skia path effect produced by <see cref="CreateEffect"/>.
     /// </summary>
+    /// <remarks>
+    /// This field is <see langword="protected"/> <see langword="internal"/> so the owning
+    /// <see cref="SkiaPaint"/> can read it in this assembly, while a <see cref="PathEffect"/>
+    /// subclass in another assembly can set it from its <see cref="CreateEffect"/> override.
+    /// </remarks>
     protected internal SKPathEffect? _sKPathEffect;
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -36,8 +36,11 @@ public abstract class PathEffect(object key)
     {
         { DashEffect.s_key, new DashEffect([1, 0], 0) }
     };
-    // protected internal: the owning SkiaPaint (same assembly) reads it via internal, while a
-    // PathEffect subclass in another assembly sets it from its CreateEffect override via protected.
+    /// <summary>
+    /// The native skia path effect produced by <see cref="CreateEffect"/>. protected internal: the
+    /// owning <see cref="SkiaPaint"/> (same assembly) reads it, while a <see cref="PathEffect"/>
+    /// subclass in another assembly sets it from its <see cref="CreateEffect"/> override.
+    /// </summary>
     protected internal SKPathEffect? _sKPathEffect;
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -42,10 +42,13 @@ public abstract class ImageFilter(object key)
         { Blur.s_key, new Blur(0,0) }
     };
     /// <summary>
-    /// The native skia image filter produced by <see cref="CreateFilter"/>. protected internal: the
-    /// owning <see cref="SkiaPaint"/> (same assembly) reads it, while an <see cref="ImageFilter"/>
-    /// subclass in another assembly sets it from its <see cref="CreateFilter"/> override.
+    /// The native Skia image filter produced by <see cref="CreateFilter"/>.
     /// </summary>
+    /// <remarks>
+    /// This field is <see langword="protected"/> <see langword="internal"/> so the owning
+    /// <see cref="SkiaPaint"/> can read it in this assembly, while an <see cref="ImageFilter"/>
+    /// subclass in another assembly can set it from its <see cref="CreateFilter"/> override.
+    /// </remarks>
     protected internal SKImageFilter? _sKImageFilter;
 
     /// <summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -41,8 +41,11 @@ public abstract class ImageFilter(object key)
         { DropShadow.s_key, new DropShadow(0,0,0,0, SKColors.Transparent) },
         { Blur.s_key, new Blur(0,0) }
     };
-    // protected internal: the owning SkiaPaint (same assembly) reads it via internal, while an
-    // ImageFilter subclass in another assembly sets it from its CreateFilter override via protected.
+    /// <summary>
+    /// The native skia image filter produced by <see cref="CreateFilter"/>. protected internal: the
+    /// owning <see cref="SkiaPaint"/> (same assembly) reads it, while an <see cref="ImageFilter"/>
+    /// subclass in another assembly sets it from its <see cref="CreateFilter"/> override.
+    /// </summary>
     protected internal SKImageFilter? _sKImageFilter;
 
     /// <summary>


### PR DESCRIPTION
Small follow-up to #2321. Making `PathEffect._sKPathEffect` / `ImageFilter._sKImageFilter` `protected internal` (so a package effect subclass can supply its native effect) made them externally visible, which trips CS1591. This adds the missing XML doc comments — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)