### PR TITLE
Backport: Uno self-paced renderer (#2338) to v2.0.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
 
     <LiveChartsVersionSuffix></LiveChartsVersionSuffix>
-    <LiveChartsVersion>2.0.1</LiveChartsVersion>
+    <LiveChartsVersion>2.0.5</LiveChartsVersion>
     <LiveChartsCodeGenVersion>1.0.1</LiveChartsCodeGenVersion>
     <LiveChartsAuthors>BetoRodriguez</LiveChartsAuthors>
 

--- a/src/LiveChartsCore/Motion/AsyncLoopTicker.cs
+++ b/src/LiveChartsCore/Motion/AsyncLoopTicker.cs
@@ -37,6 +37,11 @@ internal class AsyncLoopTicker : IFrameTicker
 
         _canvas.Invalidated += OnCoreInvalidated;
         CoreMotionCanvas.s_tickerName = nameof(AsyncLoopTicker);
+
+        // the canvas may have been invalidated before the ticker subscribed
+        // (e.g. the chart engine measures before the view raises Loaded), in
+        // that case no Invalidated event will ever come, start the loop now.
+        if (!_canvas.IsValid) OnCoreInvalidated(_canvas);
     }
 
     private void OnCoreInvalidated(CoreMotionCanvas obj) =>

--- a/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/UnoSkiaRenderer/NativeTicker.cs
@@ -25,51 +25,23 @@
 // reachable on uno skia renderer
 // HAS_OS_LVC is true when the target framework contains any of the following:
 // -windows, -android, -ios, -maccatalyst, -tizen
-// currently this is the the same file as WinUI, because uno makes this work across platforms
-// but by design this file is separated so in the future if there are any uno specific changes
+// This is a dummy class, when Uno SkiaRenderer is used, we don't need a ticker, the control itself
+// can (and should) pace frame requests. This class is needed for compatibility with Native implementations that use
+// the ticker to request frames, like CAD display link on iOS, Choreographer on Android or CompositionTarget.Rendering on Windows.
 
 using LiveChartsCore.Motion;
-using Microsoft.UI.Xaml.Media;
 
 namespace LiveChartsCore.Native;
 
 internal partial class NativeFrameTicker : IFrameTicker
 {
-    private IRenderMode _renderMode = null!;
-    private CoreMotionCanvas _canvas = null!;
-
-    public void InitializeTicker(CoreMotionCanvas canvas, IRenderMode renderMode)
-    {
-        _canvas = canvas;
-        _renderMode = renderMode;
-
-        _canvas.Invalidated += OnCoreInvalidated;
-        CompositionTarget.Rendering += OnCompositonTargetRendering;
-
-        CoreMotionCanvas.s_tickerName = "CompositionTarget.Rendering WinUI";
-    }
-
-    private void OnCoreInvalidated(CoreMotionCanvas obj) =>
-        _renderMode.InvalidateRenderer();
-
-    private void OnCompositonTargetRendering(object? sender, object e)
-    {
-        if (_canvas is null || _canvas.IsValid) return;
-        _renderMode.InvalidateRenderer();
-    }
+    public void InitializeTicker(CoreMotionCanvas canvas, IRenderMode renderMode) =>
+        // no real ticker here: Uno's skia renderer paces the frames itself.
+        // still report a name so the FPS/debug overlay does not show an empty ticker.
+        CoreMotionCanvas.s_tickerName = "self-paced by Uno's skia renderer";
 
     public void DisposeTicker()
-    {
-        CompositionTarget.Rendering -= OnCompositonTargetRendering;
-
-        // _canvas can be null when DisposeTicker is called without a prior
-        // InitializeTicker, or twice in a row — same #2216 contract violation
-        // guarded in the WPF CompositionTargetTicker.
-        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
-
-        _canvas = null!;
-        _renderMode = null!;
-    }
+    { }
 }
 
 #endif

--- a/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
+++ b/src/_Shared.Native/Platforms/WinUI/NativeTicker.cs
@@ -24,7 +24,9 @@
 
 // reachable on winui, maui winui, uno winui
 
+using System;
 using LiveChartsCore.Motion;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media;
 
 namespace LiveChartsCore.Native;
