### PR TITLE
Clean up the chart animation API (single source of truth)

### DIFF
--- a/samples/ConsoleEngineSample/LiveChartsCore.Console/LiveChartsConsole.cs
+++ b/samples/ConsoleEngineSample/LiveChartsCore.Console/LiveChartsConsole.cs
@@ -33,10 +33,13 @@ public static class LiveChartsConsole
             .HasTheme(theme => theme
                 .OnInitialized(() =>
                 {
-                    theme.AnimationsSpeed = TimeSpan.FromMilliseconds(500);
-                    theme.EasingFunction = LvcEasings.ExponentialOut;
                     theme.Colors = ColorPalletes.MaterialDesign500;
                     theme.VirtualBackroundColor = new(0, 0, 0);
+                })
+                .HasRuleForChart(chart =>
+                {
+                    chart.AnimationsSpeed = TimeSpan.FromMilliseconds(500);
+                    chart.EasingFunction = LvcEasings.ExponentialOut;
                 })
                 .HasDefaultTooltip(() => new ConsoleTooltip())
                 .HasDefaultLegend(() => new ConsoleLegend())

--- a/samples/ViewModelsSamples/LiveChartsAppSettings.cs
+++ b/samples/ViewModelsSamples/LiveChartsAppSettings.cs
@@ -22,14 +22,17 @@ public static partial class CustomLiveChartsExtensions
                 // if neccessary, override the default theme, for more info see:
                 // https://github.com/beto-rodriguez/LiveCharts2/blob/master/samples/ViewModelsSamples/LiveChartsThemeExtensions.cs
 
-                //theme =>
-                //    theme.OnInitialized(() =>
+                //theme => theme
+                //    .OnInitialized(() =>
                 //    {
-                //        theme.AnimationsSpeed = TimeSpan.FromSeconds(1);
-                //        theme.EasingFunction = EasingFunctions.BounceOut;
                 //        theme.Colors = theme.IsDark
                 //            ? ColorPalletes.MaterialDesign200
                 //            : ColorPalletes.MaterialDesign800;
+                //    })
+                //    .HasRuleForChart(chart =>
+                //    {
+                //        chart.AnimationsSpeed = TimeSpan.FromSeconds(1);
+                //        chart.EasingFunction = EasingFunctions.BounceOut;
                 //    })
             )
 

