### PR TITLE
feat(motion): CoreMotionCanvas.DrawOverlay frame-overlay hook

### DIFF
--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -114,6 +114,13 @@ public class CoreMotionCanvas : IDisposable
     public event Action<CoreMotionCanvas>? Validated;
 
     /// <summary>
+    /// An optional overlay painted on top of every frame, after all zones and the FPS panel.
+    /// Extensions use this to draw a fixed, screen-space overlay (for example a watermark).
+    /// It is not invoked while <see cref="IsTesting"/> is true, so it never affects test baselines.
+    /// </summary>
+    public static Action<CoreMotionCanvas, DrawingContext>? DrawOverlay { get; set; }
+
+    /// <summary>
     /// Returns true if the visual is valid.
     /// </summary>
     /// <value>
@@ -246,6 +253,11 @@ public class CoreMotionCanvas : IDisposable
             }
 
             IsValid = isValid;
+
+            // Painted last so it sits on top of everything; skipped under IsTesting to keep
+            // snapshot baselines clean. Extensions (e.g. the backers license watermark) opt in.
+            if (!IsTesting)
+                DrawOverlay?.Invoke(this, context);
 
             context.OnEndDraw();
         }


### PR DESCRIPTION
> 🤖 This PR was drafted by Claude (AI) on Beto's behalf. Please review before merging.

## What

Adds an optional, static `CoreMotionCanvas.DrawOverlay` callback:

```csharp
public static Action<CoreMotionCanvas, DrawingContext>? DrawOverlay { get; set; }
```

It is invoked once per frame in `DrawFrame`, **after all zones and the FPS panel**, so an extension can paint a fixed, screen-space overlay (e.g. a watermark) on top of everything. It is **skipped while `IsTesting` is true**, so it never affects snapshot baselines.

## Why

The backers package needs a way to draw a screen-space overlay (a license/evaluation watermark) without the core taking any dependency on it. This is a neutral, general-purpose seam — anything that needs a per-frame overlay can use it.

## Notes

- No behavior change unless an extension assigns `DrawOverlay` (defaults to `null`).
- Drawing happens after `IsValid` is computed, so it has no effect on validity/animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)