### PR TITLE
feat(axis): IAxisRenderOverride seam + GroupDates opt-in

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1176,6 +1176,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     {
         if (!GroupDates)
         {
+            if (_groupedSeparators is not null || _groupedLabeler is not null)
+                _possibleMaxLabelsSize = null; // labels are no longer grouped → recompute the size
             _groupedSeparators = null;
             _groupedLabeler = null;
             _groupedSignature = null;
@@ -1186,13 +1188,24 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         var min = MinLimit ?? _visibleDataBounds.Min;
         AxisLimit.ValidateLimits(ref min, ref max, MinStep);
 
-        if (_groupedSignature is { } sig && sig.Min == min && sig.Max == max) return;
+        // Cache by the visible range: re-consulting (and re-allocating separators) is pointless while
+        // the zoom hasn't moved. .Equals avoids the float == operator while keeping an exact cache key
+        // (a miss just recomputes — no correctness impact).
+        if (_groupedSignature is { } sig && sig.Min.Equals(min) && sig.Max.Equals(max)) return;
         _groupedSignature = (min, max);
+
+        // The range changed, so the grouped labels (and their two-line height) change too: drop the
+        // cached label size so it is recomputed with the new labeler.
+        _possibleMaxLabelsSize = null;
 
         if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is { } axisOverride &&
             axisOverride.TryGroup(this, chart, min, max, out var separators, out var labeler))
         {
-            _groupedSeparators = separators;
+            // Materialize: the separators are re-enumerated in both the size and draw passes, so a
+            // single-use iterator from the override would yield nothing the second time.
+            _groupedSeparators = separators is null
+                ? null
+                : separators as IReadOnlyList<double> ?? [.. separators];
             _groupedLabeler = labeler;
         }
         else

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1186,7 +1186,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         var min = MinLimit ?? _visibleDataBounds.Min;
         AxisLimit.ValidateLimits(ref min, ref max, MinStep);
 
-        if (_groupedSignature is { } sig && sig.Min == min && sig.Max == max) return;
+        if (_groupedSignature is { } sig &&
+            Math.Abs(sig.Min - min) < double.Epsilon &&
+            Math.Abs(sig.Max - max) < double.Epsilon) return;
         _groupedSignature = (min, max);
 
         if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is { } axisOverride &&

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -77,6 +77,14 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     internal DoubleMotionProperty? _animatableMin;
     internal DoubleMotionProperty? _animatableMax;
 
+    // Per-measure date-grouping state supplied by an IAxisRenderOverride (when GroupDates is set).
+    // Computed once per visible range and cached by it, so re-measuring at the same zoom does not
+    // re-consult the provider — and so we never mutate the axis' own CustomSeparators/Labeler, which
+    // would notify a property change every frame and loop the measure forever.
+    private IEnumerable<double>? _groupedSeparators;
+    private Func<double, string>? _groupedLabeler;
+    private (double Min, double Max)? _groupedSignature;
+
     // Shared by every geometry this axis animates. Mutated in-place on each Invalidate so
     // AnimationsSpeed/EasingFunction changes reach already-created visuals — every MotionProperty
     // holds a reference to this same instance, not a copy.
@@ -202,6 +210,9 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
     /// <inheritdoc cref="ICartesianAxis.SeparatorsAtCenter"/>
     public bool SeparatorsAtCenter { get; set => SetProperty(ref field, value); } = true;
+
+    /// <inheritdoc cref="ICartesianAxis.GroupDates"/>
+    public bool GroupDates { get; set => SetProperty(ref field, value); }
 
     /// <inheritdoc cref="ICartesianAxis.TicksAtCenter"/>
     public bool TicksAtCenter { get; set => SetProperty(ref field, value); } = true;
@@ -331,6 +342,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     /// </summary>
     protected virtual AxisMeasureContext BeginMeasure(CartesianChartEngine chart)
     {
+        EnsureGrouped(chart);
+
         var animation = GetAnimation(chart);
 
         var controlSize = chart.ControlSize;
@@ -888,9 +901,12 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
     private IEnumerable<double> EnumerateSeparators(double start, double end, double step)
     {
-        if (CustomSeparators is not null)
+        // Grouped separators (from an IAxisRenderOverride) take priority, then the user's
+        // CustomSeparators, then the evenly-stepped default.
+        var custom = _groupedSeparators ?? CustomSeparators;
+        if (custom is not null)
         {
-            foreach (var s in CustomSeparators)
+            foreach (var s in custom)
                 yield return s;
 
             yield break;
@@ -956,6 +972,8 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     {
         if (_dataBounds is null) throw new Exception("DataBounds not found");
         if (LabelsPaint is null) return new LvcSize(0f, 0f);
+
+        EnsureGrouped(chart);
 
         var ts = (float)TextSize;
         var labeler = GetActualLabeler();
@@ -1149,8 +1167,45 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     protected internal override Paint?[] GetPaintTasks() =>
         [SeparatorsPaint, LabelsPaint, NamePaint, ZeroPaint, TicksPaint, SubticksPaint, SubseparatorsPaint];
 
+    // Asks the provider's IAxisRenderOverride (if any) to supply grouped separators + labeler for the
+    // current visible range when GroupDates is on. Cached by (min, max) so the same zoom does not
+    // re-consult; the results are read transiently by GetActualLabeler / EnumerateSeparators (the axis'
+    // own CustomSeparators / Labeler are never written). Called at the start of both size and draw
+    // passes so two-line grouped labels reserve the right margin AND draw consistently.
+    private void EnsureGrouped(Chart chart)
+    {
+        if (!GroupDates)
+        {
+            _groupedSeparators = null;
+            _groupedLabeler = null;
+            _groupedSignature = null;
+            return;
+        }
+
+        var max = MaxLimit ?? _visibleDataBounds.Max;
+        var min = MinLimit ?? _visibleDataBounds.Min;
+        AxisLimit.ValidateLimits(ref min, ref max, MinStep);
+
+        if (_groupedSignature is { } sig && sig.Min == min && sig.Max == max) return;
+        _groupedSignature = (min, max);
+
+        if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is { } axisOverride &&
+            axisOverride.TryGroup(this, chart, min, max, out var separators, out var labeler))
+        {
+            _groupedSeparators = separators;
+            _groupedLabeler = labeler;
+        }
+        else
+        {
+            _groupedSeparators = null;
+            _groupedLabeler = null;
+        }
+    }
+
     private Func<double, string> GetActualLabeler()
     {
+        if (_groupedLabeler is not null) return _groupedLabeler;
+
         var labeler = Labeler;
 
         if (Labels is not null)

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1186,9 +1186,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         var min = MinLimit ?? _visibleDataBounds.Min;
         AxisLimit.ValidateLimits(ref min, ref max, MinStep);
 
-        if (_groupedSignature is { } sig &&
-            Math.Abs(sig.Min - min) < double.Epsilon &&
-            Math.Abs(sig.Max - max) < double.Epsilon) return;
+        if (_groupedSignature is { } sig && sig.Min == min && sig.Max == max) return;
         _groupedSignature = (min, max);
 
         if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is { } axisOverride &&

--- a/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
@@ -53,9 +53,10 @@ public abstract class ChartEngine
 
     /// <summary>
     /// Gets the render override for the given cartesian axis, if any. The override takes over how the
-    /// axis lays out its separators and labels (consulted every measure when the axis opts in via
-    /// <see cref="ICartesianAxis.GroupDates"/>). Return <see langword="null"/> (the default) to let the
-    /// axis lay itself out as usual.
+    /// axis lays out its separators and labels when the axis opts in via
+    /// <see cref="ICartesianAxis.GroupDates"/> (consulted while measuring; the axis caches the result
+    /// by the visible range, so it re-runs on zoom/pan but is skipped while the range is unchanged).
+    /// Return <see langword="null"/> (the default) to let the axis lay itself out as usual.
     /// </summary>
     public virtual IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => null;
 

--- a/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
@@ -52,6 +52,14 @@ public abstract class ChartEngine
     public virtual ISeriesRenderOverride? GetRenderOverride(ISeries series) => null;
 
     /// <summary>
+    /// Gets the render override for the given cartesian axis, if any. The override takes over how the
+    /// axis lays out its separators and labels (consulted every measure when the axis opts in via
+    /// <see cref="ICartesianAxis.GroupDates"/>). Return <see langword="null"/> (the default) to let the
+    /// axis lay itself out as usual.
+    /// </summary>
+    public virtual IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => null;
+
+    /// <summary>
     /// Gets a new instance of the default map factory.
     /// </summary>
     /// <returns></returns>

--- a/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
+++ b/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
@@ -1,0 +1,57 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using LiveChartsCore.Kernel.Sketches;
+
+namespace LiveChartsCore.Kernel.Providers;
+
+/// <summary>
+/// An optional hook a <see cref="ChartEngine"/> can supply to take over how a cartesian axis lays out
+/// its separators and labels. It is consulted on every measure (so it can adapt to zoom/pan) when the
+/// axis opts in via <see cref="ICartesianAxis.GroupDates"/>. The default engine returns none, so the
+/// axis lays itself out as usual.
+/// </summary>
+public interface IAxisRenderOverride
+{
+    /// <summary>
+    /// Supplies the separator positions and the labeler the axis should use for the current visible
+    /// range. The values are applied for this measure only — the override must not mutate the axis'
+    /// own <see cref="IPlane.CustomSeparators"/> / <see cref="IPlane.Labeler"/> (doing so each frame
+    /// would re-trigger a measure). Return <see langword="true"/> to take over, or
+    /// <see langword="false"/> to let the axis lay itself out normally.
+    /// </summary>
+    /// <param name="axis">The axis being measured.</param>
+    /// <param name="chart">The chart being measured.</param>
+    /// <param name="min">The effective visible minimum, in axis units.</param>
+    /// <param name="max">The effective visible maximum, in axis units.</param>
+    /// <param name="separators">The separator positions to draw (in axis units), or null.</param>
+    /// <param name="labeler">The labeler to format each separator, or null to keep the axis' own.</param>
+    bool TryGroup(
+        ICartesianAxis axis,
+        Chart chart,
+        double min,
+        double max,
+        out IEnumerable<double>? separators,
+        out Func<double, string>? labeler);
+}

--- a/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
+++ b/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
@@ -28,9 +28,10 @@ namespace LiveChartsCore.Kernel.Providers;
 
 /// <summary>
 /// An optional hook a <see cref="ChartEngine"/> can supply to take over how a cartesian axis lays out
-/// its separators and labels. It is consulted on every measure (so it can adapt to zoom/pan) when the
-/// axis opts in via <see cref="ICartesianAxis.GroupDates"/>. The default engine returns none, so the
-/// axis lays itself out as usual.
+/// its separators and labels. It is consulted while measuring the axis when it opts in via
+/// <see cref="ICartesianAxis.GroupDates"/> — the axis caches the result by the visible range, so
+/// <see cref="TryGroup"/> re-runs when you zoom or pan but is skipped while the range is unchanged.
+/// The default engine returns none, so the axis lays itself out as usual.
 /// </summary>
 public interface IAxisRenderOverride
 {

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -106,6 +106,14 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     bool SeparatorsAtCenter { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the axis should group dates into adaptive, multi-level
+    /// labels (e.g. a fine unit on the first line and a coarser context on the second, updating as you
+    /// zoom). Default is false. Requires a provider that supplies an
+    /// <see cref="Providers.IAxisRenderOverride"/> (otherwise the flag is ignored).
+    /// </summary>
+    bool GroupDates { get; set; }
+
+    /// <summary>
     /// Gets or sets the reserved area for the labels.
     /// </summary>
     LvcRectangle LabelsDesiredSize { get; set; }

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -109,7 +109,7 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     /// Gets or sets a value indicating whether the axis should group dates into adaptive, multi-level
     /// labels (e.g. a fine unit on the first line and a coarser context on the second, updating as you
     /// zoom). Default is false. Requires a provider that supplies an
-    /// <see cref="Providers.IAxisRenderOverride"/> (otherwise the flag is ignored).
+    /// <see cref="LiveChartsCore.Kernel.Providers.IAxisRenderOverride"/> (otherwise the flag is ignored).
     /// </summary>
     bool GroupDates { get; set; }
 

--- a/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using LiveChartsCore;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Kernel.Providers;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.ChartTests;
+
+// Guards the IAxisRenderOverride provider seam: when an axis sets GroupDates, the provider's override
+// is consulted on measure and the separators/labeler it returns are used; when GroupDates is false the
+// override is never consulted and the axis lays itself out normally.
+[TestClass]
+public class AxisRenderOverrideTests
+{
+    private sealed class RecordingGrouper : IAxisRenderOverride
+    {
+        public bool Consulted, LabelerUsed;
+        public double SeenMin, SeenMax;
+
+        public bool TryGroup(
+            ICartesianAxis axis, Chart chart, double min, double max,
+            out IEnumerable<double>? separators, out Func<double, string>? labeler)
+        {
+            Consulted = true;
+            SeenMin = min;
+            SeenMax = max;
+            separators = [10d, 50d, 90d];                 // a fixed, small set unlike the default
+            labeler = _ => { LabelerUsed = true; return "X"; };
+            return true;
+        }
+    }
+
+    private sealed class FakeEngine(RecordingGrouper grouper) : SkiaSharpProvider
+    {
+        public override IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => grouper;
+    }
+
+    private static SKCartesianChart NewChart(bool groupDates) => new()
+    {
+        Width = 600,
+        Height = 400,
+        Series = [new LineSeries<double> { Values = [0, 100], GeometrySize = 0 }],
+        XAxes = [new Axis { GroupDates = groupDates, MinLimit = 0, MaxLimit = 100 }],
+        YAxes = [new Axis()],
+    };
+
+    [TestMethod]
+    public void GroupDates_True_ConsultsOverride_AndUsesItsLabeler()
+    {
+        var grouper = new RecordingGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+            _ = NewChart(groupDates: true).GetImage();
+
+            Assert.IsTrue(grouper.Consulted, "the override must be consulted when GroupDates is true");
+            Assert.IsTrue(grouper.LabelerUsed, "the override's labeler must be used to draw the labels");
+            Assert.AreEqual(0d, grouper.SeenMin, 1e-6, "the override must receive the visible min");
+            Assert.AreEqual(100d, grouper.SeenMax, 1e-6, "the override must receive the visible max");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+
+    [TestMethod]
+    public void GroupDates_False_DoesNotConsultOverride()
+    {
+        var grouper = new RecordingGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+            _ = NewChart(groupDates: false).GetImage();
+
+            Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted when GroupDates is false");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+}

--- a/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
@@ -34,9 +34,33 @@ public class AxisRenderOverrideTests
         }
     }
 
-    private sealed class FakeEngine(RecordingGrouper grouper) : SkiaSharpProvider
+    private sealed class FakeEngine(IAxisRenderOverride grouper) : SkiaSharpProvider
     {
         public override IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => grouper;
+    }
+
+    // Yields its items once, then throws if enumerated a second time — proves CoreAxis materializes the
+    // override's separators rather than re-enumerating the same iterator in the size and draw passes.
+    private sealed class OnceEnumerable(double[] items) : IEnumerable<double>
+    {
+        private int _calls;
+        public IEnumerator<double> GetEnumerator() => _calls++ == 0
+            ? ((IEnumerable<double>)items).GetEnumerator()
+            : throw new InvalidOperationException("single-use iterator enumerated twice");
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class SingleUseGrouper : IAxisRenderOverride
+    {
+        public bool LabelerUsed;
+        public bool TryGroup(
+            ICartesianAxis axis, Chart chart, double min, double max,
+            out IEnumerable<double>? separators, out Func<double, string>? labeler)
+        {
+            separators = new OnceEnumerable([10d, 50d, 90d]);
+            labeler = _ => { LabelerUsed = true; return "X"; };
+            return true;
+        }
     }
 
     private static SKCartesianChart NewChart(bool groupDates) => new()
@@ -61,6 +85,33 @@ public class AxisRenderOverrideTests
             Assert.IsTrue(grouper.LabelerUsed, "the override's labeler must be used to draw the labels");
             Assert.AreEqual(0d, grouper.SeenMin, 1e-6, "the override must receive the visible min");
             Assert.AreEqual(100d, grouper.SeenMax, 1e-6, "the override must receive the visible max");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+
+    [TestMethod]
+    public void GroupedSeparators_SingleUseIterator_AreMaterialized()
+    {
+        var grouper = new SingleUseGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+
+            // Re-enumerating a single-use iterator (size pass + draw pass) would throw; materializing
+            // it once must not. The labeler running proves the separators reached the draw pass.
+            _ = new SKCartesianChart
+            {
+                Width = 600,
+                Height = 400,
+                Series = [new LineSeries<double> { Values = [0, 100], GeometrySize = 0 }],
+                XAxes = [new Axis { GroupDates = true, MinLimit = 0, MaxLimit = 100 }],
+                YAxes = [new Axis()],
+            }.GetImage();
+
+            Assert.IsTrue(grouper.LabelerUsed, "the grouped labeler must run, so the separators were used in the draw pass");
         }
         finally
         {


### PR DESCRIPTION
> _Drafted by Claude Code on Beto's behalf; reviewed by Beto before publishing._

## What

An **axis render-override seam**, mirroring `ISeriesRenderOverride`. It lets a provider take over how a cartesian axis lays out its **separators and labels**, opted into per-axis with a new `GroupDates` flag.

The motivating use case (built on top of this, in the BackersPackage): an **adaptive, multi-level date axis** — a fine unit on the first line and a coarser context on the second (`Nov Dec Jan Feb Mar` with `2020` under `Jan`), updating as you zoom (months → days → hours…). This PR is just the OSS seam; the date renderer lives in the package.

## API

- `ICartesianAxis.GroupDates` (bool, default `false`).
- `IAxisRenderOverride.TryGroup(axis, chart, min, max, out separators, out labeler)` in `Kernel/Providers`.
- `ChartEngine.GetAxisRenderOverride(ICartesianAxis) => null` (provider hook).

When `GroupDates` is set **and** a provider supplies an override, `CoreAxis` consults it each measure for the current visible range and uses the returned separators + labeler. Otherwise nothing changes.

## Why it's loop-safe

The override returns its separators/labeler; the axis stores them in **per-measure fields cached by `(min, max)`** and reads them transiently from `GetActualLabeler` / `EnumerateSeparators`. It never writes the axis' own `CustomSeparators`/`Labeler` — doing that every frame would fire a property-change → schedule another measure → loop forever. `EnsureGrouped` runs at the start of **both** the size pass (`GetPossibleSize`) and the draw pass (`BeginMeasure`), so two-line grouped labels reserve the correct margin and draw consistently.

## Tests

- `AxisRenderOverrideTests`: the override is consulted (with the visible min/max) and its labeler used when `GroupDates` is true; never consulted when false.
- Non-breaking: **766 CoreTests + 30 axis snapshots** green (default `GroupDates=false` path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
