### PR TITLE
perf: skip the observer's per-item INPC walk when no item can be tracked

### DIFF
--- a/src/LiveChartsCore/CoreHeatLandSeries.cs
+++ b/src/LiveChartsCore/CoreHeatLandSeries.cs
@@ -58,7 +58,8 @@ public abstract class CoreHeatLandSeries<TModel> : IGeoSeries, IHeatLegendSource
     public CoreHeatLandSeries(ICollection<TModel>? lands)
     {
         Lands = lands;
-        _observer = new CollectionDeepObserver(NotifySubscribers);
+        _observer = new CollectionDeepObserver(
+            NotifySubscribers, null, null, CollectionDeepObserver.MayContainTrackableItems<TModel>());
     }
 
     /// <summary>

--- a/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
@@ -57,6 +57,7 @@ public class CollectionDeepObserver(
 {
     private readonly HashSet<INotifyPropertyChanged> _itemsListening = [];
     private IEnumerable? _trackedCollection;
+    private bool _walksItems;
 
     /// <inheritdoc cref="IObserver.Initialize(object?)"/>
     public void Initialize(object? instance)
@@ -72,7 +73,15 @@ public class CollectionDeepObserver(
         if (instance is INotifyCollectionChanged incc)
             incc.CollectionChanged += OnCollectionChanged;
 
-        OnItemsAdded(enumerable);
+        // The per-item walk exists to subscribe INotifyPropertyChanged items and to raise
+        // the per-item callbacks. When neither can ever apply — no callbacks registered
+        // and the element type provably has no trackable instances — skip it entirely:
+        // the walk is O(N) and boxes every struct, which at large-data scale (a multi-
+        // million-point double[] or struct[] assigned to Series.Values) measures in
+        // SECONDS of pure overhead on every assignment.
+        _walksItems = onItemAdded is not null || onItemRemoved is not null || MayContainTrackableItems(enumerable);
+        if (_walksItems)
+            OnItemsAdded(enumerable);
 
         _trackedCollection = enumerable;
     }
@@ -85,13 +94,57 @@ public class CollectionDeepObserver(
         if (_trackedCollection is INotifyCollectionChanged incc)
             incc.CollectionChanged -= OnCollectionChanged;
 
-        OnItemsRemoved(_trackedCollection);
+        if (_walksItems)
+            OnItemsRemoved(_trackedCollection);
 
         _trackedCollection = null;
     }
 
+    // Whether any instance in the collection could ever need PropertyChanged tracking,
+    // decided from the collection's IEnumerable<T> element type(s):
+    //
+    //   - A VALUE TYPE never can — even one implementing INPC: enumerating through the
+    //     non-generic IEnumerable boxes each item, so the subscription would attach to a
+    //     temporary box the collection does not hold (the handler can never fire) while
+    //     _itemsListening roots that box. Skipping is both faster and more correct.
+    //   - A SEALED reference type that does not implement INPC has no INPC instances.
+    //   - Anything else (an INPC type, an open hierarchy, a non-generic collection)
+    //     may contain trackable items — walk as always.
+    private static bool MayContainTrackableItems(IEnumerable enumerable)
+    {
+        var foundElementType = false;
+
+        foreach (var i in enumerable.GetType().GetInterfaces())
+        {
+            if (!i.IsGenericType || i.GetGenericTypeDefinition() != typeof(IEnumerable<>))
+                continue;
+
+            var elementType = i.GetGenericArguments()[0];
+
+            if (elementType.IsValueType ||
+                (elementType.IsSealed && !typeof(INotifyPropertyChanged).IsAssignableFrom(elementType)))
+            {
+                foundElementType = true;
+                continue;
+            }
+
+            return true;
+        }
+
+        // Walk unless every element type was provably untrackable (a non-generic
+        // collection exposes no element type to prove anything about).
+        return !foundElementType;
+    }
+
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
+        if (!_walksItems)
+        {
+            // Untrackable items and no per-item callbacks: any change is just "redraw".
+            onChange();
+            return;
+        }
+
         switch (e.Action)
         {
             case NotifyCollectionChangedAction.Add:

--- a/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
@@ -203,11 +203,15 @@ public class CollectionDeepObserver : IObserver
         _onChange();
     }
 
+    // The `is not ValueType` guard: enumerating through the non-generic IEnumerable BOXES
+    // every struct, so an INPC-struct subscription would attach to that temporary box — a
+    // handler that can never fire — and root it in _itemsListening (mutated items then miss
+    // the value-equality Remove and leak past Dispose). Untrackable by nature, every ctor.
     private void OnItemsAdded(IEnumerable newItems)
     {
         foreach (var item in newItems)
         {
-            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem)
+            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem && item is not ValueType)
             {
                 if (_itemsListening.Add(inpcItem))
                 {
@@ -223,7 +227,8 @@ public class CollectionDeepObserver : IObserver
     {
         foreach (var item in oldItems)
         {
-            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem && _itemsListening.Remove(inpcItem))
+            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem && item is not ValueType
+                && _itemsListening.Remove(inpcItem))
             {
                 inpcItem.PropertyChanged -= OnItemPropertyChanged;
             }

--- a/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
@@ -25,15 +25,16 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-#if NET462
 using System.Linq;
-#endif
 
 namespace LiveChartsCore.Kernel.Observers;
 
 /// <summary>
-/// A Class that tracks both, <see cref="INotifyCollectionChanged.CollectionChanged"/> event and
-/// the <see cref="INotifyPropertyChanged.PropertyChanged"/> event of each element in the collection.
+/// A Class that tracks the <see cref="INotifyCollectionChanged.CollectionChanged"/> event of a
+/// collection and, when item tracking applies (it can be disabled for element types that can
+/// never be tracked — see <see cref="MayContainTrackableItems{T}"/> — and never applies to
+/// value-type items, whose subscription would attach to a temporary box), the
+/// <see cref="INotifyPropertyChanged.PropertyChanged"/> event of each element in the collection.
 /// </summary>
 public class CollectionDeepObserver : IObserver
 {
@@ -182,11 +183,10 @@ public class CollectionDeepObserver : IObserver
 
             case NotifyCollectionChangedAction.Reset:
 
-#if NET462
+                // Snapshot: OnItemsRemoved removes from _itemsListening while this iterates
+                // it — only .NET Core 3.0+ hash sets tolerate that, and this assembly also
+                // runs on older runtimes through the netstandard2.0 asset.
                 OnItemsRemoved(_itemsListening.ToArray());
-#else
-                OnItemsRemoved(_itemsListening);
-#endif
                 _itemsListening.Clear();
 
                 if (sender is IEnumerable enumerable)

--- a/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
@@ -41,6 +41,7 @@ public class CollectionDeepObserver : IObserver
     private readonly Action<object>? _onItemAdded;
     private readonly Action<object>? _onItemRemoved;
     private readonly bool _walksItems;
+    private readonly bool _tracksItemProperties;
     private readonly HashSet<INotifyPropertyChanged> _itemsListening = [];
     private IEnumerable? _trackedCollection;
 
@@ -55,7 +56,7 @@ public class CollectionDeepObserver : IObserver
     /// This action is also called for each item when the collection is initialized.
     /// </param>
     /// <param name="onItemRemoved">
-    /// if specified, this acction is called each time an item is removed in the collection.
+    /// if specified, this action is called each time an item is removed in the collection.
     /// This action is also called for each item when the collection is disposed.
     /// </param>
     public CollectionDeepObserver(
@@ -85,6 +86,10 @@ public class CollectionDeepObserver : IObserver
         _onChange = onChange;
         _onItemAdded = onItemAdded;
         _onItemRemoved = onItemRemoved;
+        // Per-item callbacks need the walk even when property tracking is off; the
+        // PropertyChanged subscription itself stays gated on _tracksItemProperties so a
+        // callback-driven walk over untrackable items never attaches handlers to boxes.
+        _tracksItemProperties = trackItemProperties;
         _walksItems = onItemAdded is not null || onItemRemoved is not null || trackItemProperties;
     }
 
@@ -202,7 +207,7 @@ public class CollectionDeepObserver : IObserver
     {
         foreach (var item in newItems)
         {
-            if (item is INotifyPropertyChanged inpcItem)
+            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem)
             {
                 if (_itemsListening.Add(inpcItem))
                 {
@@ -218,7 +223,7 @@ public class CollectionDeepObserver : IObserver
     {
         foreach (var item in oldItems)
         {
-            if (item is INotifyPropertyChanged inpcItem && _itemsListening.Remove(inpcItem))
+            if (_tracksItemProperties && item is INotifyPropertyChanged inpcItem && _itemsListening.Remove(inpcItem))
             {
                 inpcItem.PropertyChanged -= OnItemPropertyChanged;
             }

--- a/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
+++ b/src/LiveChartsCore/Kernel/Observers/CollectionDeepObserver.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -32,32 +32,79 @@ using System.Linq;
 namespace LiveChartsCore.Kernel.Observers;
 
 /// <summary>
-/// A Class that tracks both, <see cref="INotifyCollectionChanged.CollectionChanged"/> event and 
+/// A Class that tracks both, <see cref="INotifyCollectionChanged.CollectionChanged"/> event and
 /// the <see cref="INotifyPropertyChanged.PropertyChanged"/> event of each element in the collection.
 /// </summary>
-/// <remarks>
-/// Initializes a new instance of the <see cref="CollectionDeepObserver"/> class.
-/// </remarks>
-/// <param name="onChange">
-/// An action that is called when the collection items or a property in an item in the collection change.
-/// </param>
-/// <param name="onItemAdded">
-/// if specified, this action is called for each new item in the collection.
-/// This action is also called for each item when the collection is initialized.
-/// </param>
-/// <param name="onItemRemoved">
-/// if specified, this acction is called each time an item is removed in the collection.
-/// This action is also called for each item when the collection is disposed.
-/// </param>
-public class CollectionDeepObserver(
-    Action onChange,
-    Action<object>? onItemAdded = null,
-    Action<object>? onItemRemoved = null)
-        : IObserver
+public class CollectionDeepObserver : IObserver
 {
+    private readonly Action _onChange;
+    private readonly Action<object>? _onItemAdded;
+    private readonly Action<object>? _onItemRemoved;
+    private readonly bool _walksItems;
     private readonly HashSet<INotifyPropertyChanged> _itemsListening = [];
     private IEnumerable? _trackedCollection;
-    private bool _walksItems;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CollectionDeepObserver"/> class.
+    /// </summary>
+    /// <param name="onChange">
+    /// An action that is called when the collection items or a property in an item in the collection change.
+    /// </param>
+    /// <param name="onItemAdded">
+    /// if specified, this action is called for each new item in the collection.
+    /// This action is also called for each item when the collection is initialized.
+    /// </param>
+    /// <param name="onItemRemoved">
+    /// if specified, this acction is called each time an item is removed in the collection.
+    /// This action is also called for each item when the collection is disposed.
+    /// </param>
+    public CollectionDeepObserver(
+        Action onChange,
+        Action<object>? onItemAdded = null,
+        Action<object>? onItemRemoved = null)
+            : this(onChange, onItemAdded, onItemRemoved, trackItemProperties: true)
+    { }
+
+    /// <inheritdoc cref="CollectionDeepObserver(Action, Action{object}?, Action{object}?)"/>
+    /// <param name="onChange">See the other overload.</param>
+    /// <param name="onItemAdded">See the other overload.</param>
+    /// <param name="onItemRemoved">See the other overload.</param>
+    /// <param name="trackItemProperties">
+    /// Whether items could need <see cref="INotifyPropertyChanged"/> tracking — generic callers
+    /// decide statically via <see cref="MayContainTrackableItems{T}"/>. When <c>false</c> and no
+    /// per-item callbacks are registered, the per-item walk is skipped entirely: it is O(N) and
+    /// boxes every struct, which at large-data scale (a multi-million-point <c>double[]</c> or
+    /// struct collection assigned to a series) measures in SECONDS of pure overhead per assignment.
+    /// </param>
+    public CollectionDeepObserver(
+        Action onChange,
+        Action<object>? onItemAdded,
+        Action<object>? onItemRemoved,
+        bool trackItemProperties)
+    {
+        _onChange = onChange;
+        _onItemAdded = onItemAdded;
+        _onItemRemoved = onItemRemoved;
+        _walksItems = onItemAdded is not null || onItemRemoved is not null || trackItemProperties;
+    }
+
+    /// <summary>
+    /// Whether any instance of <typeparamref name="T"/> could ever need
+    /// <see cref="INotifyPropertyChanged"/> tracking:
+    /// <list type="bullet">
+    /// <item>A VALUE TYPE never can — even one implementing INPC: enumerating through the
+    /// non-generic <see cref="IEnumerable"/> boxes each item, so the subscription would attach
+    /// to a temporary box the collection does not hold (the handler can never fire) while the
+    /// observer roots that box. Skipping is both faster and more correct.</item>
+    /// <item>A SEALED reference type that does not implement INPC has no INPC instances.</item>
+    /// <item>Anything else (an INPC type, an open hierarchy) may contain trackable items.</item>
+    /// </list>
+    /// Evaluated on the statically-known type only — AOT/trimmer safe, no reflection over
+    /// the collection instance.
+    /// </summary>
+    public static bool MayContainTrackableItems<T>() =>
+        !typeof(T).IsValueType &&
+        (!typeof(T).IsSealed || typeof(INotifyPropertyChanged).IsAssignableFrom(typeof(T)));
 
     /// <inheritdoc cref="IObserver.Initialize(object?)"/>
     public void Initialize(object? instance)
@@ -73,13 +120,6 @@ public class CollectionDeepObserver(
         if (instance is INotifyCollectionChanged incc)
             incc.CollectionChanged += OnCollectionChanged;
 
-        // The per-item walk exists to subscribe INotifyPropertyChanged items and to raise
-        // the per-item callbacks. When neither can ever apply — no callbacks registered
-        // and the element type provably has no trackable instances — skip it entirely:
-        // the walk is O(N) and boxes every struct, which at large-data scale (a multi-
-        // million-point double[] or struct[] assigned to Series.Values) measures in
-        // SECONDS of pure overhead on every assignment.
-        _walksItems = onItemAdded is not null || onItemRemoved is not null || MayContainTrackableItems(enumerable);
         if (_walksItems)
             OnItemsAdded(enumerable);
 
@@ -100,48 +140,12 @@ public class CollectionDeepObserver(
         _trackedCollection = null;
     }
 
-    // Whether any instance in the collection could ever need PropertyChanged tracking,
-    // decided from the collection's IEnumerable<T> element type(s):
-    //
-    //   - A VALUE TYPE never can — even one implementing INPC: enumerating through the
-    //     non-generic IEnumerable boxes each item, so the subscription would attach to a
-    //     temporary box the collection does not hold (the handler can never fire) while
-    //     _itemsListening roots that box. Skipping is both faster and more correct.
-    //   - A SEALED reference type that does not implement INPC has no INPC instances.
-    //   - Anything else (an INPC type, an open hierarchy, a non-generic collection)
-    //     may contain trackable items — walk as always.
-    private static bool MayContainTrackableItems(IEnumerable enumerable)
-    {
-        var foundElementType = false;
-
-        foreach (var i in enumerable.GetType().GetInterfaces())
-        {
-            if (!i.IsGenericType || i.GetGenericTypeDefinition() != typeof(IEnumerable<>))
-                continue;
-
-            var elementType = i.GetGenericArguments()[0];
-
-            if (elementType.IsValueType ||
-                (elementType.IsSealed && !typeof(INotifyPropertyChanged).IsAssignableFrom(elementType)))
-            {
-                foundElementType = true;
-                continue;
-            }
-
-            return true;
-        }
-
-        // Walk unless every element type was provably untrackable (a non-generic
-        // collection exposes no element type to prove anything about).
-        return !foundElementType;
-    }
-
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (!_walksItems)
         {
             // Untrackable items and no per-item callbacks: any change is just "redraw".
-            onChange();
+            _onChange();
             return;
         }
 
@@ -191,7 +195,7 @@ public class CollectionDeepObserver(
                 break;
         }
 
-        onChange();
+        _onChange();
     }
 
     private void OnItemsAdded(IEnumerable newItems)
@@ -206,7 +210,7 @@ public class CollectionDeepObserver(
                 }
             }
 
-            onItemAdded?.Invoke(item);
+            _onItemAdded?.Invoke(item);
         }
     }
 
@@ -219,9 +223,9 @@ public class CollectionDeepObserver(
                 inpcItem.PropertyChanged -= OnItemPropertyChanged;
             }
 
-            onItemRemoved?.Invoke(item);
+            _onItemRemoved?.Invoke(item);
         }
     }
 
-    private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e) => onChange();
+    private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e) => _onChange();
 }

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -115,7 +115,11 @@ public abstract class Series<TModel, TVisual, TLabel>
         if (typeof(IVariableSvgPath).IsAssignableFrom(typeof(TVisual)))
             SeriesProperties |= SeriesProperties.IsSVGPath;
 
-        _observer = new CollectionDeepObserver(NotifySubscribers);
+        // The per-item INPC walk is skipped statically when no TModel instance could ever
+        // be tracked (value types, sealed non-INPC classes) — at large-data scale the walk
+        // is seconds of boxing per Values assignment, for nothing.
+        _observer = new CollectionDeepObserver(
+            NotifySubscribers, null, null, CollectionDeepObserver.MayContainTrackableItems<TModel>());
 
         Values = values;
     }

--- a/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using CoreTests.MockedObjects;
+using LiveChartsCore.Kernel.Observers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+// The observer's per-item walk (subscribe INotifyPropertyChanged on every item) is
+// skipped when no instance could ever need it: value-type elements (enumeration boxes
+// each item, so a subscription would attach to a temporary box the collection does not
+// hold) and sealed non-INPC elements. Collection-level notifications still redraw, and
+// per-item callbacks (the chart-level Series/Axes observers) always force the walk.
+[TestClass]
+public class CollectionDeepObserverSkipTests
+{
+    private struct InpcValue : INotifyPropertyChanged
+    {
+        public static int Subscriptions;
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add => Subscriptions++;
+            remove { }
+        }
+    }
+
+    [TestMethod]
+    public void InpcStructItems_AreNotSubscribed()
+    {
+        // Subscribing a struct's PropertyChanged through the walk attaches the handler to
+        // the enumeration's TEMPORARY BOX — it can never fire, and the box stays rooted
+        // in the observer. The walk must be skipped for value types entirely.
+        InpcValue.Subscriptions = 0;
+        var collection = new ObservableCollection<InpcValue> { new(), new() };
+
+        var observer = new TestObserver<InpcValue>
+        {
+            MyCollection = collection
+        };
+
+        Assert.AreEqual(0, InpcValue.Subscriptions, "a boxed-copy subscription can never fire — it must not be made");
+
+        collection.Add(new InpcValue());
+        Assert.AreEqual(1, observer.ChangesCount, "collection changes still redraw");
+        Assert.AreEqual(0, InpcValue.Subscriptions, "per-change items are not subscribed either");
+    }
+
+    [TestMethod]
+    public void ValueTypeItems_StillRedrawOnEveryCollectionChange()
+    {
+        var collection = new ObservableCollection<int> { 1, 2, 3 };
+        var observer = new TestObserver<int>
+        {
+            MyCollection = collection
+        };
+
+        collection.Add(4);
+        Assert.AreEqual(1, observer.ChangesCount, "Add redraws");
+
+        collection.RemoveAt(0);
+        Assert.AreEqual(2, observer.ChangesCount, "Remove redraws");
+
+        collection.Clear();
+        Assert.AreEqual(3, observer.ChangesCount, "Reset redraws");
+
+        observer.Dispose(); // the skipped walk must not break the symmetric dispose
+    }
+
+    [TestMethod]
+    public void PerItemCallbacks_ForceTheWalk()
+    {
+        // The chart-level observers (Series/Axes/Sections) rely on per-item add/remove
+        // callbacks — those must keep walking even for value-type elements.
+        var seen = new List<object>();
+        var observer = new CollectionDeepObserver(() => { }, onItemAdded: seen.Add);
+
+        var collection = new ObservableCollection<int> { 1, 2, 3 };
+        observer.Initialize(collection);
+        Assert.AreEqual(3, seen.Count, "initialization raises the callback per existing item");
+
+        collection.Add(4);
+        Assert.AreEqual(4, seen.Count, "changes raise the callback per added item");
+
+        observer.Dispose();
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
@@ -112,6 +112,25 @@ public class CollectionDeepObserverSkipTests
     }
 
     [TestMethod]
+    public void DefaultCtorWalk_NeverSubscribesInpcStructs()
+    {
+        // Defense in depth: even when the walk runs with tracking ON (the default 3-arg
+        // ctor — non-generic callers can't use the static gate), an INPC STRUCT must not
+        // be subscribed: the handler would attach to the enumeration's temporary box and
+        // root it in the observer.
+        InpcValue.Subscriptions = 0;
+        var observer = new CollectionDeepObserver(() => { });
+
+        var collection = new ObservableCollection<InpcValue> { new(), new() };
+        observer.Initialize(collection);
+        collection.Add(new InpcValue());
+
+        Assert.AreEqual(0, InpcValue.Subscriptions, "boxed-copy subscriptions can never fire — none may be made");
+
+        observer.Dispose();
+    }
+
+    [TestMethod]
     public void CallbackWalk_WithTrackingOff_DoesNotSubscribeInpc()
     {
         // The walk can be forced by per-item callbacks while property tracking is off

--- a/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
@@ -7,11 +7,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CoreTests.CoreObjectsTests;
 
-// The observer's per-item walk (subscribe INotifyPropertyChanged on every item) is
-// skipped when no instance could ever need it: value-type elements (enumeration boxes
-// each item, so a subscription would attach to a temporary box the collection does not
-// hold) and sealed non-INPC elements. Collection-level notifications still redraw, and
-// per-item callbacks (the chart-level Series/Axes observers) always force the walk.
+// The observer's per-item walk (subscribe INotifyPropertyChanged on every item) is gated
+// STATICALLY by the generic caller on the element type — no reflection over the collection
+// instance, AOT/trimmer safe. Value types never walk (enumeration boxes each item, so a
+// subscription would attach to a temporary box the collection does not hold), sealed
+// non-INPC classes never walk; collection-level notifications still redraw, and per-item
+// callbacks (the chart-level Series/Axes observers) always force the walk.
 [TestClass]
 public class CollectionDeepObserverSkipTests
 {
@@ -24,6 +25,26 @@ public class CollectionDeepObserverSkipTests
             add => Subscriptions++;
             remove { }
         }
+    }
+
+    private sealed class SealedPlain { }
+    private sealed class SealedInpc : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
+    }
+    private class OpenPlain { }
+
+    [TestMethod]
+    public void StaticGate_DecidesByElementType()
+    {
+        Assert.IsFalse(CollectionDeepObserver.MayContainTrackableItems<int>(), "primitives never need tracking");
+        Assert.IsFalse(CollectionDeepObserver.MayContainTrackableItems<InpcValue>(), "an INPC STRUCT subscription lands on a dead box — untrackable");
+        Assert.IsFalse(CollectionDeepObserver.MayContainTrackableItems<SealedPlain>(), "a sealed non-INPC class has no INPC instances");
+
+        Assert.IsTrue(CollectionDeepObserver.MayContainTrackableItems<SealedInpc>(), "a sealed INPC class is tracked");
+        Assert.IsTrue(CollectionDeepObserver.MayContainTrackableItems<OpenPlain>(), "an open hierarchy may hold INPC-derived instances");
+        Assert.IsTrue(CollectionDeepObserver.MayContainTrackableItems<object>(), "object may hold anything");
+        Assert.IsTrue(CollectionDeepObserver.MayContainTrackableItems<INotifyPropertyChanged>(), "the interface itself is trackable");
     }
 
     [TestMethod]
@@ -72,9 +93,10 @@ public class CollectionDeepObserverSkipTests
     public void PerItemCallbacks_ForceTheWalk()
     {
         // The chart-level observers (Series/Axes/Sections) rely on per-item add/remove
-        // callbacks — those must keep walking even for value-type elements.
+        // callbacks — those must keep walking even for untrackable element types.
         var seen = new List<object>();
-        var observer = new CollectionDeepObserver(() => { }, onItemAdded: seen.Add);
+        var observer = new CollectionDeepObserver(
+            () => { }, onItemAdded: seen.Add, onItemRemoved: null, trackItemProperties: false);
 
         var collection = new ObservableCollection<int> { 1, 2, 3 };
         observer.Initialize(collection);

--- a/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CollectionDeepObserverSkipTests.cs
@@ -20,9 +20,12 @@ public class CollectionDeepObserverSkipTests
     {
         public static int Subscriptions;
 
+        private static void IncrementSubscriptions() =>
+            _ = System.Threading.Interlocked.Increment(ref Subscriptions);
+
         public event PropertyChangedEventHandler? PropertyChanged
         {
-            add => Subscriptions++;
+            add => IncrementSubscriptions();
             remove { }
         }
     }
@@ -104,6 +107,30 @@ public class CollectionDeepObserverSkipTests
 
         collection.Add(4);
         Assert.AreEqual(4, seen.Count, "changes raise the callback per added item");
+
+        observer.Dispose();
+    }
+
+    [TestMethod]
+    public void CallbackWalk_WithTrackingOff_DoesNotSubscribeInpc()
+    {
+        // The walk can be forced by per-item callbacks while property tracking is off
+        // (untrackable element types): the callbacks must fire per item, but no
+        // PropertyChanged subscription may be made — for value types that subscription
+        // would land on the enumeration's temporary box and root it.
+        InpcValue.Subscriptions = 0;
+        var seen = new List<object>();
+        var observer = new CollectionDeepObserver(
+            () => { }, onItemAdded: seen.Add, onItemRemoved: null, trackItemProperties: false);
+
+        var collection = new ObservableCollection<InpcValue> { new(), new() };
+        observer.Initialize(collection);
+        Assert.AreEqual(2, seen.Count, "the callback walk still runs");
+        Assert.AreEqual(0, InpcValue.Subscriptions, "no PropertyChanged subscription on a walked box");
+
+        collection.Add(new InpcValue());
+        Assert.AreEqual(3, seen.Count);
+        Assert.AreEqual(0, InpcValue.Subscriptions, "per-change items are not subscribed either");
 
         observer.Dispose();
     }

--- a/tests/CoreTests/MockedObjects/TestObserver.cs
+++ b/tests/CoreTests/MockedObjects/TestObserver.cs
@@ -10,7 +10,10 @@ public class TestObserver<T> : IDisposable
 
     public TestObserver()
     {
-        _observerer = new CollectionDeepObserver(() => ChangesCount++);
+        // Mirrors Series<TModel>: the per-item INPC walk is gated statically on the
+        // element type (value types and sealed non-INPC classes never walk).
+        _observerer = new CollectionDeepObserver(
+            () => ChangesCount++, null, null, CollectionDeepObserver.MayContainTrackableItems<T>());
     }
 
     public IEnumerable<T> MyCollection


### PR DESCRIPTION
## The problem

`CollectionDeepObserver` walks **every item** of a collection on `Initialize` (i.e. on every `Series.Values` assignment) and the changed items on every notification, to subscribe `INotifyPropertyChanged`. The walk enumerates through the non-generic `IEnumerable`, which **boxes every struct item**.

For large value-type data this is pure overhead: assigning a multi-million-point `double[]` or struct collection to `Series.Values` spends seconds boxing items (tens of seconds at the extreme end), and the walk can never find anything to track:

- No **value-type** instance can usefully be tracked — the subscription attaches to the enumeration's *temporary box*, a handler that can never fire. Worse, the box is left rooted in `_itemsListening`, so today an INPC struct collection silently leaks dead boxes.
- A **sealed** reference type that does not implement INPC provably has no INPC instances.

## The fix

The walk decision is made **statically by the generic callers** — `Series<TModel>` and `CoreHeatLandSeries<TModel>` evaluate `CollectionDeepObserver.MayContainTrackableItems<TModel>()` (value type, or sealed non-INPC ⇒ skip) and pass it to a new constructor overload. No reflection over the collection instance, so the change is **AOT- and trimmer-safe** (no IL2075/IL3050), allocation-free, and gates on the exact `TModel` the series consumes.

Everything else is untouched:

- INPC types, open class hierarchies and `object` element types walk exactly as before (pinned by the existing `ChangesCountTest`).
- Per-item callbacks (the chart-level Series/Axes/Sections observers) always force the walk.
- Collection-change notifications still trigger a redraw in every case.
- The existing 3-parameter constructor keeps the always-walk behavior — source and binary compatible.

## Tests

- `MayContainTrackableItems<T>` truth table: primitives / INPC structs / sealed plain classes skip; sealed INPC / open hierarchies / `object` / interfaces walk.
- An INPC **struct** collection makes zero `PropertyChanged` subscriptions (counter in the event accessor — fails before the fix, and pins the box-leak fix).
- Value-type collections still redraw on Add/Remove/Reset and dispose cleanly.
- Per-item callbacks keep walking on init and per change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)