### PR TITLE
fix(charts): hide stale plot when the draw margin collapses

### DIFF
--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -737,8 +737,19 @@ public class CartesianChartEngine(
         SetDrawMargin(ControlSize, actualMargin);
 
         // invalid dimensions, probably the chart is too small
-        // or it is initializing in the UI and has no dimensions yet
-        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
+        // or it is initializing in the UI and has no dimensions yet.
+        // We can't lay the chart out, but we must NOT just return: the canvas keeps painting the
+        // last frame's geometry at its previous transform, so the series looks "stuck" at the old
+        // size. Instead clip the plot zones to nothing so the stale series/separators are hidden,
+        // then repaint. Nothing is disposed — a resize back to a valid size re-measures and
+        // RegisterClipZones() restores the real clip, so the chart returns instantly with no
+        // animation restart.
+        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
+        {
+            HidePlotZones();
+            Canvas.Invalidate();
+            return;
+        }
 
         DrawMarginDefined?.Invoke(this);
 
@@ -1271,6 +1282,19 @@ public class CartesianChartEngine(
         Canvas.Zones[CanvasZone.DrawMargin].Clip = new(new(x, y), new(w, h));
         Canvas.Zones[CanvasZone.XCrosshair].Clip = new(new(x, 0), new(w, size.Height));
         Canvas.Zones[CanvasZone.YCrosshair].Clip = new(new(0, y), new(size.Width, h));
+    }
+
+    // Hides every zone that holds plot content (series + axis separators/crosshairs) by clipping it
+    // to a zero-area rectangle. Used when the draw margin collapses so the last, now-invalid frame
+    // is not left painted. A constructed (location, size) rectangle is NOT LvcRectangle.Empty — Empty
+    // means "no clip / draw everywhere" — so even at the origin this reliably clips out all pixels.
+    // The legend/tooltip/title live in NoClip and are intentionally left visible.
+    private void HidePlotZones()
+    {
+        var hidden = new LvcRectangle(new LvcPoint(), new LvcSize(0, 0));
+        Canvas.Zones[CanvasZone.DrawMargin].Clip = hidden;
+        Canvas.Zones[CanvasZone.XCrosshair].Clip = hidden;
+        Canvas.Zones[CanvasZone.YCrosshair].Clip = hidden;
     }
 
     private double GetThreshold(ICartesianAxis axis, Scaler scale)

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -1284,19 +1284,6 @@ public class CartesianChartEngine(
         Canvas.Zones[CanvasZone.YCrosshair].Clip = new(new(0, y), new(size.Width, h));
     }
 
-    // Hides every zone that holds plot content (series + axis separators/crosshairs) by clipping it
-    // to a zero-area rectangle. Used when the draw margin collapses so the last, now-invalid frame
-    // is not left painted. A constructed (location, size) rectangle is NOT LvcRectangle.Empty — Empty
-    // means "no clip / draw everywhere" — so even at the origin this reliably clips out all pixels.
-    // The legend/tooltip/title live in NoClip and are intentionally left visible.
-    private void HidePlotZones()
-    {
-        var hidden = new LvcRectangle(new LvcPoint(), new LvcSize(0, 0));
-        Canvas.Zones[CanvasZone.DrawMargin].Clip = hidden;
-        Canvas.Zones[CanvasZone.XCrosshair].Clip = hidden;
-        Canvas.Zones[CanvasZone.YCrosshair].Clip = hidden;
-    }
-
     private double GetThreshold(ICartesianAxis axis, Scaler scale)
     {
         var bouncingDistancePixels = axis.Orientation == AxisOrientation.X

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -564,6 +564,36 @@ public abstract class Chart
     }
 
     /// <summary>
+    /// Hides the plot content by clipping the draw-margin and crosshair zones to a zero-area
+    /// rectangle. Used by every chart engine when the draw margin collapses (the reserved margins
+    /// exceed the control), so the previous, now-invalid frame is not left painted at its old
+    /// transform. A constructed (location, size) rectangle is NOT <see cref="LvcRectangle.Empty"/> —
+    /// Empty means "no clip / draw everywhere" — so even at the origin this reliably clips out all
+    /// pixels. The legend, title and labels live in the NoClip zone and are intentionally untouched.
+    /// </summary>
+    protected void HidePlotZones()
+    {
+        var hidden = new LvcRectangle(new LvcPoint(), new LvcSize(0, 0));
+        Canvas.Zones[CanvasZone.DrawMargin].Clip = hidden;
+        Canvas.Zones[CanvasZone.XCrosshair].Clip = hidden;
+        Canvas.Zones[CanvasZone.YCrosshair].Clip = hidden;
+    }
+
+    /// <summary>
+    /// Resets the plot zone clips back to <see cref="LvcRectangle.Empty"/> (no clip). Engines that do
+    /// not otherwise manage their clips (pie, polar, treemap, sankey) call this on a valid measure so
+    /// a previous <see cref="HidePlotZones"/> is undone and the plot becomes visible again. Engines
+    /// that set real clips on every valid measure (cartesian via RegisterClipZones, geo map) restore
+    /// themselves and don't need it.
+    /// </summary>
+    protected void ResetPlotZoneClips()
+    {
+        Canvas.Zones[CanvasZone.DrawMargin].Clip = LvcRectangle.Empty;
+        Canvas.Zones[CanvasZone.XCrosshair].Clip = LvcRectangle.Empty;
+        Canvas.Zones[CanvasZone.YCrosshair].Clip = LvcRectangle.Empty;
+    }
+
+    /// <summary>
     /// Saves the previous size of the chart.
     /// </summary>
     protected void SetPreviousSize() => _previousSize = ControlSize;

--- a/src/LiveChartsCore/GeoMapChart.cs
+++ b/src/LiveChartsCore/GeoMapChart.cs
@@ -561,10 +561,12 @@ public class GeoMapChart : Chart
 
         if (View.Title is not null) AddTitleToChart();
 
-        // Bail when the chart is too small for a map after reservations
-        // (matches cartesian behavior).
+        // Bail when the chart is too small for a map after reservations (matches cartesian behavior).
+        // Hide the plot zone first so the previous, now-invalid map isn't left painted at its old
+        // transform; the valid path below re-sets the draw-margin clip, so recovery is automatic.
         if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
         {
+            HidePlotZones();
             Canvas.Invalidate();
             return;
         }

--- a/src/LiveChartsCore/PieChartEngine.cs
+++ b/src/LiveChartsCore/PieChartEngine.cs
@@ -214,9 +214,19 @@ public class PieChartEngine(
 
         SetDrawMargin(ControlSize, actualMargin);
 
-        // invalid dimensions, probably the chart is too small
-        // or it is initializing in the UI and has no dimensions yet
-        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
+        // invalid dimensions, probably the chart is too small or it is initializing in the UI and
+        // has no dimensions yet. Don't just return — the canvas would keep painting the previous
+        // frame's geometry at its old transform (the series looks frozen at the prior size). Hide the
+        // plot instead; a resize back to a valid size resets the clips below and re-measures.
+        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
+        {
+            HidePlotZones();
+            Canvas.Invalidate();
+            return;
+        }
+
+        // pie doesn't clip its plot zone, so undo a previous collapse-hide before drawing.
+        ResetPlotZoneClips();
 
         if (View.Title is not null) AddTitleToChart();
 

--- a/src/LiveChartsCore/PolarChartEngine.cs
+++ b/src/LiveChartsCore/PolarChartEngine.cs
@@ -481,9 +481,19 @@ public class PolarChartEngine(
             SetDrawMargin(ControlSize, m);
         }
 
-        // invalid dimensions, probably the chart is too small
-        // or it is initializing in the UI and has no dimensions yet
-        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
+        // invalid dimensions, probably the chart is too small or it is initializing in the UI and
+        // has no dimensions yet. Don't just return — the canvas would keep painting the previous
+        // frame's geometry at its old transform (the series looks frozen at the prior size). Hide the
+        // plot instead; a resize back to a valid size resets the clips below and re-measures.
+        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
+        {
+            HidePlotZones();
+            Canvas.Invalidate();
+            return;
+        }
+
+        // polar doesn't clip its plot zone, so undo a previous collapse-hide before drawing.
+        ResetPlotZoneClips();
 
         if (View.Title is not null) AddTitleToChart();
 

--- a/src/LiveChartsCore/SankeyChartEngine.cs
+++ b/src/LiveChartsCore/SankeyChartEngine.cs
@@ -144,7 +144,18 @@ public class SankeyChartEngine(
 
         SetDrawMargin(ControlSize, actualMargin);
 
-        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
+        // invalid dimensions (too small, or initializing with no size yet). Don't just return — the
+        // canvas would keep painting the previous frame's geometry at its old transform. Hide the
+        // plot instead; a resize back to a valid size resets the clips below and re-measures.
+        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
+        {
+            HidePlotZones();
+            Canvas.Invalidate();
+            return;
+        }
+
+        // sankey doesn't clip its plot zone, so undo a previous collapse-hide before drawing.
+        ResetPlotZoneClips();
 
         if (View.Title is not null) AddTitleToChart();
 

--- a/src/LiveChartsCore/TreemapChartEngine.cs
+++ b/src/LiveChartsCore/TreemapChartEngine.cs
@@ -152,7 +152,18 @@ public class TreemapChartEngine(
 
         SetDrawMargin(ControlSize, actualMargin);
 
-        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
+        // invalid dimensions (too small, or initializing with no size yet). Don't just return — the
+        // canvas would keep painting the previous frame's geometry at its old transform. Hide the
+        // plot instead; a resize back to a valid size resets the clips below and re-measures.
+        if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0)
+        {
+            HidePlotZones();
+            Canvas.Invalidate();
+            return;
+        }
+
+        // treemap doesn't clip its plot zone, so undo a previous collapse-hide before drawing.
+        ResetPlotZoneClips();
 
         if (View.Title is not null) AddTitleToChart();
 

--- a/tests/CoreTests/ChartTests/CollapsedDrawMarginAllChartsTests.cs
+++ b/tests/CoreTests/ChartTests/CollapsedDrawMarginAllChartsTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+using LiveChartsCore.Defaults;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+// The collapsed-draw-margin freeze (see CollapsedDrawMarginTests for the cartesian case) is shared by
+// EVERY chart engine: each one returned from Measure when DrawMarginSize <= 0, leaving the canvas to
+// repaint the previous frame's geometry at its old transform. The fix lives on the base Chart
+// (HidePlotZones / ResetPlotZoneClips) and is wired into pie, polar, treemap and sankey here, plus
+// geo map and cartesian in their own tests. Pie/polar/treemap/sankey never clip their plot zone, so
+// "healthy" is DrawMargin clip == Empty (no clip); a collapse clips it to a zero-area non-Empty rect,
+// and a valid measure resets it back to Empty.
+//
+// ExplicitDisposing = true is REQUIRED: without it GetImage calls Unload() after drawing, which cleans
+// the canvas zones (Zones = []), and the next read lazily recreates fresh zones whose clips are all
+// the default Empty — wiping the very state under test.
+[TestClass]
+public class CollapsedDrawMarginAllChartsTests
+{
+    // left + right (and top + bottom) exceed the 300px control, so DrawMarginSize goes negative.
+    private static readonly Margin s_collapsing = new(200, 200, 200, 200);
+
+    private static LvcRectangle DrawMarginClip(InMemorySkiaSharpChart chart) =>
+        chart.CoreCanvas.Zones[CanvasZone.DrawMargin].Clip;
+
+    private static void AssertHideThenReset(InMemorySkiaSharpChart chart, Action<Margin?> setMargin, string what)
+    {
+        _ = chart.GetImage();
+
+        // force the draw margin to collapse.
+        setMargin(s_collapsing);
+        _ = chart.GetImage();
+
+        var collapsed = DrawMarginClip(chart);
+        Assert.IsTrue(collapsed.Width <= 0 && collapsed.Height <= 0,
+            $"{what}: a collapsed draw margin must clip the plot zone to zero area, got {collapsed.Width}x{collapsed.Height}");
+        Assert.AreNotEqual(LvcRectangle.Empty, collapsed,
+            $"{what}: the hide-clip must be a constructed zero-area rect, not LvcRectangle.Empty (= no clip)");
+
+        // valid layout again: the plot zone clip must reset to Empty (these engines draw unclipped).
+        setMargin(null);
+        _ = chart.GetImage();
+        Assert.AreEqual(LvcRectangle.Empty, DrawMarginClip(chart),
+            $"{what}: a valid measure must reset the plot zone to no-clip after a collapse");
+    }
+
+    [TestMethod]
+    public void Pie_HidesThenResets()
+    {
+        var chart = new SKPieChart
+        {
+            Width = 300,
+            Height = 300,
+            AnimationsSpeed = TimeSpan.Zero,
+            ExplicitDisposing = true,
+            Series = [new PieSeries<int> { Values = [1] }, new PieSeries<int> { Values = [2] }],
+        };
+        AssertHideThenReset(chart, m => chart.DrawMargin = m, "pie");
+    }
+
+    // A title taller than the whole control forces the draw margin to collapse on the Top reservation.
+    // (Polar ignores the view DrawMargin — a separate, pre-existing bug at PolarChartEngine line 481,
+    // where SetDrawMargin uses the raw auto margin `m` instead of the computed `actualMargin` — so we
+    // collapse it through the title path that every engine honors.)
+    private static LiveChartsCore.SkiaSharpView.VisualElements.DrawnLabelVisual GiantTitle() =>
+        new(new LiveChartsCore.SkiaSharpView.Drawing.Geometries.LabelGeometry
+        {
+            Text = "x",
+            TextSize = 4000,
+            Paint = new LiveChartsCore.SkiaSharpView.Painting.SolidColorPaint(),
+        });
+
+    [TestMethod]
+    public void Polar_HidesThenResets()
+    {
+        var chart = new SKPolarChart
+        {
+            Width = 300,
+            Height = 300,
+            AnimationsSpeed = TimeSpan.Zero,
+            ExplicitDisposing = true,
+            Title = GiantTitle(),
+            Series = [new PolarLineSeries<int> { Values = [1, 2, 3] }],
+        };
+
+        _ = chart.GetImage();
+        var collapsed = DrawMarginClip(chart);
+        Assert.IsTrue(collapsed.Width <= 0 || collapsed.Height <= 0,
+            $"polar: a title taller than the control must collapse the draw margin, got {collapsed.Width}x{collapsed.Height}");
+        Assert.AreNotEqual(LvcRectangle.Empty, collapsed,
+            "polar: the hide-clip must be a constructed zero-area rect, not LvcRectangle.Empty (= no clip)");
+
+        chart.Title = null;
+        _ = chart.GetImage();
+        Assert.AreEqual(LvcRectangle.Empty, DrawMarginClip(chart),
+            "polar: a valid measure must reset the plot zone to no-clip after a collapse");
+    }
+
+    [TestMethod]
+    public void Treemap_HidesThenResets()
+    {
+        var chart = new SKTreemapChart
+        {
+            Width = 300,
+            Height = 300,
+            AnimationsSpeed = TimeSpan.Zero,
+            ExplicitDisposing = true,
+            Series = [new TreemapSeries<TreemapNode> { Values = [new(1), new(2), new(3)] }],
+        };
+        AssertHideThenReset(chart, m => chart.DrawMargin = m, "treemap");
+    }
+
+    [TestMethod]
+    public void Sankey_HidesThenResets()
+    {
+        var sources = new[] { new SankeyNode("A"), new SankeyNode("B") };
+        var sinks = new[] { new SankeyNode("X"), new SankeyNode("Y") };
+        var chart = new SKSankeyChart
+        {
+            Width = 300,
+            Height = 300,
+            AnimationsSpeed = TimeSpan.Zero,
+            ExplicitDisposing = true,
+            Series =
+            [
+                new SankeySeries<SankeyNode>
+                {
+                    Values = sources.Concat(sinks).ToArray(),
+                    Links =
+                    [
+                        new SankeyLink<SankeyNode>(sources[0], sinks[0], 4),
+                        new SankeyLink<SankeyNode>(sources[1], sinks[1], 6),
+                    ],
+                }
+            ],
+        };
+        AssertHideThenReset(chart, m => chart.DrawMargin = m, "sankey");
+    }
+
+    // Geo map already had a collapse branch but only Invalidate()'d — it left the previous map painted.
+    // It now hides too. Unlike the others, geo map re-sets a REAL draw-margin clip on the valid path
+    // (its projection rectangle), so recovery restores a positive clip rather than Empty.
+    [TestMethod]
+    public void GeoMap_HidesThenResets()
+    {
+        var chart = new SKGeoMap
+        {
+            Width = 300,
+            Height = 300,
+            ExplicitDisposing = true,
+            Title = GiantTitle(),
+            Series = [new HeatLandSeries { Lands = [new() { Name = "fra", Value = 10 }] }],
+        };
+
+        _ = chart.GetImage();
+        var collapsed = DrawMarginClip(chart);
+        Assert.IsTrue(collapsed.Width <= 0 && collapsed.Height <= 0,
+            $"geomap: a title taller than the control must collapse + hide the plot zone, got {collapsed.Width}x{collapsed.Height}");
+        Assert.AreNotEqual(LvcRectangle.Empty, collapsed,
+            "geomap: the hide-clip must be a constructed zero-area rect, not LvcRectangle.Empty (= no clip)");
+
+        chart.Title = null;
+        _ = chart.GetImage();
+        var restored = DrawMarginClip(chart);
+        Assert.IsTrue(restored.Width > 0 && restored.Height > 0,
+            $"geomap: a valid measure must restore a real positive draw-margin clip, got {restored.Width}x{restored.Height}");
+    }
+}

--- a/tests/CoreTests/ChartTests/CollapsedDrawMarginTests.cs
+++ b/tests/CoreTests/ChartTests/CollapsedDrawMarginTests.cs
@@ -1,0 +1,86 @@
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Measure;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+[TestClass]
+public class CollapsedDrawMarginTests
+{
+    // When the reserved margins exceed the control (a tiny resize, or an explicit DrawMargin wider
+    // than the control), the draw margin collapses (Width <= 0 || Height <= 0). Measure used to just
+    // `return` there — but the canvas keeps painting the previous frame's geometry at its old
+    // transform, so the series looks frozen at the prior size. The fix clips every plot zone to a
+    // zero-area (but non-Empty) rectangle so the stale content is hidden, and the next valid measure
+    // restores the real clip via RegisterClipZones(). These pin that contract. An explicit oversized
+    // DrawMargin is used to force the collapse deterministically (auto-margins clamp to a tiny
+    // positive size instead).
+
+    private static SKCartesianChart NewChart() => new()
+    {
+        Width = 300,
+        Height = 300,
+        AnimationsSpeed = System.TimeSpan.Zero,
+        Series = [new LineSeries<double> { Values = [1, 2, 3, 4, 5] }],
+        XAxes = [new Axis()],
+        YAxes = [new Axis()],
+        ExplicitDisposing = true,
+    };
+
+    // left + right (and top + bottom) exceed the 300px control, so DrawMarginSize goes negative.
+    private static readonly Margin s_collapsing = new(200, 200, 200, 200);
+
+    private static LvcRectangle DrawMarginClip(SKCartesianChart chart) =>
+        chart.CoreCanvas.Zones[CanvasZone.DrawMargin].Clip;
+
+    [TestMethod]
+    public void CollapsedMargin_HidesPlotZone_NotEmptyClip()
+    {
+        var chart = NewChart();
+        _ = chart.GetImage();
+
+        // sanity: a healthy chart clips the draw-margin zone to a real, positive-area rect.
+        var healthy = DrawMarginClip(chart);
+        Assert.IsTrue(healthy.Width > 0 && healthy.Height > 0,
+            $"expected a positive draw-margin clip when healthy, got {healthy.Width}x{healthy.Height}");
+
+        // force the draw margin to collapse.
+        chart.DrawMargin = s_collapsing;
+        _ = chart.GetImage();
+
+        var collapsed = DrawMarginClip(chart);
+
+        // the zone is clipped to nothing (no plot pixels), so the stale frame can't show...
+        Assert.IsTrue(collapsed.Width <= 0 && collapsed.Height <= 0,
+            $"a collapsed draw margin must clip the plot zone to zero area, got {collapsed.Width}x{collapsed.Height}");
+
+        // ...but it must NOT be LvcRectangle.Empty, which the drawing context treats as "no clip"
+        // (draw everywhere) and would instead LEAVE the stale frame fully visible.
+        Assert.AreNotEqual(LvcRectangle.Empty, collapsed,
+            "the hide-clip must be a constructed zero-area rect, not LvcRectangle.Empty (= no clip)");
+    }
+
+    [TestMethod]
+    public void RecoversToRealClip_AfterMarginValidAgain()
+    {
+        var chart = NewChart();
+        _ = chart.GetImage();
+
+        chart.DrawMargin = s_collapsing;
+        _ = chart.GetImage();
+        var collapsed = DrawMarginClip(chart);
+        Assert.IsTrue(collapsed.Width <= 0 && collapsed.Height <= 0, "precondition: margin collapsed");
+
+        // restore a valid layout: nothing was disposed, so a plain re-measure must restore a real
+        // positive clip (RegisterClipZones overwrites the hide-clip).
+        chart.DrawMargin = null;
+        _ = chart.GetImage();
+
+        var restored = DrawMarginClip(chart);
+        Assert.IsTrue(restored.Width > 0 && restored.Height > 0,
+            $"the draw-margin clip must recover after the margin is valid again, got {restored.Width}x{restored.Height}");
+    }
+}


### PR DESCRIPTION
> _Drafted by Claude Code on Beto's behalf; reviewed by Beto before publishing._

## Problem

When a chart is resized so small that the reserved margins exceed the control (or an explicit `DrawMargin` is wider than the control), `DrawMarginSize` goes `<= 0`. Every chart engine returned from `Measure` at that point, *before* the series-drawing loop:

```csharp
if (DrawMarginSize.Width <= 0 || DrawMarginSize.Height <= 0) return;
```

Neither a plain series nor a render-override re-renders, but the motion canvas keeps painting the **previous frame's geometry at its old transform** — so the plot looks frozen at the prior size instead of disappearing. This affects **cartesian, pie, polar, treemap, sankey and the geo map** (reproducible with a plain OSS series — not specific to any render path).

## Fix

Two helpers on the base `Chart`:

```csharp
protected void HidePlotZones()        // clip DrawMargin + X/YCrosshair to a zero-area, non-Empty rect
protected void ResetPlotZoneClips()   // restore them to LvcRectangle.Empty (no clip)
```

A constructed zero-area rect is **not** `LvcRectangle.Empty` — which the drawing context treats as *"no clip / draw everywhere"* — so it reliably clips out every pixel even at the origin.

Wired per engine:
- **Cartesian** uses the shared `HidePlotZones` (private copy removed); `RegisterClipZones` already restores the real clip on a valid measure.
- **Pie / polar / treemap / sankey** never clip their plot zone, so they hide on collapse and call `ResetPlotZoneClips` on the valid path to undo it.
- **Geo map** already had a collapse branch that only `Invalidate()`'d — it now hides too; its valid path re-sets a real draw-margin clip, so it self-restores.

Nothing is disposed: a resize back to a valid size re-measures and restores the clip — **instant, no animation restart, no per-frame rebuild** during a resize drag. Legend / title / axis labels live in the `NoClip` zone and intentionally stay visible.

## Tests

- `CollapsedDrawMarginTests` (cartesian, 2) + `CollapsedDrawMarginAllChartsTests` (pie / polar / treemap / sankey / geo map, 5): each forces a collapse and asserts the plot zone is clipped to a zero-area-but-not-`Empty` rect, then restored on a valid measure. All verified to fail without the fix.
- Full suite green: **761 CoreTests + 166 SnapshotTests** (measure-path edit across all engines, so snapshots were run — all unchanged).

## Side finding (not fixed here)

`PolarChartEngine` ignores the view `DrawMargin`: line 481 calls `SetDrawMargin(ControlSize, m)` with the raw auto margin `m` instead of the `actualMargin` it computes from `viewDrawMargin` two lines above. Left out of this PR to keep the concern separate; the polar test collapses via an oversized title instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