@@ -33,38 +35,69 @@ internal partial class NativeFrameTicker : IFrameTicker
 {
     private IRenderMode _renderMode = null!;
     private CoreMotionCanvas _canvas = null!;
+    private DispatcherQueue _dispatcher = null!;
+    private bool _isSubscribed;
 
     public void InitializeTicker(CoreMotionCanvas canvas, IRenderMode renderMode)
     {
         _canvas = canvas;
         _renderMode = renderMode;
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
 
         _canvas.Invalidated += OnCoreInvalidated;
-        CompositionTarget.Rendering += OnCompositonTargetRendering;
+        _canvas.Validated += OnCoreValidated;
 
         CoreMotionCanvas.s_tickerName = "CompositionTarget.Rendering WinUI";
+
+        if (!_canvas.IsValid) OnCoreInvalidated(_canvas);
     }
 
-    private void OnCoreInvalidated(CoreMotionCanvas obj) =>
-        _renderMode.InvalidateRenderer();
+    private void OnCoreInvalidated(CoreMotionCanvas obj) => RunOnUI(StartLoop);
+
+    private void OnCoreValidated(CoreMotionCanvas obj) => RunOnUI(StopLoop);
+
+    private void StartLoop()
+    {
+        if (_isSubscribed || _canvas is null) return;
+        _isSubscribed = true;
+        CompositionTarget.Rendering += OnCompositonTargetRendering;
+    }
+
+    private void StopLoop()
+    {
+        if (!_isSubscribed) return;
+        _isSubscribed = false;
+        CompositionTarget.Rendering -= OnCompositonTargetRendering;
+    }
 
     private void OnCompositonTargetRendering(object? sender, object e)
     {
-        if (_canvas is null || _canvas.IsValid) return;
+        if (_canvas is null || _canvas.IsValid) { StopLoop(); return; }
         _renderMode.InvalidateRenderer();
+    }
+
+    private void RunOnUI(Action action)
+    {
+        if (_dispatcher is null || _dispatcher.HasThreadAccess) action();
+        else _ = _dispatcher.TryEnqueue(() => action());
     }
 
     public void DisposeTicker()
     {
-        CompositionTarget.Rendering -= OnCompositonTargetRendering;
+        StopLoop();
 
         // _canvas can be null when DisposeTicker is called without a prior
         // InitializeTicker, or twice in a row — same #2216 contract violation
         // guarded in the WPF CompositionTargetTicker.
-        if (_canvas is not null) _canvas.Invalidated -= OnCoreInvalidated;
+        if (_canvas is not null)
+        {
+            _canvas.Invalidated -= OnCoreInvalidated;
+            _canvas.Validated -= OnCoreValidated;
+        }
 
         _canvas = null!;
         _renderMode = null!;
+        _dispatcher = null!;
     }
 }
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp.Avalonia/MotionCanvas.cs
@@ -44,7 +44,6 @@ public class MotionCanvas : UserControl
 
     static MotionCanvas()
     {
-        SkiaSharpDrawingContext.s_clearCanvasOnNewFrame = false;
         _ = LiveChartsSkiaSharp.EnsureInitialized();
     }
 
@@ -119,7 +118,8 @@ public class MotionCanvas : UserControl
             using var lease = leaseFeature.Lease();
 
             motionCanvas.DrawFrame(
-                new SkiaSharpDrawingContext(motionCanvas, lease.SkCanvas, background));
+                new SkiaSharpDrawingContext(
+                    motionCanvas, lease.SkCanvas, background, clearCanvasOnNewFrame: false));
         }
 
         public void Dispose() { }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -38,11 +38,26 @@ namespace LiveChartsCore.SkiaSharpView.Drawing;
 /// <param name="canvas">The canvas.</param>
 /// <param name="background">The background color.</param>
 /// <param name="clearBlendMode">The blend mode to use when clearing the canvas. Default is <see cref="SKBlendMode.SrcIn"/>.</param>
