### PR TITLE
perf: the NativeTicker should invalidate the rendering only when the canvas is invalid

### DIFF
--- a/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
+++ b/src/LiveChartsCore/Motion/CoreMotionCanvas.cs
@@ -114,6 +114,14 @@ public class CoreMotionCanvas : IDisposable
     public event Action<CoreMotionCanvas>? Validated;
 
     /// <summary>
+    /// Occurs after a frame has been drawn (once <see cref="IsValid"/> has been updated
+    /// for that frame), whether or not the canvas is now valid. A frame ticker can use
+    /// this to drive a self-paced loop: request another frame while the canvas is still
+    /// invalid, and stop once it becomes valid.
+    /// </summary>
+    public event Action<CoreMotionCanvas>? FrameRendered;
+
+    /// <summary>
     /// Returns true if the visual is valid.
     /// </summary>
     /// <value>
@@ -284,6 +292,10 @@ public class CoreMotionCanvas : IDisposable
 
             _nextFrameDelay = frameDelay;
         }
+
+        // IsValid (and, for the non-vsync path, _nextFrameDelay) are now finalized for
+        // this frame, so it is safe for a ticker to decide whether to request another.
+        FrameRendered?.Invoke(this);
     }
 
     /// <summary>

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
@@ -29,7 +29,6 @@
 // but by design this file is separated so in the future if there are any uno specific changes
 
 using LiveChartsCore.Motion;
-using Microsoft.UI.Xaml.Media;
 
 namespace LiveChartsCore.Native;
 
@@ -44,28 +43,32 @@ internal partial class NativeFrameTicker : IFrameTicker
         _renderMode = renderMode;
 
         _canvas.Invalidated += OnCoreInvalidated;
-        CompositionTarget.Rendering += OnCompositonTargetRendering;
+        _canvas.FrameRendered += OnFrameRendered;
 
-        CoreMotionCanvas.s_tickerName = "CompositionTarget.Rendering WinUI";
+        CoreMotionCanvas.s_tickerName = "SKCanvasElement self-paced (Uno)";
+
+        if (!_canvas.IsValid) OnCoreInvalidated(_canvas);
     }
 
     private void OnCoreInvalidated(CoreMotionCanvas obj) =>
-        _renderMode.InvalidateRenderer();
+        _renderMode?.InvalidateRenderer();
 
