### PR TITLE
refactor(axis): move GroupDates to DateTimeAxis/TimeSpanAxis as GroupTimeUnits

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -77,7 +77,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     internal DoubleMotionProperty? _animatableMin;
     internal DoubleMotionProperty? _animatableMax;
 
-    // Per-measure date-grouping state supplied by an IAxisRenderOverride (when GroupDates is set).
+    // Per-measure grouping state supplied by the provider's IAxisRenderOverride (when any).
     // Computed once per visible range and cached by it, so re-measuring at the same zoom does not
     // re-consult the provider — and so we never mutate the axis' own CustomSeparators/Labeler, which
     // would notify a property change every frame and loop the measure forever.
@@ -210,9 +210,6 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
 
     /// <inheritdoc cref="ICartesianAxis.SeparatorsAtCenter"/>
     public bool SeparatorsAtCenter { get; set => SetProperty(ref field, value); } = true;
-
-    /// <inheritdoc cref="ICartesianAxis.GroupDates"/>
-    public bool GroupDates { get; set => SetProperty(ref field, value); }
 
     /// <inheritdoc cref="ICartesianAxis.TicksAtCenter"/>
     public bool TicksAtCenter { get; set => SetProperty(ref field, value); } = true;
@@ -1168,13 +1165,15 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         [SeparatorsPaint, LabelsPaint, NamePaint, ZeroPaint, TicksPaint, SubticksPaint, SubseparatorsPaint];
 
     // Asks the provider's IAxisRenderOverride (if any) to supply grouped separators + labeler for the
