### PR TITLE
fix(polar): honor the view DrawMargin

### DIFF
--- a/src/LiveChartsCore/PolarChartEngine.cs
+++ b/src/LiveChartsCore/PolarChartEngine.cs
@@ -478,7 +478,7 @@ public class PolarChartEngine(
                 Margin.IsAuto(rm.Right) ? m.Right : rm.Right,
                 Margin.IsAuto(rm.Bottom) ? m.Bottom : rm.Bottom);
 
-            SetDrawMargin(ControlSize, m);
+            SetDrawMargin(ControlSize, actualMargin);
         }
 
         // invalid dimensions, probably the chart is too small

--- a/tests/CoreTests/ChartTests/PolarDrawMarginTests.cs
+++ b/tests/CoreTests/ChartTests/PolarDrawMarginTests.cs
@@ -1,0 +1,46 @@
+using System;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+[TestClass]
+public class PolarDrawMarginTests
+{
+    // PolarChartEngine.Measure computed `actualMargin` from the view's DrawMargin (honoring explicit
+    // sides, falling back to the auto margin for Margin.Auto sides) but then called
+    // SetDrawMargin(ControlSize, m) with the raw AUTO margin `m`, silently ignoring the user's
+    // DrawMargin entirely (every other engine — cartesian, pie, treemap, sankey — uses actualMargin).
+    // This pins that an explicit DrawMargin is honored.
+    [TestMethod]
+    public void ExplicitDrawMargin_IsHonored()
+    {
+        // distinct sides so a left/right or top/bottom swap would be caught.
+        var margin = new Margin(40, 50, 60, 70); // left, top, right, bottom
+
+        var chart = new SKPolarChart
+        {
+            Width = 300,
+            Height = 300,
+            AnimationsSpeed = TimeSpan.Zero,
+            ExplicitDisposing = true,
+            DrawMargin = margin,
+            Series = [new PolarLineSeries<int> { Values = [1, 2, 3] }],
+        };
+
+        _ = chart.GetImage();
+
+        var core = ((IChartView)chart).CoreChart;
+
+        // location is the (left, top) of the requested margin...
+        Assert.AreEqual(40f, core.DrawMarginLocation.X, 1e-4, "left margin not honored");
+        Assert.AreEqual(50f, core.DrawMarginLocation.Y, 1e-4, "top margin not honored");
+
+        // ...and the size is the control minus the requested left+right / top+bottom.
+        Assert.AreEqual(300f - 40f - 60f, core.DrawMarginSize.Width, 1e-4, "left/right margin not honored");
+        Assert.AreEqual(300f - 50f - 70f, core.DrawMarginSize.Height, 1e-4, "top/bottom margin not honored");
+    }
+}


### PR DESCRIPTION
> _Drafted by Claude Code on Beto's behalf; reviewed by Beto before publishing._

## Problem

`PolarChartEngine.Measure` honors the view's `DrawMargin` in name only. It computes `actualMargin` from `viewDrawMargin` (taking explicit sides, falling back to the auto margin for `Margin.Auto` sides)…

```csharp
var rm = viewDrawMargin ?? new Margin(Margin.Auto);
var actualMargin = new Margin(
    Margin.IsAuto(rm.Left) ? m.Left : rm.Left,
    Margin.IsAuto(rm.Top) ? m.Top : rm.Top,
    Margin.IsAuto(rm.Right) ? m.Right : rm.Right,
    Margin.IsAuto(rm.Bottom) ? m.Bottom : rm.Bottom);

SetDrawMargin(ControlSize, m);   // <-- passes the raw AUTO margin, not actualMargin
```

…then passes the raw auto margin `m`, so a user-set `DrawMargin` on a polar chart is silently ignored. Every other engine (cartesian, pie, treemap, sankey) passes `actualMargin`.

## Fix

One line: `SetDrawMargin(ControlSize, actualMargin)`.

## Tests

- `PolarDrawMarginTests.ExplicitDrawMargin_IsHonored`: sets a `DrawMargin` with four distinct sides and asserts `DrawMarginLocation` / `DrawMarginSize` reflect it. Verified to fail without the fix (left location was the auto `26.67`, not the requested `40`).
- Full suite green: **755 CoreTests + 166 SnapshotTests** (no existing polar snapshot sets a `DrawMargin`, so none change).

Found while extending the collapsed-draw-margin fix (#2325) to polar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