+/// <param name="clearCanvasOnNewFrame">
+/// Whether the canvas should be cleared at the beginning of each frame.
+/// Avalonia and Uno-Skia hosts clear the surface themselves before invoking
+/// <see cref="DrawingContext.OnBeginDraw"/>, so they pass <c>false</c>. Default
+/// <c>true</c> for hosts where SkiaSharp owns the surface and must clear it
+/// explicitly (WPF, MAUI, WinForms, Blazor, in-memory).
+/// </param>
 public class SkiaSharpDrawingContext(
-    CoreMotionCanvas motionCanvas, SKCanvas canvas, SKColor background, SKBlendMode clearBlendMode = SKBlendMode.SrcIn)
+    CoreMotionCanvas motionCanvas,
+    SKCanvas canvas,
+    SKColor background,
+    SKBlendMode clearBlendMode = SKBlendMode.SrcIn,
+    bool clearCanvasOnNewFrame = true)
         : DrawingContext
 {
-    internal static bool s_clearCanvasOnNewFrame = true;
+    /// <summary>
+    /// Gets a value indicating whether the canvas is cleared at the beginning of
+    /// each frame. See the constructor parameter of the same name.
+    /// </summary>
+    public bool ClearCanvasOnNewFrame { get; } = clearCanvasOnNewFrame;
 
     /// <summary>
     /// Gets or sets the motion canvas.
@@ -112,7 +127,7 @@ public class SkiaSharpDrawingContext(
 
     internal override void OnBeginDraw()
     {
-        if (!s_clearCanvasOnNewFrame)
+        if (!ClearCanvasOnNewFrame)
             return;
 
         // clear the canvas with the background color if it's fully opaque

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/LiveChartsCore.SkiaSharpView.Uno.WinUI.csproj
@@ -59,6 +59,15 @@
        Condition="!$(TargetFramework.Contains('-windows'))"
        Include="SkiaSharp.Views.Uno.WinUI"
        Version="$(LatestSkiaSharpVersion)" />
+    <!--
+    On WASM with Uno's native renderer the charts shape text through HarfBuzzSharp
+    directly, so the wasm relink needs libHarfBuzzSharp; the Skia renderer brings it
+    on its own, the native renderer does not (#2020, #2333).
+    -->
+    <PackageReference
+       Condition="$(TargetFramework.Contains('-browserwasm'))"
+       Include="HarfBuzzSharp.NativeAssets.WebAssembly"
+       Version="$(HarfBuzzWASMVersion)" />
   </ItemGroup>
 
   <!-- Include Uno skia renderer if needed -->

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
@@ -56,8 +56,13 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
     public void InitializeRenderMode(CoreMotionCanvas canvas) =>
         _renderMode.InitializeRenderMode(canvas);
 
-    public void DisposeRenderMode() =>
+    public void DisposeRenderMode()
+    {
+        // delegate to the nested render mode so the canvas invalidation
+        // subscription is removed, then release the native element.
+        _renderMode.DisposeRenderMode();
         _renderMode.Dispose();
+    }
 
     public void InvalidateRenderer() =>
         _renderMode.InvalidateRenderer();
@@ -75,23 +80,41 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
             IsHitTestVisible = true;
 
             _canvas = canvas;
-            CoreMotionCanvas.s_externalRenderer = $"{nameof(SkiaRenderMode)} via {nameof(SKCanvasElement)}";
+            CoreMotionCanvas.s_externalRenderer = $"{nameof(SkiaRenderMode)} via {nameof(SKCanvasElement)} (Uno self-paced)";
+
+            _canvas.Invalidated += OnCanvasCoreInvalidated;
         }
+
+        private void OnCanvasCoreInvalidated(CoreMotionCanvas obj) =>
+            InvalidateRenderer();
 
         private void SkiaRenderMode_PointerMoved(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e) =>
             Debug.WriteLine("skia sees pointer moved");
 
-        public void DisposeRenderMode() =>
+        public void DisposeRenderMode()
+        {
+            // guard against double-dispose or dispose-before-initialize.
+            if (_canvas is null) return;
+
+            _canvas.Invalidated -= OnCanvasCoreInvalidated;
             _canvas = null!;
+        }
 
         public void InvalidateRenderer() =>
             Invalidate();
 
         protected override void RenderOverride(SKCanvas canvas, Size area)
         {
+            // nothing to draw once the render mode has been disposed; bailing out
+            // also avoids re-invalidating in an endless loop after disposal.
+            if (_canvas is null) return;
+
             FrameRequest?.Invoke(
                 new SkiaSharpDrawingContext(
                     _canvas, canvas, GetBackground(), clearCanvasOnNewFrame: false));
+
+            if (_canvas.IsValid) return;
+            Invalidate();
         }
 
         private SKColor GetBackground() =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.Uno.WinUI/Rendering/SkiaRenderMode.cs
@@ -47,11 +47,6 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
         Children.Add(_renderMode);
     }
 
-    static SkiaRenderMode()
-    {
-        SkiaSharpDrawingContext.s_clearCanvasOnNewFrame = false;
-    }
-
     public event CoreMotionCanvas.FrameRequestHandler FrameRequest
     {
         add => _renderMode.FrameRequest += value;
@@ -95,7 +90,8 @@ internal partial class SkiaRenderMode : Grid, IRenderMode
         protected override void RenderOverride(SKCanvas canvas, Size area)
         {
             FrameRequest?.Invoke(
-                new SkiaSharpDrawingContext(_canvas, canvas, GetBackground()));
+                new SkiaSharpDrawingContext(
+                    _canvas, canvas, GetBackground(), clearCanvasOnNewFrame: false));
         }
 
         private SKColor GetBackground() =>

--- a/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
+++ b/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
@@ -58,11 +58,11 @@ public partial class MotionCanvas : Canvas
 
                     if (Uno.WinUI.Graphics2DSK.SKCanvasElement.IsSupportedOnCurrentPlatform())
                     {
+                        // At this point, Uno has full control of the frame pacing.
+                        // SkiaRenderMode inherits from SKCanvasElement, it integrates with Uno's skia renderer and will draw when and how Uno needs.
+                        // NativeFrameTicker is a dummy ticker at this point, instead the frames are paced by Uno's skia renderer.
                         renderMode = new SkiaRenderMode();
-
-                        ticker = settings.TryUseVSync
-                            ? new NativeFrameTicker()
-                            : new AsyncLoopTicker();
+                        ticker = new NativeFrameTicker();
                     }
                     else
                     {

--- a/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
+++ b/src/skiasharp/_Shared.WinUI/MotionCanvas.cs
@@ -47,11 +47,31 @@ public partial class MotionCanvas : Canvas
                     IFrameTicker ticker;
 
 #if !HAS_OS_LVC
-                    var renderMode = new SkiaRenderMode();
+                    // SKCanvasElement only works when the app runs Uno's Skia renderer;
+                    // under the native renderer (e.g. WASM native) its constructor throws
+                    // PlatformNotSupportedException, so fall back to the SkiaSharp.Views
+                    // elements in that case (#2020, #2333). CompositionTarget.Rendering
+                    // does not tick continuously under the native renderer either, so the
+                    // fallback also needs the async-loop ticker or animations freeze at
+                    // the first frame.
+                    IRenderMode renderMode;
 
-                    ticker = settings.TryUseVSync
-                        ? new NativeFrameTicker()
-                        : new AsyncLoopTicker();
+                    if (Uno.WinUI.Graphics2DSK.SKCanvasElement.IsSupportedOnCurrentPlatform())
+                    {
+                        renderMode = new SkiaRenderMode();
+
+                        ticker = settings.TryUseVSync
+                            ? new NativeFrameTicker()
+                            : new AsyncLoopTicker();
+                    }
+                    else
+                    {
+                        renderMode = settings.UseGPU
+                            ? new GPURenderMode()
+                            : new CPURenderMode();
+
+                        ticker = new AsyncLoopTicker();
+                    }
 #else
                     IRenderMode renderMode = settings.UseGPU
                         ? new GPURenderMode()

--- a/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
+++ b/tests/CoreTests/CoreObjectsTests/FrameTickerTesting.cs
@@ -51,6 +51,33 @@ public class FrameTickerTesting
         ticker.DisposeTicker();
     }
 
+    // Regression for #2020/#2333. AsyncLoopTicker is purely event-driven: it
+    // only starts its drawing loop when CoreMotionCanvas.Invalidated fires.
+    // On Uno's native renderer (e.g. WASM native) the chart engine can
+    // invalidate the canvas before the view raises Loaded — that is, before
+    // MotionCanvasComposer.Initialize subscribes the ticker. A canvas that is
+    // already invalid at InitializeTicker time never raises another event on
+    // its own, so the ticker idled forever and the chart froze before its
+    // first frame. The contract pinned here: initializing the ticker against
+    // an already-invalid canvas must start the drawing loop immediately.
+    [TestMethod]
+    public void AsyncLoopTicker_CanvasInvalidatedBeforeInitialize_StartsDrawingLoop()
+    {
+        var ticker = new AsyncLoopTicker();
+        var canvas = new CoreMotionCanvas();
+        var renderMode = new CountingRenderMode();
+
+        // the chart engine updated before the view loaded
+        canvas.Invalidate();
+
+        // the first loop iteration runs synchronously inside InitializeTicker
+        ticker.InitializeTicker(canvas, renderMode);
+
+        ticker.DisposeTicker();
+
+        Assert.IsTrue(renderMode.InvalidateCount >= 1);
+    }
+
     private sealed class NoopRenderMode : IRenderMode
     {
         public event CoreMotionCanvas.FrameRequestHandler FrameRequest { add { } remove { } }
@@ -58,5 +85,16 @@ public class FrameTickerTesting
         public void InitializeRenderMode(CoreMotionCanvas canvas) { }
         public void DisposeRenderMode() { }
         public void InvalidateRenderer() { }
+    }
+
+    private sealed class CountingRenderMode : IRenderMode
+    {
+        public int InvalidateCount { get; private set; }
+
+        public event CoreMotionCanvas.FrameRequestHandler FrameRequest { add { } remove { } }
+
+        public void InitializeRenderMode(CoreMotionCanvas canvas) { }
+        public void DisposeRenderMode() { }
+        public void InvalidateRenderer() => InvalidateCount++;
     }
 }

--- a/tests/CoreTests/OtherTests/SkiaSharpDrawingContextTests.cs
+++ b/tests/CoreTests/OtherTests/SkiaSharpDrawingContextTests.cs
@@ -1,0 +1,75 @@
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+[TestClass]
+public class SkiaSharpDrawingContextTests
+{
+    // Regression for #2303. When an application hosts a LiveCharts chart from both
+    // Avalonia and WPF (or any other backend) in the same process, the Avalonia
+    // chart used to "poison" the WPF chart so that animation frames stacked on top
+    // of each other instead of clearing. Root cause: clearCanvasOnNewFrame used to
+    // be a process-static field, and Avalonia/Uno-Skia static initializers flipped
+    // it to false because their host clears the surface before invoking Render.
+    // Once flipped, every other SkiaSharpDrawingContext in the process (WPF, MAUI,
+    // WinForms, Blazor, in-memory) silently skipped its own clear too.
+    //
+    // The fix moved the flag onto the instance via a constructor parameter. This
+    // test pins that contract: constructing an opt-out context must not affect a
+    // sibling default-constructed context. Verified by pre-filling a surface with
+    // a known colour, constructing an opt-out context (the Avalonia/Uno-Skia
+    // path), then constructing a default context and calling OnBeginDraw on it —
+    // the surface pixel must be the default context's Background, not the
+    // pre-fill colour.
+    [TestMethod]
+    public void OnBeginDraw_OnDefaultContext_ClearsCanvas_EvenWhenAnotherContextOptedOut()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+        var motion = new CoreMotionCanvas();
+
+        // mimic the Avalonia / Uno-Skia call site that opts out of clearing
+        _ = new SkiaSharpDrawingContext(
+            motion, surface.Canvas, SKColor.Empty, clearCanvasOnNewFrame: false);
+
+        // pre-fill with a colour distinct from the upcoming Background
+        surface.Canvas.Clear(SKColors.Blue);
+
+        // a default-construct context (WPF / MAUI / WinForms / Blazor) MUST still clear
+        var defaultCtx = new SkiaSharpDrawingContext(motion, surface.Canvas, SKColors.Red);
+        defaultCtx.OnBeginDraw();
+
+        using var snapshot = surface.Snapshot();
+        using var pixmap = snapshot.PeekPixels();
+
+        Assert.AreEqual(
+            SKColors.Red,
+            pixmap.GetPixelColor(5, 5),
+            "Avalonia/Uno-Skia opt-out from clearCanvasOnNewFrame must be per-instance " +
+            "— a default context in the same process must still clear on OnBeginDraw.");
+    }
+
+    [TestMethod]
+    public void OnBeginDraw_OnOptedOutContext_DoesNotClearCanvas()
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+        var motion = new CoreMotionCanvas();
+
+        surface.Canvas.Clear(SKColors.Blue);
+
+        var optedOut = new SkiaSharpDrawingContext(
+            motion, surface.Canvas, SKColors.Red, clearCanvasOnNewFrame: false);
+        optedOut.OnBeginDraw();
+
+        using var snapshot = surface.Snapshot();
+        using var pixmap = snapshot.PeekPixels();
+
+        Assert.AreEqual(
+            SKColors.Blue,
+            pixmap.GetPixelColor(5, 5),
+            "A context constructed with clearCanvasOnNewFrame:false must not touch " +
+            "the canvas in OnBeginDraw — the host is responsible for clearing.");
+    }
+}