-    private void OnCompositonTargetRendering(object? sender, object e)
+    private void OnFrameRendered(CoreMotionCanvas obj)
     {
-        if (_canvas is null || _canvas.IsValid) return;
-        _renderMode.InvalidateRenderer();
+        if (_canvas is not null && !_canvas.IsValid)
+            _renderMode.InvalidateRenderer();
     }
 
     public void DisposeTicker()
     {
-        CompositionTarget.Rendering -= OnCompositonTargetRendering;
-
         // _canvas can be null when DisposeTicker is called without a prior
         // InitializeTicker, or twice in a row — same #2216 contract violation
         // guarded in the WPF CompositionTargetTicker.
-        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
+        if (_canvas is not null)
+        {
+            _canvas.Invalidated -= OnCoreInvalidated;
+            _canvas.FrameRendered -= OnFrameRendered;
+        }
 
         _canvas = null!;
         _renderMode = null!;

--- a/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
@@ -24,7 +24,9 @@
 
 // reachable on winui, maui winui, uno winui
 
+using System;
 using LiveChartsCore.Motion;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media;
 
 namespace LiveChartsCore.Native;
@@ -33,38 +35,69 @@ internal partial class NativeFrameTicker : IFrameTicker
 {
     private IRenderMode _renderMode = null!;
     private CoreMotionCanvas _canvas = null!;
+    private DispatcherQueue _dispatcher = null!;
+    private bool _isSubscribed;
 
     public void InitializeTicker(CoreMotionCanvas canvas, IRenderMode renderMode)
     {
         _canvas = canvas;
         _renderMode = renderMode;
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
 
         _canvas.Invalidated += OnCoreInvalidated;
-        CompositionTarget.Rendering += OnCompositonTargetRendering;
+        _canvas.Validated += OnCoreValidated;
 
         CoreMotionCanvas.s_tickerName = "CompositionTarget.Rendering WinUI";
+
+        if (!_canvas.IsValid) OnCoreInvalidated(_canvas);
     }
 
-    private void OnCoreInvalidated(CoreMotionCanvas obj) =>
-        _renderMode.InvalidateRenderer();
+    private void OnCoreInvalidated(CoreMotionCanvas obj) => RunOnUI(StartLoop);
+
+    private void OnCoreValidated(CoreMotionCanvas obj) => RunOnUI(StopLoop);
+
+    private void StartLoop()
+    {
+        if (_isSubscribed || _canvas is null) return;
+        _isSubscribed = true;
+        CompositionTarget.Rendering += OnCompositonTargetRendering;
+    }
+
+    private void StopLoop()
+    {
+        if (!_isSubscribed) return;
+        _isSubscribed = false;
+        CompositionTarget.Rendering -= OnCompositonTargetRendering;
+    }
 
     private void OnCompositonTargetRendering(object? sender, object e)
     {
-        if (_canvas is null || _canvas.IsValid) return;
+        if (_canvas is null || _canvas.IsValid) { StopLoop(); return; }
         _renderMode.InvalidateRenderer();
+    }
+
+    private void RunOnUI(Action action)
+    {
+        if (_dispatcher is null || _dispatcher.HasThreadAccess) action();
+        else _ = _dispatcher.TryEnqueue(() => action());
     }
 
     public void DisposeTicker()
     {
-        CompositionTarget.Rendering -= OnCompositonTargetRendering;
+        StopLoop();
 
         // _canvas can be null when DisposeTicker is called without a prior
         // InitializeTicker, or twice in a row — same #2216 contract violation
         // guarded in the WPF CompositionTargetTicker.
-        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
+        if (_canvas is not null)
+        {
+            _canvas.Invalidated -= OnCoreInvalidated;
+            _canvas.Validated -= OnCoreValidated;
+        }
 
         _canvas = null!;
         _renderMode = null!;
+        _dispatcher = null!;
     }
 }
 

--- a/tests/SharedUITests/CartesianChartTests.cs
+++ b/tests/SharedUITests/CartesianChartTests.cs
@@ -98,9 +98,7 @@ public class CartesianChartTests
         await App.PopNavigation();
         await App.NavigateToView(sut);
 
-        // ToDo: improve this method? as a workaround for now we just wait for some time
-        // await sut.Chart.WaitUntilChartRenders();
-        await Task.Delay(2000);
+        await sut.Chart.WaitUntilChartLoadsAndRenders();
 
         Assert.ChartIsLoaded(sut.Chart);
 #endif

--- a/tests/SharedUITests/Helpers/UIHelpersExtensions.cs
+++ b/tests/SharedUITests/Helpers/UIHelpersExtensions.cs
@@ -49,6 +49,33 @@ public static class UIHelpersExtensions
 
     extension(IChartView chartView)
     {
+        public async Task WaitUntilChartLoadsAndRenders(int timeoutMs = 10000, int pollMs = 50)
+        {
+            bool HasRenderedPoints()
+            {
+                if (!chartView.CoreChart.IsLoaded)
+                    return false;
+
+                var points = (chartView.Series ?? [])
+                    .SelectMany(s => s.Fetch(chartView.CoreChart))
+                    .ToArray();
+
+                // mirrors Assert.ChartIsLoaded: non-empty, every point has a positioned visual
+                return points.Length > 0 && points.All(p =>
+                {
+                    var v = p.Context.Visual;
+                    return v is not null && v.X > 0 && v.Y > 0;
+                });
+            }
+
+            var waited = 0;
+            while (waited < timeoutMs && !HasRenderedPoints())
+            {
+                await Task.Delay(pollMs);
+                waited += pollMs;
+            }
+        }
+
         public Task WaitUntilChartRenders()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/tests/SharedUITests/PieChartTests.cs
+++ b/tests/SharedUITests/PieChartTests.cs
@@ -47,9 +47,7 @@ public class PieChartTests
         await App.PopNavigation();
         await App.NavigateToView(sut);
 
-        // ToDo: improve this method? as a workaround for now we just wait for some time
-        // await sut.Chart.WaitUntilChartRenders();
-        await Task.Delay(2000);
+        await sut.Chart.WaitUntilChartLoadsAndRenders();
 
         Assert.ChartIsLoaded(sut.Chart);
 #endif


### PR DESCRIPTION
Currently, the NativeTicker will cause the UI to refresh continuously (up to the refresh rate of the screen) in WinUI and Uno Platform because CompositionTarget.Rendering's contract does that as long as you're subscribed. Instead, we should only refresh when the canvas is not IsValid.