### PR TITLE
Fixed logarithmic x-axis subseparators

### DIFF
--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1726,7 +1726,7 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
             float xs = 0f, ys = 0f;
             if (_orientation == AxisOrientation.X)
             {
-                xs = scale.MeasureInPixels(s * kl);
+                xs = scale.MeasureInPixels(s + s * kl);
             }
             else
             {


### PR DESCRIPTION
### Description
When using the `LogarithmicAxis` on the x-axel the subseparators were rendered incorrectly. Instead of condensing and getting tighter as they approached the next power of 10, the gaps between the subseparators incorrectly grew larger and larger the closer they got to the next major tick.

This behavior is mathematically incorrect for a standard logarithmic scale. The issue was caused by an incorrect scaling calculation inside `CoreAxis.UpdateSubseparators`. This PR fixes the problem by properly applying the logarithmic step factor (`s + s * kl`) when measuring pixels for the subseparators, ensuring they group together correctly.

### How to reproduce
1. Create a chart with a `LogarithmicAxis`.
2. Enable `Subseparators` (e.g., set `SubseparatorsCount = 9`).
3. Observe that the subseparators spacing incorrectly expands (grows larger) as it approaches the next major power of 10.

### Visual proof
With this change, the subseparators now follow a true logarithmic distribution, getting progressively tighter as you move from left to right towards the next power of 10.