--- a/samples/ViewModelsSamples/LiveChartsAppSettings.cs
+++ b/samples/ViewModelsSamples/LiveChartsAppSettings.cs
@@ -19,7 +19,7 @@ public static partial class CustomLiveChartsExtensions
             // across all the supported UI frameworks, but you could also
             // use XAML based themes if your platform supports them.
             .AddDefaultTheme(
-                // if neccessary, override the default theme, for more info see:
+                // if necessary, override the default theme, for more info see:
                 // https://github.com/beto-rodriguez/LiveCharts2/blob/master/samples/ViewModelsSamples/LiveChartsThemeExtensions.cs
 
                 //theme => theme

--- a/samples/ViewModelsSamples/LiveChartsThemeExtensions.cs
+++ b/samples/ViewModelsSamples/LiveChartsThemeExtensions.cs
@@ -19,14 +19,19 @@ public static class LiveChartsThemeExtensions
             {
                 // the OnInitialized method is called when the // mark
                 // theme is applied to a chart for the first time // mark
-                // here ee can define colors, animations speed, easing function, etc. // mark
-                theme.AnimationsSpeed = TimeSpan.FromSeconds(1);
-                theme.EasingFunction = EasingFunctions.BounceOut;
+                // here we can define colors, palettes, etc. // mark
                 theme.Colors = [
                     new(66, 165, 245),
                     new(30, 136, 229),
                     new(21, 101, 192)
                 ];
+            })
+            .HasRuleForChart(chart =>
+            {
+                // animations are configured on the chart view itself; // mark
+                // a rule here applies them to every chart unless the user sets them explicitly // mark
+                chart.AnimationsSpeed = TimeSpan.FromSeconds(1);
+                chart.EasingFunction = EasingFunctions.BounceOut;
             })
             .HasRuleForBarSeries(series =>
             {

--- a/samples/VorticeSample/LiveChartsCore.Vortice/LiveChartsVortice.cs
+++ b/samples/VorticeSample/LiveChartsCore.Vortice/LiveChartsVortice.cs
@@ -40,10 +40,13 @@ public static class LiveChartsVortice
             .HasTheme(theme => theme
                 .OnInitialized(() =>
                 {
-                    theme.AnimationsSpeed = TimeSpan.FromMilliseconds(800);
-                    theme.EasingFunction = EasingFunctions.ExponentialOut;
                     theme.Colors = ColorPalletes.MaterialDesign500;
                     theme.VirtualBackroundColor = new(255, 255, 255);
+                })
+                .HasRuleForChart(chart =>
+                {
+                    chart.AnimationsSpeed = TimeSpan.FromMilliseconds(800);
+                    chart.EasingFunction = EasingFunctions.ExponentialOut;
                 })
                 .HasDefaultTooltip(() => new VorticeDefaultTooltip())
                 .HasDefaultLegend(() => new VorticeDefaultLegend())

--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -374,12 +374,7 @@ public class CartesianChartEngine(
         Sections = _chartView.Sections?.Select(x => x.ChartElementSource).Where(static x => x.IsVisible) ?? [];
         VisualElements = _chartView.VisualElements ?? [];
 
-        ActualAnimationsSpeed = _chartView.AnimationsSpeed == TimeSpan.MaxValue
-            ? theme.AnimationsSpeed
-            : _chartView.AnimationsSpeed;
-        ActualEasingFunction = _chartView.EasingFunction == EasingFunctions.Unset
-            ? theme.EasingFunction
-            : _chartView.EasingFunction;
+        UpdateAnimation();
 
         #endregion
 

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -253,8 +253,8 @@ public abstract class Chart
     /// per-element override). It is rebuilt in place from the view's
     /// <see cref="IChartView.AnimationsSpeed"/> / <see cref="IChartView.EasingFunction"/> on every
     /// measure (see <see cref="UpdateAnimation"/>), so already-created visuals pick up runtime
-    /// changes without recreation. A null <see cref="Drawing.Animation.EasingFunction"/> or a zero
-    /// <see cref="Drawing.Animation.Duration"/> disables animations.
+    /// changes without recreation. A null <see cref="Animation.EasingFunction"/> or a zero
+    /// <see cref="Animation.Duration"/> disables animations.
     /// </summary>
     public Animation Animation { get; } = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
 

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -249,45 +249,26 @@ public abstract class Chart
     public IChartTooltip? Tooltip { get; protected set; }
 
     /// <summary>
-    /// Gets the animations speed. Setting this also refreshes <see cref="Animation"/> so
-    /// already-created chart-default geometries pick up the new duration without recreation.
+    /// Gets the resolved animation shared by chart-default geometries (those without a
+    /// per-element override). It is rebuilt in place from the view's
+    /// <see cref="IChartView.AnimationsSpeed"/> / <see cref="IChartView.EasingFunction"/> on every
+    /// measure (see <see cref="UpdateAnimation"/>), so already-created visuals pick up runtime
+    /// changes without recreation. A null <see cref="Drawing.Animation.EasingFunction"/> or a zero
+    /// <see cref="Drawing.Animation.Duration"/> disables animations.
     /// </summary>
-    /// <value>
-    /// The animations speed.
-    /// </value>
-    public TimeSpan ActualAnimationsSpeed
+    public Animation Animation { get; } = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
+
+    /// <summary>
+    /// Rebuilds <see cref="Animation"/> in place from the view's animation settings. Called once
+    /// per measure, after the theme has been applied to the view (so themed or user-set values are
+    /// already in place). This is the single place that resolves the chart-level animation;
+    /// per-element overrides resolve against it in their own GetAnimation.
+    /// </summary>
+    internal void UpdateAnimation()
     {
-        get;
-        protected set
-        {
-            field = value;
-            Animation.Duration = (long)value.TotalMilliseconds;
-        }
+        Animation.Duration = (long)View.AnimationsSpeed.TotalMilliseconds;
+        Animation.EasingFunction = View.EasingFunction;
     }
-
-    /// <summary>
-    /// Gets the easing function. Setting this also refreshes <see cref="Animation"/> so
-    /// already-created chart-default geometries pick up the new function without recreation.
-    /// </summary>
-    /// <value>
-    /// The easing function.
-    /// </value>
-    public Func<float, float>? ActualEasingFunction
-    {
-        get;
-        protected set
-        {
-            field = value;
-            Animation.EasingFunction = value;
-        }
-    } = EasingFunctions.QuadraticOut;
-
-    /// <summary>
-    /// Shared animation reference used by chart-default geometries (geometries that don't
-    /// have a per-element override). Mutated in-place by <see cref="ActualAnimationsSpeed"/>
-    /// and <see cref="ActualEasingFunction"/> so existing visuals pick up new settings.
-    /// </summary>
-    internal Animation Animation { get; } = new(EasingFunctions.QuadraticOut, TimeSpan.Zero);
 
     /// <summary>
     /// Gets the visual elements.

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1456,8 +1456,10 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
         if (AnimationsSpeed is null && EasingFunction is null)
             return chart.Animation;
 
-        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
-        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        _animation.Duration = AnimationsSpeed.HasValue
+            ? (long)AnimationsSpeed.Value.TotalMilliseconds
+            : chart.Animation.Duration;
+        _animation.EasingFunction = EasingFunction ?? chart.Animation.EasingFunction;
         return _animation;
     }
 

--- a/src/LiveChartsCore/CorePolarAxis.cs
+++ b/src/LiveChartsCore/CorePolarAxis.cs
@@ -603,8 +603,10 @@ public abstract class CorePolarAxis<TTextGeometry, TLineGeometry, TCircleGeometr
         if (AnimationsSpeed is null && EasingFunction is null)
             return chart.Animation;
 
-        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
-        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        _animation.Duration = AnimationsSpeed.HasValue
+            ? (long)AnimationsSpeed.Value.TotalMilliseconds
+            : chart.Animation.Duration;
+        _animation.EasingFunction = EasingFunction ?? chart.Animation.EasingFunction;
         return _animation;
     }
 }

--- a/src/LiveChartsCore/EasingFunctions.cs
+++ b/src/LiveChartsCore/EasingFunctions.cs
@@ -32,8 +32,6 @@ namespace LiveChartsCore;
 /// </summary>
 public static class EasingFunctions
 {
-    internal static Func<float, float> Unset { get; } = t => t;
-
     /// <summary>
     /// Gets the back in.
     /// </summary>

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -127,8 +127,9 @@ public interface ISeries : IChartElement
     string? GeometrySvg { get; set; }
 
     /// <summary>
-    /// Gets or sets the animations speed, if this property is null, the
-    /// <see cref="Chart.ActualAnimationsSpeed"/> property will be used.
+    /// Gets or sets the animations speed; when null the series inherits the chart-level animation
+    /// (see <see cref="Chart.Animation"/>). Set it to <see cref="TimeSpan.Zero"/> to disable
+    /// animations for this series only.
     /// </summary>
     /// <value>
     /// The animations speed.
@@ -136,8 +137,8 @@ public interface ISeries : IChartElement
     TimeSpan? AnimationsSpeed { get; set; }
 
     /// <summary>
-    /// Gets or sets the easing function to animate the series, if this property is null, the
-    /// <see cref="Chart.ActualEasingFunction"/> property will be used.
+    /// Gets or sets the easing function used to animate the series; when null the series inherits
+    /// the chart-level easing (see <see cref="Chart.Animation"/>).
     /// </summary>
     /// <value>
     /// The easing function.

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -352,10 +352,9 @@ public static class Extensions
     /// Points the given <paramref name="properties"/> at the chart's shared
     /// <see cref="Chart.Animation"/> instance. When <paramref name="properties"/> is null or
     /// empty, every animatable property on <paramref name="animatable"/> is bound to the same
-    /// instance. Because that instance is mutated in-place when
-    /// <see cref="Chart.ActualAnimationsSpeed"/> or <see cref="Chart.ActualEasingFunction"/>
-    /// change, callers using this overload pick up chart-level animation changes without
-    /// recreating their geometries.
+    /// instance. Because that instance is mutated in-place by <see cref="Chart.UpdateAnimation"/>
+    /// when the view's animation settings change, callers using this overload pick up chart-level
+    /// animation changes without recreating their geometries.
     /// </summary>
     /// <param name="animatable">The animatable object.</param>
     /// <param name="chart">

--- a/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
+++ b/src/LiveChartsCore/Kernel/LiveChartsSettings.cs
@@ -70,7 +70,7 @@ public class LiveChartsSettings
     /// <value>
     /// The default easing function.
     /// </value>
-    public Func<float, float> EasingFunction { get; set; } = EasingFunctions.Unset;
+    public Func<float, float> EasingFunction { get; set; } = EasingFunctions.ExponentialOut;
 
     /// <summary>
     /// Gets or sets the default animations speed.
@@ -78,7 +78,7 @@ public class LiveChartsSettings
     /// <value>
     /// The default animations speed.
     /// </value>
-    public TimeSpan AnimationsSpeed { get; set; } = TimeSpan.MaxValue;
+    public TimeSpan AnimationsSpeed { get; set; } = TimeSpan.FromMilliseconds(800);
 
     /// <summary>
     /// Gets or sets the default zoom speed.

--- a/src/LiveChartsCore/Kernel/Sketches/IPlane.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IPlane.cs
@@ -176,8 +176,9 @@ public interface IPlane : IChartElement
     IList<string>? Labels { get; set; }
 
     /// <summary>
-    /// Gets or sets the animations speed, if this property is null, the
-    /// <see cref="Chart.ActualAnimationsSpeed"/> property will be used.
+    /// Gets or sets the animations speed; when null the axis inherits the chart-level animation
+    /// (see <see cref="Chart.Animation"/>). Set it to <see cref="TimeSpan.Zero"/> to disable
+    /// animations for this axis only.
     /// </summary>
     /// <value>
     /// The animations speed.
@@ -185,8 +186,8 @@ public interface IPlane : IChartElement
     TimeSpan? AnimationsSpeed { get; set; }
 
     /// <summary>
-    /// Gets or sets the easing function to animate the series, if this property is null, the
-    /// <see cref="Chart.ActualEasingFunction"/> property will be used.
+    /// Gets or sets the easing function used to animate the axis; when null the axis inherits the
+    /// chart-level easing (see <see cref="Chart.Animation"/>).
     /// </summary>
     /// <value>
     /// The easing function.

--- a/src/LiveChartsCore/PieChartEngine.cs
+++ b/src/LiveChartsCore/PieChartEngine.cs
@@ -143,12 +143,7 @@ public class PieChartEngine(
         TooltipPosition = view.TooltipPosition;
         Tooltip = view.Tooltip;
 
-        ActualAnimationsSpeed = view.AnimationsSpeed == TimeSpan.MaxValue
-            ? theme.AnimationsSpeed
-            : view.AnimationsSpeed;
-        ActualEasingFunction = view.EasingFunction == EasingFunctions.Unset
-            ? theme.EasingFunction
-            : view.EasingFunction;
+        UpdateAnimation();
 
         SeriesContext = new SeriesContext(VisibleSeries, this);
         var themeId = theme.ThemeId;

--- a/src/LiveChartsCore/PolarChartEngine.cs
+++ b/src/LiveChartsCore/PolarChartEngine.cs
@@ -204,12 +204,7 @@ public class PolarChartEngine(
         TooltipPosition = view.TooltipPosition;
         Tooltip = view.Tooltip;
 
-        ActualAnimationsSpeed = view.AnimationsSpeed == TimeSpan.MaxValue
-            ? theme.AnimationsSpeed
-            : view.AnimationsSpeed;
-        ActualEasingFunction = view.EasingFunction == EasingFunctions.Unset
-            ? theme.EasingFunction
-            : view.EasingFunction;
+        UpdateAnimation();
 
         FitToBounds = view.FitToBounds;
         TotalAnge = (float)view.TotalAngle;

--- a/src/LiveChartsCore/SankeyChartEngine.cs
+++ b/src/LiveChartsCore/SankeyChartEngine.cs
@@ -97,12 +97,7 @@ public class SankeyChartEngine(
         TooltipPosition = view.TooltipPosition;
         Tooltip = view.Tooltip;
 
-        ActualAnimationsSpeed = view.AnimationsSpeed == TimeSpan.MaxValue
-            ? theme.AnimationsSpeed
-            : view.AnimationsSpeed;
-        ActualEasingFunction = view.EasingFunction == EasingFunctions.Unset
-            ? theme.EasingFunction
-            : view.EasingFunction;
+        UpdateAnimation();
 
         SeriesContext = new SeriesContext(VisibleSeries, this);
         var themeId = theme.ThemeId;

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -457,11 +457,10 @@ public abstract class Series<TModel, TVisual, TLabel>
 
     /// <summary>
     /// Returns the <see cref="Animation"/> instance that every geometry this series animates
-    /// should reference. With no per-series override, the chart's shared <see cref="Chart.Animation"/>
-    /// is returned directly so chart-level <see cref="Chart.ActualAnimationsSpeed"/> /
-    /// <see cref="Chart.ActualEasingFunction"/> changes propagate to already-created visuals.
-    /// With a per-series override, a series-owned instance is mutated in-place from the active
-    /// settings.
+    /// should reference. When neither <see cref="AnimationsSpeed"/> nor <see cref="EasingFunction"/>
+    /// is set, the chart's shared <see cref="Chart.Animation"/> is returned directly (so chart-level
+    /// animation changes propagate to already-created visuals without recreation). When either is
+    /// set, a series-owned instance is mutated in place, inheriting the unset field from the chart.
     /// </summary>
     /// <param name="chart">The chart whose <see cref="Chart.Animation"/> is used as the fallback.</param>
     protected Animation GetAnimation(Chart chart)
@@ -469,8 +468,10 @@ public abstract class Series<TModel, TVisual, TLabel>
         if (AnimationsSpeed is null && EasingFunction is null)
             return chart.Animation;
 
-        _animation.Duration = (long)(AnimationsSpeed ?? chart.ActualAnimationsSpeed).TotalMilliseconds;
-        _animation.EasingFunction = EasingFunction ?? chart.ActualEasingFunction;
+        _animation.Duration = AnimationsSpeed.HasValue
+            ? (long)AnimationsSpeed.Value.TotalMilliseconds
+            : chart.Animation.Duration;
+        _animation.EasingFunction = EasingFunction ?? chart.Animation.EasingFunction;
         return _animation;
     }
 

--- a/src/LiveChartsCore/Themes/Theme.cs
+++ b/src/LiveChartsCore/Themes/Theme.cs
@@ -75,22 +75,6 @@ public class Theme
     public LvcColor VirtualBackroundColor { get; set; } = new(255, 255, 255);
 
     /// <summary>
-    /// Gets or sets the default easing function.
-    /// </summary>
-    /// <value>
-    /// The default easing function.
-    /// </value>
-    public Func<float, float> EasingFunction { get; set; } = EasingFunctions.ExponentialOut;
-
-    /// <summary>
-    /// Gets or sets the default animations speed.
-    /// </summary>
-    /// <value>
-    /// The default animations speed.
-    /// </value>
-    public TimeSpan AnimationsSpeed { get; set; } = TimeSpan.FromMilliseconds(800);
-
-    /// <summary>
     /// Gets or sets the tooltip text size.
     /// </summary>
     public float TooltipTextSize { get; set; } = 16f;

--- a/src/LiveChartsCore/TreemapChartEngine.cs
+++ b/src/LiveChartsCore/TreemapChartEngine.cs
@@ -99,12 +99,7 @@ public class TreemapChartEngine(
         TooltipPosition = view.TooltipPosition;
         Tooltip = view.Tooltip;
 
-        ActualAnimationsSpeed = view.AnimationsSpeed == TimeSpan.MaxValue
-            ? theme.AnimationsSpeed
-            : view.AnimationsSpeed;
-        ActualEasingFunction = view.EasingFunction == EasingFunctions.Unset
-            ? theme.EasingFunction
-            : view.EasingFunction;
+        UpdateAnimation();
 
         SeriesContext = new SeriesContext(VisibleSeries, this);
         var themeId = theme.ThemeId;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
@@ -60,8 +60,6 @@ public static class ThemesExtensions
                     .OnInitialized(() =>
                     {
                         theme.RequestedTheme = requestedTheme;
-                        theme.AnimationsSpeed = TimeSpan.FromMilliseconds(800);
-                        theme.EasingFunction = EasingFunctions.ExponentialOut;
 
                         if (theme.IsDark)
                         {

--- a/tests/CoreTests/ChartTests/ChartViewThemeTests.cs
+++ b/tests/CoreTests/ChartTests/ChartViewThemeTests.cs
@@ -82,6 +82,37 @@ public class ChartViewThemeTests
     }
 
     [TestMethod]
+    public void ChartLevelRuleSetsAnimationsSpeed()
+    {
+        // Regression for the original motivation of this refactor: a HasRuleForChart rule that
+        // sets the chart-level animation must reach the chart's single resolved Animation. Before
+        // the cleanup the chart kept a parallel ActualAnimationsSpeed resolved from a MaxValue
+        // sentinel, so theme-driven animation settings were easy to lose.
+        try
+        {
+            _ = BuildThemeWith(t => t.HasRuleForChart(
+                view => view.AnimationsSpeed = System.TimeSpan.FromMilliseconds(1234)));
+
+            var chart = new SKCartesianChart
+            {
+                Width = 300,
+                Height = 300,
+                Series = [new LineSeries<double> { Values = [1, 2, 3] }]
+            };
+
+            _ = chart.GetImage();
+
+            Assert.AreEqual(
+                1234L, ((IChartView)chart).CoreChart.Animation.Duration,
+                "A HasRuleForChart AnimationsSpeed must flow into the chart's resolved Animation.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
     public void ChartLevelRuleReachesGeoMap()
     {
         // Regression: GeoMapChart.Measure discarded GetTheme() and never called


### PR DESCRIPTION
Cleans up the animation configuration, which had grown into too many overlapping paths and was hard to debug (the original motivation: setting chart animation from a theme).

### Before
The same two concepts (easing + duration) lived in 7 places with **3 different "inherit" conventions** (`TimeSpan.MaxValue`, the `EasingFunctions.Unset` lambda compared *by reference*, and `null`), plus:
- `Chart.ActualAnimationsSpeed` / `ActualEasingFunction` — parallel shadow state whose setters mutated a shared `Animation` as a side effect.
- `Theme.EasingFunction` / `Theme.AnimationsSpeed` fields, duplicating the global defaults.
- the resolution `== sentinel ? theme : view` copy-pasted across **five** engines.

### After — one resolution path
- **`Chart.Animation`** is the single resolved instance, rebuilt in place once per measure by **`Chart.UpdateAnimation()`** from the view's `AnimationsSpeed` / `EasingFunction`. It is now **public read-only**.
- Animation **defaults** (800 ms / `ExponentialOut`) live on `LiveChartsSettings` (the global config that already feeds the view defaults). A theme can still override per chart via `HasRuleForChart` (the #2341 path) — that's the case that originally didn't work cleanly.
- `Series` / `Axis` `GetAnimation` resolves against `chart.Animation`: both `null` → inherit the shared instance (runtime changes still propagate, per #1926/#2219); otherwise the unset field falls back to the chart. `TimeSpan.Zero` disables for that element only.

### Removed
`Chart.ActualAnimationsSpeed`, `Chart.ActualEasingFunction`, `EasingFunctions.Unset`, the `TimeSpan.MaxValue` inherit sentinel, `Theme.EasingFunction`, `Theme.AnimationsSpeed`, and the five duplicated engine blocks.

### Behavior
**Preserved** — same 800 ms / `ExponentialOut` defaults, same "null easing disables", same per-series inheritance. This is an internal cleanup, not a behavior change. Verified by the full existing suite (CoreTests 805, SnapshotTests 174) plus a new regression test for the theme → chart animation path. Samples that set `theme.AnimationsSpeed` / `theme.EasingFunction` were moved to `HasRuleForChart`.

### Note on the public API
This keeps `IChartView.AnimationsSpeed` as `TimeSpan` (non-null): the chart-view is the root and the theme/global already fills it via #2341, so it needs no `null`-inherit sentinel. `null`-inherit lives on `ISeries`/`IPlane` (already nullable). A follow-up could add a read-only `Animation` to `IChartView` for symmetry — currently readable via `chart.CoreChart.Animation`.

2.1.x — breaking changes are acceptable; the removed members were either internal or rarely-used theme fields.