--- a/tests/SharedUITests/CartesianChartTests.cs
+++ b/tests/SharedUITests/CartesianChartTests.cs
@@ -98,9 +98,7 @@ public class CartesianChartTests
         await App.PopNavigation();
         await App.NavigateToView(sut);
 
-        // ToDo: improve this method? as a workaround for now we just wait for some time
-        // await sut.Chart.WaitUntilChartRenders();
-        await Task.Delay(2000);
+        await sut.Chart.WaitUntilChartLoadsAndRenders();
 
         Assert.ChartIsLoaded(sut.Chart);
 #endif

--- a/tests/SharedUITests/Helpers/UIHelpersExtensions.cs
+++ b/tests/SharedUITests/Helpers/UIHelpersExtensions.cs
@@ -49,6 +49,33 @@ public static class UIHelpersExtensions
 
     extension(IChartView chartView)
     {
+        public async Task WaitUntilChartLoadsAndRenders(int timeoutMs = 10000, int pollMs = 50)
+        {
+            bool HasRenderedPoints()
+            {
+                if (!chartView.CoreChart.IsLoaded)
+                    return false;
+
+                var points = (chartView.Series ?? [])
+                    .SelectMany(s => s.Fetch(chartView.CoreChart))
+                    .ToArray();
+
+                // mirrors Assert.ChartIsLoaded: non-empty, every point has a positioned visual
+                return points.Length > 0 && points.All(p =>
+                {
+                    var v = p.Context.Visual;
+                    return v is not null && v.X > 0 && v.Y > 0;
+                });
+            }
+
+            var waited = 0;
+            while (waited < timeoutMs && !HasRenderedPoints())
+            {
+                await Task.Delay(pollMs);
+                waited += pollMs;
+            }
+        }
+
         public Task WaitUntilChartRenders()
         {
             var tcs = new TaskCompletionSource<object>();

--- a/tests/SharedUITests/PieChartTests.cs
+++ b/tests/SharedUITests/PieChartTests.cs
@@ -47,9 +47,7 @@ public class PieChartTests
         await App.PopNavigation();
         await App.NavigateToView(sut);
 
-        // ToDo: improve this method? as a workaround for now we just wait for some time
-        // await sut.Chart.WaitUntilChartRenders();
-        await Task.Delay(2000);
+        await sut.Chart.WaitUntilChartLoadsAndRenders();
 
         Assert.ChartIsLoaded(sut.Chart);
 #endif


### PR DESCRIPTION
Backports #2338 (Uno self-paced renderer) onto `release/v2.0.x`.

Because the release branch's Uno render path predates two fixes #2338 builds on, this lands as a 3-commit chain so #2338 itself applies as a verbatim cherry-pick and the render path converges with `master`:

1. **`fix(drawing)`: per-instance `clearCanvasOnNewFrame` (#2303)** — full backport of #2311. Release still had the process-static field; makes it a per-instance ctor param so an Avalonia/Uno-Skia opt-out can't poison WPF/MAUI/WinForms/Blazor in-process. Includes its regression test.
2. **`fix(uno)`: native-renderer support render path (#2020, #2333)** — *partial* backport of #2334, render files only (`MotionCanvas.cs`, `AsyncLoopTicker.cs`, `Uno.WinUI.csproj`, `FrameTickerTesting.cs`). The CI-workflow and `UnoPlatformSample` build changes from #2334 are intentionally omitted — they target master-only CI jobs and the WASM-AOT sample showcase, neither relevant to the stable branch.
3. **`perf`: Uno self-paced renderer (#2338)** — clean cherry-pick on top of the two above.

### Verification
- The four render files (`SkiaRenderMode.cs`, `MotionCanvas.cs`, both `NativeTicker.cs`) are **byte-for-byte identical to `master`** after the chain.
- `CoreTests` pass for the backported core changes (`FrameTicker*`, `SkiaSharpDrawingContext*`).
- `LiveChartsCore.SkiaSharpView.Uno.WinUI` builds clean (`net10.0-desktop`).
- Factos UI tests run per-platform in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)