-    // current visible range when GroupDates is on. Cached by (min, max) so the same zoom does not
-    // re-consult; the results are read transiently by GetActualLabeler / EnumerateSeparators (the axis'
-    // own CustomSeparators / Labeler are never written). Called at the start of both size and draw
-    // passes so two-line grouped labels reserve the right margin AND draw consistently.
+    // current visible range. The engine decides whether the axis is overridden (e.g. by the axis'
+    // concrete type and its own opt-in flags) — when it returns null the axis lays itself out as
+    // usual. Cached by (min, max) so the same zoom does not re-consult; the results are read
+    // transiently by GetActualLabeler / EnumerateSeparators (the axis' own CustomSeparators / Labeler
+    // are never written). Called at the start of both size and draw passes so two-line grouped labels
+    // reserve the right margin AND draw consistently.
     private void EnsureGrouped(Chart chart)
     {
-        if (!GroupDates)
+        if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is not { } axisOverride)
         {
             if (_groupedSeparators is not null || _groupedLabeler is not null)
                 _possibleMaxLabelsSize = null; // labels are no longer grouped → recompute the size
@@ -1198,8 +1197,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         // cached label size so it is recomputed with the new labeler.
         _possibleMaxLabelsSize = null;
 
-        if (LiveCharts.DefaultSettings.GetProvider().GetAxisRenderOverride(this) is { } axisOverride &&
-            axisOverride.TryGroup(this, chart, min, max, out var separators, out var labeler))
+        if (axisOverride.TryGroup(this, chart, min, max, out var separators, out var labeler))
         {
             // Materialize: the separators are re-enumerated in both the size and draw passes, so a
             // single-use iterator from the override would yield nothing the second time.

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1551,6 +1551,11 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         var actualRotatation = r;
         const double toRadians = Math.PI / 180;
 
+        // Grouped labels are multi-line blocks centered on their tick (fine unit on one line,
+        // coarse context on another); left-aligned lines would shift the narrow line toward the
+        // previous tick. Reset when grouping turns off so the default layout returns.
+        label.LinesAlignment = _groupedLabeler is not null ? Align.Middle : Align.Start;
+
         if (_orientation == AxisOrientation.Y)
         {
             actualRotatation %= 180;

--- a/src/LiveChartsCore/Drawing/BaseLabelGeometry.cs
+++ b/src/LiveChartsCore/Drawing/BaseLabelGeometry.cs
@@ -190,6 +190,13 @@ public abstract partial class BaseLabelGeometry : Animatable, IDrawnElement
     public Align HorizontalAlign { get; set; } = Align.Middle;
 
     /// <summary>
+    /// Gets or sets how each line of a multi-line label aligns horizontally inside the label
+    /// block (the block itself is placed by <see cref="HorizontalAlign"/>). Default is
+    /// <see cref="Align.Start"/>. Right-to-left text always aligns lines to the end.
+    /// </summary>
+    public Align LinesAlignment { get; set; } = Align.Start;
+
+    /// <summary>
     /// Gets or sets the text.
     /// </summary>
     public string Text { get; set; } = string.Empty;

--- a/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
+++ b/src/LiveChartsCore/Kernel/Providers/ChartEngine.cs
@@ -53,10 +53,12 @@ public abstract class ChartEngine
 
     /// <summary>
     /// Gets the render override for the given cartesian axis, if any. The override takes over how the
-    /// axis lays out its separators and labels when the axis opts in via
-    /// <see cref="ICartesianAxis.GroupDates"/> (consulted while measuring; the axis caches the result
-    /// by the visible range, so it re-runs on zoom/pan but is skipped while the range is unchanged).
-    /// Return <see langword="null"/> (the default) to let the axis lay itself out as usual.
+    /// axis lays out its separators and labels; the engine decides which axes are overridden — e.g.
+    /// by the axis' concrete type and its own opt-in flags, like GroupTimeUnits on the DateTime axis
+    /// (consulted while measuring; the axis caches the result by the visible range, so it re-runs on
+    /// zoom/pan but is skipped while the range is unchanged). Return <see langword="null"/> (the
+    /// default) to let the axis lay itself out as usual. Consulted on every measure pass, so
+    /// implementations should be cheap (e.g. a type check + flag read) rather than allocating per call.
     /// </summary>
     public virtual IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => null;
 

--- a/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
+++ b/src/LiveChartsCore/Kernel/Providers/IAxisRenderOverride.cs
@@ -28,10 +28,11 @@ namespace LiveChartsCore.Kernel.Providers;
 
 /// <summary>
 /// An optional hook a <see cref="ChartEngine"/> can supply to take over how a cartesian axis lays out
-/// its separators and labels. It is consulted while measuring the axis when it opts in via
-/// <see cref="ICartesianAxis.GroupDates"/> — the axis caches the result by the visible range, so
-/// <see cref="TryGroup"/> re-runs when you zoom or pan but is skipped while the range is unchanged.
-/// The default engine returns none, so the axis lays itself out as usual.
+/// its separators and labels. The engine decides which axes are overridden (e.g. by the axis'
+/// concrete type and its own opt-in flags, like GroupTimeUnits on the DateTime axis); the axis caches
+/// the result by the visible range, so <see cref="TryGroup"/> re-runs when you zoom or pan but is
+/// skipped while the range is unchanged. The default engine returns none, so the axis lays itself out
+/// as usual.
 /// </summary>
 public interface IAxisRenderOverride
 {

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -106,14 +106,6 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     bool SeparatorsAtCenter { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the axis should group dates into adaptive, multi-level
-    /// labels (e.g. a fine unit on the first line and a coarser context on the second, updating as you
-    /// zoom). Default is false. Requires a provider that supplies an
-    /// <see cref="LiveChartsCore.Kernel.Providers.IAxisRenderOverride"/> (otherwise the flag is ignored).
-    /// </summary>
-    bool GroupDates { get; set; }
-
-    /// <summary>
     /// Gets or sets the reserved area for the labels.
     /// </summary>
     LvcRectangle LabelsDesiredSize { get; set; }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/DateTimeAxis.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/DateTimeAxis.cs
@@ -45,4 +45,12 @@ public class DateTimeAxis : Axis
         Labeler = value => formatter(value.AsDate());
         MinStep = unit.Ticks;
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the axis should group its time units into adaptive,
+    /// multi-level labels (e.g. a fine unit on the first line and a coarser context on the second,
+    /// updating as you zoom). Default is false. Requires a chart engine that supplies an axis render
+    /// override for this axis (otherwise the flag is ignored).
+    /// </summary>
+    public bool GroupTimeUnits { get; set => SetProperty(ref field, value); }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/DrawingTextExtensions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/DrawingTextExtensions.cs
@@ -87,8 +87,7 @@ internal static class DrawingTextExtensions
             canvas.DrawRect(rax, ray, size.Width, size.Height, bgPaint);
         }
 
-        var horizontalPadding = label.Padding.Left + label.Padding.Right;
-        var lao = 0f;
+        var contentWidth = size.Width - label.Padding.Left - label.Padding.Right;
 
         foreach (var pb in blobArray.Blobs)
         {
@@ -97,9 +96,15 @@ internal static class DrawingTextExtensions
 
             var blobPosition = pb.Position;
 
-            // line alignmen offset.
-            if (blobArray.IsRTL)
-                lao = size.Width - horizontalPadding - blobArray.LineWidths[pb.Line];
+            // line alignment offset.
+            var lao = blobArray.IsRTL
+                ? contentWidth - blobArray.LineWidths[pb.Line]
+                : label.LinesAlignment switch
+                {
+                    Align.Middle => (contentWidth - blobArray.LineWidths[pb.Line]) * 0.5f,
+                    Align.End => contentWidth - blobArray.LineWidths[pb.Line],
+                    _ => 0f
+                };
 
             canvas.DrawText(
                 pb.Blob,

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/TimeSpanAxis.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/TimeSpanAxis.cs
@@ -45,4 +45,12 @@ public class TimeSpanAxis : Axis
         Labeler = value => formatter(value.AsTimeSpan());
         MinStep = unit.Ticks;
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the axis should group its time units into adaptive,
+    /// multi-level labels (e.g. a fine unit on the first line and a coarser context on the second,
+    /// updating as you zoom). Default is false. Requires a chart engine that supplies an axis render
+    /// override for this axis (otherwise the flag is ignored).
+    /// </summary>
+    public bool GroupTimeUnits { get; set => SetProperty(ref field, value); }
 }

--- a/src/skiasharp/_Shared.Xaml/CartesianAxes.cs
+++ b/src/skiasharp/_Shared.Xaml/CartesianAxes.cs
@@ -88,6 +88,10 @@ public partial class XamlDateTimeAxis : BaseXamlAxis<DateTimeAxis>
 {
     static UIProperty<TimeSpan>                 interval =      new(TimeSpan.FromDays(1), XamlGeneration.OnAxisIntervalChanged);
     static UIProperty<Func<DateTime, string>>   dateFormatter = new(null, XamlGeneration.OnDateTimeAxisDateFormatterChanged);
+    static UIProperty<bool>                     groupTimeUnits = new(false, OnGroupTimeUnitsChanged);
+
+    private static void OnGroupTimeUnitsChanged(IXamlWrapper<ICartesianAxis> axis, bool oldValue, bool newValue) =>
+        ((DateTimeAxis)axis.WrappedObject).GroupTimeUnits = newValue;
 
 #if AVALONIA_LVC
     /// <inheritdoc />
@@ -107,6 +111,10 @@ public partial class XamlTimeSpanAxis : BaseXamlAxis<TimeSpanAxis>
 {
     static UIProperty<TimeSpan>                 interval =      new(TimeSpan.FromSeconds(1), XamlGeneration.OnAxisIntervalChanged);
     static UIProperty<Func<TimeSpan, string>>   timeFormatter = new(null, XamlGeneration.OnTimeSpanAxisFormatterChanged);
+    static UIProperty<bool>                     groupTimeUnits = new(false, OnGroupTimeUnitsChanged);
+
+    private static void OnGroupTimeUnitsChanged(IXamlWrapper<ICartesianAxis> axis, bool oldValue, bool newValue) =>
+        ((TimeSpanAxis)axis.WrappedObject).GroupTimeUnits = newValue;
 
 #if AVALONIA_LVC
     /// <inheritdoc />

--- a/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
@@ -10,9 +10,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CoreTests.ChartTests;
 
-// Guards the IAxisRenderOverride provider seam: when an axis sets GroupDates, the provider's override
-// is consulted on measure and the separators/labeler it returns are used; when GroupDates is false the
-// override is never consulted and the axis lays itself out normally.
+// Guards the IAxisRenderOverride provider seam: the engine decides which axes are overridden (here,
+// like the real engines, by the concrete axis type plus its GroupTimeUnits flag); when the engine
+// returns an override it is consulted on measure and the separators/labeler it returns are used; when
+// the engine returns null the override is never consulted and the axis lays itself out normally.
 [TestClass]
 public class AxisRenderOverrideTests
 {
@@ -34,9 +35,17 @@ public class AxisRenderOverrideTests
         }
     }
 
+    // Mirrors how a real engine is expected to gate the seam: by the concrete axis type and its own
+    // opt-in flag — core no longer carries any grouping flag.
     private sealed class FakeEngine(IAxisRenderOverride grouper) : SkiaSharpProvider
     {
-        public override IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) => grouper;
+        public override IAxisRenderOverride? GetAxisRenderOverride(ICartesianAxis axis) =>
+            axis switch
+            {
+                DateTimeAxis { GroupTimeUnits: true } => grouper,
+                TimeSpanAxis { GroupTimeUnits: true } => grouper,
+                _ => null
+            };
     }
 
     // Yields its items once, then throws if enumerated a second time — proves CoreAxis materializes the
@@ -63,25 +72,33 @@ public class AxisRenderOverrideTests
         }
     }
 
-    private static SKCartesianChart NewChart(bool groupDates) => new()
+    private static SKCartesianChart NewChart(ICartesianAxis xAxis) => new()
     {
         Width = 600,
         Height = 400,
         Series = [new LineSeries<double> { Values = [0, 100], GeometrySize = 0 }],
-        XAxes = [new Axis { GroupDates = groupDates, MinLimit = 0, MaxLimit = 100 }],
+        XAxes = [xAxis],
         YAxes = [new Axis()],
     };
 
+    private static DateTimeAxis NewDateTimeAxis(bool groupTimeUnits) =>
+        new(TimeSpan.FromTicks(1), date => date.Ticks.ToString())
+        {
+            GroupTimeUnits = groupTimeUnits,
+            MinLimit = 0,
+            MaxLimit = 100
+        };
+
     [TestMethod]
-    public void GroupDates_True_ConsultsOverride_AndUsesItsLabeler()
+    public void GroupTimeUnits_True_ConsultsOverride_AndUsesItsLabeler()
     {
         var grouper = new RecordingGrouper();
         try
         {
             LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
-            _ = NewChart(groupDates: true).GetImage();
+            _ = NewChart(NewDateTimeAxis(groupTimeUnits: true)).GetImage();
 
-            Assert.IsTrue(grouper.Consulted, "the override must be consulted when GroupDates is true");
+            Assert.IsTrue(grouper.Consulted, "the override must be consulted when GroupTimeUnits is true");
             Assert.IsTrue(grouper.LabelerUsed, "the override's labeler must be used to draw the labels");
             Assert.AreEqual(0d, grouper.SeenMin, 1e-6, "the override must receive the visible min");
             Assert.AreEqual(100d, grouper.SeenMax, 1e-6, "the override must receive the visible max");
@@ -102,14 +119,7 @@ public class AxisRenderOverrideTests
 
             // Re-enumerating a single-use iterator (size pass + draw pass) would throw; materializing
             // it once must not. The labeler running proves the separators reached the draw pass.
-            _ = new SKCartesianChart
-            {
-                Width = 600,
-                Height = 400,
-                Series = [new LineSeries<double> { Values = [0, 100], GeometrySize = 0 }],
-                XAxes = [new Axis { GroupDates = true, MinLimit = 0, MaxLimit = 100 }],
-                YAxes = [new Axis()],
-            }.GetImage();
+            _ = NewChart(NewDateTimeAxis(groupTimeUnits: true)).GetImage();
 
             Assert.IsTrue(grouper.LabelerUsed, "the grouped labeler must run, so the separators were used in the draw pass");
         }
@@ -120,15 +130,15 @@ public class AxisRenderOverrideTests
     }
 
     [TestMethod]
-    public void GroupDates_False_DoesNotConsultOverride()
+    public void GroupTimeUnits_False_DoesNotConsultOverride()
     {
         var grouper = new RecordingGrouper();
         try
         {
             LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
-            _ = NewChart(groupDates: false).GetImage();
+            _ = NewChart(NewDateTimeAxis(groupTimeUnits: false)).GetImage();
 
-            Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted when GroupDates is false");
+            Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted when GroupTimeUnits is false");
         }
         finally
         {

--- a/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
@@ -110,6 +110,29 @@ public class AxisRenderOverrideTests
     }
 
     [TestMethod]
+    public void GroupTimeUnits_True_OnTimeSpanAxis_ConsultsOverride()
+    {
+        var grouper = new RecordingGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+            _ = NewChart(new TimeSpanAxis(TimeSpan.FromTicks(1), span => span.Ticks.ToString())
+            {
+                GroupTimeUnits = true,
+                MinLimit = 0,
+                MaxLimit = 100
+            }).GetImage();
+
+            Assert.IsTrue(grouper.Consulted, "the override must be consulted when GroupTimeUnits is true");
+            Assert.IsTrue(grouper.LabelerUsed, "the override's labeler must be used to draw the labels");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+
+    [TestMethod]
     public void GroupedSeparators_SingleUseIterator_AreMaterialized()
     {
         var grouper = new SingleUseGrouper();
@@ -139,6 +162,23 @@ public class AxisRenderOverrideTests
             _ = NewChart(NewDateTimeAxis(groupTimeUnits: false)).GetImage();
 
             Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted when GroupTimeUnits is false");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+
+    [TestMethod]
+    public void PlainAxis_DoesNotConsultOverride()
+    {
+        var grouper = new RecordingGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+            _ = NewChart(new Axis { MinLimit = 0, MaxLimit = 100 }).GetImage();
+
+            Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted for axes the engine does not match");
         }
         finally
         {

--- a/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRenderOverrideTests.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Providers;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.SKCharts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
 
 namespace CoreTests.ChartTests;
 
@@ -162,6 +166,49 @@ public class AxisRenderOverrideTests
             _ = NewChart(NewDateTimeAxis(groupTimeUnits: false)).GetImage();
 
             Assert.IsFalse(grouper.Consulted, "the override must NOT be consulted when GroupTimeUnits is false");
+        }
+        finally
+        {
+            LiveCharts.Configure(s => s.AddSkiaSharp());
+        }
+    }
+
+    [TestMethod]
+    public void GroupedLabels_CenterTheirLines_AndResetWhenNotGrouped()
+    {
+        // Grouped labels are multi-line blocks centered on their tick; left-aligned lines would
+        // shift the narrow line toward the previous tick (the "18:0000:00" collision). Ungrouped
+        // axes must keep the default Start alignment so existing layouts don't move.
+        var grouper = new RecordingGrouper();
+        try
+        {
+            LiveCharts.Configure(s => s.HasProvider(new FakeEngine(grouper)));
+
+            var groupedPaint = new SolidColorPaint(SKColors.Black);
+            var groupedAxis = NewDateTimeAxis(groupTimeUnits: true);
+            groupedAxis.LabelsPaint = groupedPaint;
+            var groupedChart = NewChart(groupedAxis);
+            _ = CoreObjectsTests.ChangingPaintTasks.DrawChart(groupedChart);
+
+            var groupedLabels = groupedPaint.GetGeometries(groupedChart.CoreCanvas)
+                .Cast<BaseLabelGeometry>().ToArray();
+            Assert.IsTrue(groupedLabels.Length > 0, "expected drawn axis labels");
+            Assert.IsTrue(
+                groupedLabels.All(l => l.LinesAlignment == Align.Middle),
+                "grouped multi-line labels must center their lines on the tick");
+
+            var plainPaint = new SolidColorPaint(SKColors.Black);
+            var plainAxis = NewDateTimeAxis(groupTimeUnits: false);
+            plainAxis.LabelsPaint = plainPaint;
+            var plainChart = NewChart(plainAxis);
+            _ = CoreObjectsTests.ChangingPaintTasks.DrawChart(plainChart);
+
+            var plainLabels = plainPaint.GetGeometries(plainChart.CoreCanvas)
+                .Cast<BaseLabelGeometry>().ToArray();
+            Assert.IsTrue(plainLabels.Length > 0, "expected drawn axis labels");
+            Assert.IsTrue(
+                plainLabels.All(l => l.LinesAlignment == Align.Start),
+                "ungrouped labels must keep the default Start alignment");
         }
         finally
         {


### PR DESCRIPTION
## Why

#2329 placed the grouping opt-in (`GroupDates`) on `ICartesianAxis`, but core has no idea whether an axis carries time values — only the `DateTimeAxis` / `TimeSpanAxis` path knows that. And since both DateTime **and** TimeSpan are supported, the name now says what is actually grouped: **`GroupTimeUnits`**.

## What changed

- **Removed** `ICartesianAxis.GroupDates` and its `CoreAxis` implementation (unreleased API from #2329, so no breaking change for consumers).
- **Added** `DateTimeAxis.GroupTimeUnits` and `TimeSpanAxis.GroupTimeUnits` (SkiaSharp layer, where the value type is known).
- The `IAxisRenderOverride` seam stays in core, but the **engine** now decides which axes are overridden — e.g. by the concrete axis type plus its opt-in flag — instead of core gating on a bool. `ChartEngine.GetAxisRenderOverride` returning `null` (the default) keeps the axis laying itself out as usual, and `CoreAxis` resets its grouped state when that happens. This also works for XAML usage: `CoreAxis` passes `this` (the inner wrapped axis) to the engine, so a concrete-type check sees the real `DateTimeAxis`.
- XAML wrappers (`XamlDateTimeAxis` / `XamlTimeSpanAxis`) expose a `GroupTimeUnits` bindable property; its change handler lives next to the wrapper (which can see the concrete axis type) rather than in core''s `XamlGeneration`.
- **New: `BaseLabelGeometry.LinesAlignment`** (default `Start` — nothing moves for existing labels). Driving the grouped renderer end-to-end surfaced that multi-line label lines were always left-aligned within the block (only RTL got an end offset), so a grouped label with a wide context line ("Jun 2, 2020") shoved its narrow fine line ("00:00") left of the tick and collided with the neighbor ("18:0000:00"). The SkiaSharp text renderer now applies per-line alignment, and `CoreAxis` sets `Middle` on its labels while a grouped labeler is active, resetting to `Start` when grouping turns off.

## Tests

- `AxisRenderOverrideTests` reworked to the new contract: the fake engine gates by `DateTimeAxis/TimeSpanAxis { GroupTimeUnits: true }`, mirroring how a real engine is expected to register overrides.
- New pins: a `TimeSpanAxis` is consulted like the DateTime one; a plain `Axis` the engine does not match never is; grouped labels center their lines and reset to `Start` when ungrouped.
- 772 CoreTests (net8.0) and 166 SnapshotTests green (all existing multiline baselines pixel-identical); WPF + Avalonia view projects build, and the generated `GroupTimeUnitsProperty` DP was verified in the WPF generator output.
- Verified end-to-end against the BackersPackage `DateGroupingOverride`: pixel snapshots at two-year (months + year context) and two-day (hours + date context) tiers, plus a grouped-vs-ungrouped pixel-difference pin of the engine gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)