### PR TITLE
perf: precompute cubic-bezier easing into a lookup table

### DIFF
--- a/src/LiveChartsCore/Easing/CubicBezierEasingFunction.cs
+++ b/src/LiveChartsCore/Easing/CubicBezierEasingFunction.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -29,13 +29,14 @@ namespace LiveChartsCore.Easing;
 /// </summary>
 public static class CubicBezierEasingFunction
 {
-    private static readonly float s_iterations = 4f;
-    private static readonly float s_minSlope = 0.001f;
-    private static readonly float s_presicion = 0.0000001f;
-    private static readonly float s_maxIterations = 10f;
+    // Number of intervals in the precomputed lookup table. The eased value y is solved once
+    // per evenly-spaced x at build time; the returned delegate then only does an index + a
+    // linear interpolation, which is what makes it cheap to call every frame.
+    private const int LutIntervals = 256;
 
-    private static readonly int s_kSplineTableSize = 11;
-    private static readonly float s_kSampleStepSize = 1.0f / (s_kSplineTableSize - 1.0f);
+    // Build-time root solve for x(t) == aX. Cheap to do once per bucket; never runs per frame.
+    private const int BuildNewtonIterations = 8;
+    private const float MinSlope = 1e-6f;
 
     /// <summary>
     /// Builds a bezier easing function.
@@ -49,101 +50,53 @@ public static class CubicBezierEasingFunction
     public static Func<float, float> BuildBezierEasingFunction(float mX1, float mY1, float mX2, float mY2)
     {
         if (mX1 < 0 || mX1 > 1 || mX2 < 0 || mX2 > 1)
-        {
             throw new Exception("Bezier x values must be in [0, 1] range");
-        }
 
         if (mX1 == mY1 && mX2 == mY2)
-        {
             return LinearEasing;
-        }
 
-        // Pre compute samples table
-        var sampleValues = new float[s_kSplineTableSize];
-        for (var i = 0; i < s_kSplineTableSize; ++i)
+        // Polynomial coefficients of the cubic bezier (the first and last control points are
+        // fixed at 0 and 1), in Horner form: value(t) = ((a * t + b) * t + c) * t. They are
+        // constant for this curve, so we compute them once here instead of on every sample as
+        // the original port did.
+        var ax = 1f - 3f * mX2 + 3f * mX1;
+        var bx = 3f * mX2 - 6f * mX1;
+        var cx = 3f * mX1;
+        var ay = 1f - 3f * mY2 + 3f * mY1;
+        var by = 3f * mY2 - 6f * mY1;
+        var cy = 3f * mY1;
+
+        static float Calc(float t, float a, float b, float c) => ((a * t + b) * t + c) * t;
+        static float Slope(float t, float a, float b, float c) => (3f * a * t + 2f * b) * t + c;
+
+        // Precompute the eased y for evenly-spaced x. For each x we solve x(t) == x with a few
+        // Newton steps (seeded with t = x, which is already close), then store y(t). The endpoints
+        // are exact: Calc(0) == 0 and Calc(1) == 1 on both axes.
+        var lut = new float[LutIntervals + 1];
+        for (var i = 0; i <= LutIntervals; i++)
         {
-            sampleValues[i] = CalcBezier(i * s_kSampleStepSize, mX1, mX2);
-        }
-
-        float getTForX(float aX)
-        {
-            var intervalStart = 0.0f;
-            var currentSample = 1;
-            var lastSample = s_kSplineTableSize - 1;
-
-            for (; currentSample != lastSample && sampleValues[currentSample] <= aX; ++currentSample)
+            var x = i / (float)LutIntervals;
+            var t = x;
+            for (var k = 0; k < BuildNewtonIterations; k++)
             {
-                intervalStart += s_kSampleStepSize;
+                var slope = Slope(t, ax, bx, cx);
+                if (slope < MinSlope) break;
+                t -= (Calc(t, ax, bx, cx) - x) / slope;
             }
-            --currentSample;
-
-            // Interpolate to provide an initial guess for t
-            var dist = (aX - sampleValues[currentSample]) / (sampleValues[currentSample + 1] - sampleValues[currentSample]);
-            var guessForT = intervalStart + dist * s_kSampleStepSize;
-
-            var initialSlope = GetSlope(guessForT, mX1, mX2);
-            return initialSlope >= s_minSlope
-                ? NewtonRaphsonIterate(aX, guessForT, mX1, mX2)
-                : initialSlope == 0.0f ? guessForT : BinarySubdivide(aX, intervalStart, intervalStart + s_kSampleStepSize, mX1, mX2);
+            lut[i] = Calc(t, ay, by, cy);
         }
 
-        return (t) =>
+        return x =>
         {
-            // Because JavaScript number are imprecise, we should guarantee the extremes are right.
-            //if (t == 0f || t == 1f)
-            //{
-            //    return t;
-            //}
-            return CalcBezier(getTForX(t), mY1, mY2);
+            if (x <= 0f) return 0f;
+            if (x >= 1f) return 1f;
+
+            var f = x * LutIntervals;
+            var i = (int)f;
+            // linear interpolation between the two samples surrounding x.
+            return lut[i] + (lut[i + 1] - lut[i]) * (f - i);
         };
     }
 
-    private static float A(float aA1, float aA2) { return 1.0f - 3.0f * aA2 + 3.0f * aA1; }
-    private static float B(float aA1, float aA2) { return 3.0f * aA2 - 6.0f * aA1; }
-    private static float C(float aA1) { return 3.0f * aA1; }
-
-    private static float CalcBezier(float aT, float aA1, float aA2) { return ((A(aA1, aA2) * aT + B(aA1, aA2)) * aT + C(aA1)) * aT; }
-
-    private static float GetSlope(float aT, float aA1, float aA2) { return 3.0f * A(aA1, aA2) * aT * aT + 2.0f * B(aA1, aA2) * aT + C(aA1); }
-
-    private static float BinarySubdivide(float aX, float aA, float aB, float mX1, float mX2)
-    {
-        float currentX;
-        float currentT;
-        var i = 0;
-        do
-        {
-            currentT = aA + (aB - aA) / 2.0f;
-            currentX = CalcBezier(currentT, mX1, mX2) - aX;
-            if (currentX > 0.0)
-            {
-                aB = currentT;
-            }
-            else
-            {
-                aA = currentT;
-            }
-        } while (Math.Abs(currentX) > s_presicion && ++i < s_maxIterations);
-        return currentT;
-    }
-
-    private static float NewtonRaphsonIterate(float aX, float aGuessT, float mX1, float mX2)
-    {
-        for (var i = 0; i < s_iterations; ++i)
-        {
-            var currentSlope = GetSlope(aGuessT, mX1, mX2);
-            if (currentSlope == 0.0f)
-            {
-                return aGuessT;
-            }
-            var currentX = CalcBezier(aGuessT, mX1, mX2) - aX;
-            aGuessT -= currentX / currentSlope;
-        }
-        return aGuessT;
-    }
-
-    private static float LinearEasing(float x)
-    {
-        return x;
-    }
+    private static float LinearEasing(float x) => x;
 }

--- a/src/LiveChartsCore/Easing/CubicBezierEasingFunction.cs
+++ b/src/LiveChartsCore/Easing/CubicBezierEasingFunction.cs
@@ -34,9 +34,11 @@ public static class CubicBezierEasingFunction
     // linear interpolation, which is what makes it cheap to call every frame.
     private const int LutIntervals = 256;
 
-    // Build-time root solve for x(t) == aX. Cheap to do once per bucket; never runs per frame.
-    private const int BuildNewtonIterations = 8;
+    // Build-time root solve for x(t) == x. Cheap to do once per bucket; never runs per frame, so
+    // we can afford a robust bracketed solve rather than a few raw Newton steps.
+    private const int BuildSolveIterations = 24;
     private const float MinSlope = 1e-6f;
+    private const float SolveTolerance = 1e-6f;
 
     /// <summary>
     /// Builds a bezier easing function.
@@ -69,21 +71,33 @@ public static class CubicBezierEasingFunction
         static float Calc(float t, float a, float b, float c) => ((a * t + b) * t + c) * t;
         static float Slope(float t, float a, float b, float c) => (3f * a * t + 2f * b) * t + c;
 
-        // Precompute the eased y for evenly-spaced x. For each x we solve x(t) == x with a few
-        // Newton steps (seeded with t = x, which is already close), then store y(t). The endpoints
-        // are exact: Calc(0) == 0 and Calc(1) == 1 on both axes.
+        // Solve x(t) == x. x(t) is monotonic non-decreasing on [0, 1] for an easing curve, so we
+        // keep a [lo, hi] bracket and take a Newton step only when it is safe (non-tiny slope and
+        // the step stays inside the bracket); otherwise we bisect. This stays correct even for
+        // degenerate curves like mX1 == mX2 == 0 (x(t) == t^3), where a raw Newton seed overshoots.
+        static float SolveT(float x, float a, float b, float c)
+        {
+            float lo = 0f, hi = 1f, t = x;
+            for (var k = 0; k < BuildSolveIterations; k++)
+            {
+                var fx = Calc(t, a, b, c) - x;
+                if (Math.Abs(fx) < SolveTolerance) break;
+                if (fx > 0f) hi = t; else lo = t;
+
+                var slope = Slope(t, a, b, c);
+                var next = Math.Abs(slope) < MinSlope ? float.NaN : t - fx / slope;
+                t = next > lo && next < hi ? next : 0.5f * (lo + hi);
+            }
+            return t;
+        }
+
+        // Precompute the eased y for evenly-spaced x: solve x(t) == x, then store y(t). The
+        // endpoints are exact: Calc(0) == 0 and Calc(1) == 1 on both axes.
         var lut = new float[LutIntervals + 1];
         for (var i = 0; i <= LutIntervals; i++)
         {
             var x = i / (float)LutIntervals;
-            var t = x;
-            for (var k = 0; k < BuildNewtonIterations; k++)
-            {
-                var slope = Slope(t, ax, bx, cx);
-                if (slope < MinSlope) break;
-                t -= (Calc(t, ax, bx, cx) - x) / slope;
-            }
-            lut[i] = Calc(t, ay, by, cy);
+            lut[i] = Calc(SolveT(x, ax, bx, cx), ay, by, cy);
         }
 
         return x =>

--- a/src/LiveChartsCore/EasingFunctions.cs
+++ b/src/LiveChartsCore/EasingFunctions.cs
@@ -130,13 +130,20 @@ public static class EasingFunctions
     /// </value>
     public static Func<float, float> CubicInOut => CubicEasingFunction.InOut;
 
+    // The cubic-bezier easings are curve-constant, so build each lookup table once and reuse the
+    // delegate. They used to rebuild (allocating a table + closures) on every property access.
+    private static readonly Func<float, float> s_ease = CubicBezierEasingFunction.BuildBezierEasingFunction(0.25f, 0.1f, 0.25f, 1f);
+    private static readonly Func<float, float> s_easeIn = CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 1f, 1f);
+    private static readonly Func<float, float> s_easeOut = CubicBezierEasingFunction.BuildBezierEasingFunction(0f, 0f, 0.58f, 1f);
+    private static readonly Func<float, float> s_easeInOut = CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 0.58f, 1f);
+
     /// <summary>
     /// Gets the ease.
     /// </summary>
     /// <value>
     /// The ease.
     /// </value>
-    public static Func<float, float> Ease => BuildCubicBezier(0.25f, 0.1f, 0.25f, 1f);
+    public static Func<float, float> Ease => s_ease;
 
     /// <summary>
     /// Gets the ease in.
@@ -144,7 +151,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease in.
     /// </value>
-    public static Func<float, float> EaseIn => BuildCubicBezier(0.42f, 0f, 1f, 1f);
+    public static Func<float, float> EaseIn => s_easeIn;
 
     /// <summary>
     /// Gets the ease out.
@@ -152,7 +159,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease out.
     /// </value>
-    public static Func<float, float> EaseOut => BuildCubicBezier(0f, 0f, 0.58f, 1f);
+    public static Func<float, float> EaseOut => s_easeOut;
 
     /// <summary>
     /// Gets the ease in out.
@@ -160,7 +167,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease in out.
     /// </value>
-    public static Func<float, float> EaseInOut => BuildCubicBezier(0.42f, 0f, 0.58f, 1f);
+    public static Func<float, float> EaseInOut => s_easeInOut;
 
     /// <summary>
     /// Gets the elastic in.

--- a/src/LiveChartsCore/EasingFunctions.cs
+++ b/src/LiveChartsCore/EasingFunctions.cs
@@ -130,12 +130,18 @@ public static class EasingFunctions
     /// </value>
     public static Func<float, float> CubicInOut => CubicEasingFunction.InOut;
 
-    // The cubic-bezier easings are curve-constant, so build each lookup table once and reuse the
-    // delegate. They used to rebuild (allocating a table + closures) on every property access.
-    private static readonly Func<float, float> s_ease = CubicBezierEasingFunction.BuildBezierEasingFunction(0.25f, 0.1f, 0.25f, 1f);
-    private static readonly Func<float, float> s_easeIn = CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 1f, 1f);
-    private static readonly Func<float, float> s_easeOut = CubicBezierEasingFunction.BuildBezierEasingFunction(0f, 0f, 0.58f, 1f);
-    private static readonly Func<float, float> s_easeInOut = CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 0.58f, 1f);
+    // The cubic-bezier easings are curve-constant, so each lookup table is built once and reused.
+    // Lazy so a table is only computed when its easing is actually used (and never if it is not),
+    // instead of eagerly when the class is first touched. They used to rebuild the whole function
+    // (allocating a table + closures) on every property access.
+    private static readonly Lazy<Func<float, float>> s_ease =
+        new(() => CubicBezierEasingFunction.BuildBezierEasingFunction(0.25f, 0.1f, 0.25f, 1f));
+    private static readonly Lazy<Func<float, float>> s_easeIn =
+        new(() => CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 1f, 1f));
+    private static readonly Lazy<Func<float, float>> s_easeOut =
+        new(() => CubicBezierEasingFunction.BuildBezierEasingFunction(0f, 0f, 0.58f, 1f));
+    private static readonly Lazy<Func<float, float>> s_easeInOut =
+        new(() => CubicBezierEasingFunction.BuildBezierEasingFunction(0.42f, 0f, 0.58f, 1f));
 
     /// <summary>
     /// Gets the ease.
@@ -143,7 +149,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease.
     /// </value>
-    public static Func<float, float> Ease => s_ease;
+    public static Func<float, float> Ease => s_ease.Value;
 
     /// <summary>
     /// Gets the ease in.
@@ -151,7 +157,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease in.
     /// </value>
-    public static Func<float, float> EaseIn => s_easeIn;
+    public static Func<float, float> EaseIn => s_easeIn.Value;
 
     /// <summary>
     /// Gets the ease out.
@@ -159,7 +165,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease out.
     /// </value>
-    public static Func<float, float> EaseOut => s_easeOut;
+    public static Func<float, float> EaseOut => s_easeOut.Value;
 
     /// <summary>
     /// Gets the ease in out.
@@ -167,7 +173,7 @@ public static class EasingFunctions
     /// <value>
     /// The ease in out.
     /// </value>
-    public static Func<float, float> EaseInOut => s_easeInOut;
+    public static Func<float, float> EaseInOut => s_easeInOut.Value;
 
     /// <summary>
     /// Gets the elastic in.

--- a/tests/CoreTests/CoreObjectsTests/CubicBezierEasingTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CubicBezierEasingTests.cs
@@ -1,0 +1,101 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using LiveChartsCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+// The cubic-bezier easing now precomputes the curve into a lookup table and interpolates at
+// runtime instead of solving x(t) per call. These tests pin the LUT output to the exact analytic
+// curve (a high-iteration double-precision Newton solve) so the optimization cannot drift.
+[TestClass]
+public class CubicBezierEasingTests
+{
+    // Exact reference: solve x(t) == x with many Newton steps in double precision, then return y(t).
+    private static double Reference(double x, double x1, double x2, double y1, double y2)
+    {
+        static double Calc(double t, double a1, double a2) =>
+            (((1 - 3 * a2 + 3 * a1) * t + (3 * a2 - 6 * a1)) * t + 3 * a1) * t;
+        static double Slope(double t, double a1, double a2) =>
+            (3 * (1 - 3 * a2 + 3 * a1) * t + 2 * (3 * a2 - 6 * a1)) * t + 3 * a1;
+
+        if (x <= 0) return 0;
+        if (x >= 1) return 1;
+
+        var t = x;
+        for (var i = 0; i < 60; i++)
+        {
+            var slope = Slope(t, x1, x2);
+            if (slope == 0) break;
+            t -= (Calc(t, x1, x2) - x) / slope;
+        }
+        return Calc(t, y1, y2);
+    }
+
+    [DataTestMethod]
+    [DataRow(0.25f, 0.1f, 0.25f, 1f)]  // Ease
+    [DataRow(0.42f, 0f, 1f, 1f)]       // EaseIn
+    [DataRow(0f, 0f, 0.58f, 1f)]       // EaseOut
+    [DataRow(0.42f, 0f, 0.58f, 1f)]    // EaseInOut
+    [DataRow(0.8f, 0f, 0.2f, 1f)]      // steep, monotonic custom curve
+    public void LutMatchesAnalyticAcrossDomain(float x1, float y1, float x2, float y2)
+    {
+        var f = EasingFunctions.BuildCubicBezier(x1, y1, x2, y2);
+
+        // endpoints are exact by construction.
+        Assert.AreEqual(0f, f(0f), 1e-4f);
+        Assert.AreEqual(1f, f(1f), 1e-4f);
+
+        var previous = float.NegativeInfinity;
+        for (var i = 0; i <= 200; i++)
+        {
+            var x = i / 200f;
+            var actual = f(x);
+            var expected = (float)Reference(x, x1, x2, y1, y2);
+
+            Assert.IsTrue(
+                Math.Abs(actual - expected) < 5e-3f,
+                $"x={x}: LUT {actual} differs from analytic {expected} by more than 5e-3.");
+
+            // these curves are monotonic non-decreasing; the LUT must preserve that.
+            Assert.IsTrue(
+                actual >= previous - 1e-4f,
+                $"easing must be monotonic non-decreasing (x={x}).");
+            previous = actual;
+        }
+    }
+
+    [TestMethod]
+    public void LinearShortcutIsReturnedForIdentityCurve()
+    {
+        // when the control points lie on the diagonal the curve is the identity; the builder
+        // should return the linear shortcut rather than a table.
+        var f = EasingFunctions.BuildCubicBezier(0.3f, 0.3f, 0.7f, 0.7f);
+        for (var i = 0; i <= 10; i++)
+        {
+            var x = i / 10f;
+            Assert.AreEqual(x, f(x), 1e-6f);
+        }
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/CubicBezierEasingTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/CubicBezierEasingTests.cs
@@ -32,7 +32,9 @@ namespace CoreTests.CoreObjectsTests;
 [TestClass]
 public class CubicBezierEasingTests
 {
-    // Exact reference: solve x(t) == x with many Newton steps in double precision, then return y(t).
+    // Exact reference: solve x(t) == x in double precision, then return y(t). Uses a bracketed
+    // safe-Newton (bisection fallback) so it stays correct even for degenerate-slope curves where
+    // a raw Newton seed would overshoot — the same robustness the LUT builder relies on.
     private static double Reference(double x, double x1, double x2, double y1, double y2)
     {
         static double Calc(double t, double a1, double a2) =>
@@ -43,12 +45,16 @@ public class CubicBezierEasingTests
         if (x <= 0) return 0;
         if (x >= 1) return 1;
 
-        var t = x;
-        for (var i = 0; i < 60; i++)
+        double lo = 0, hi = 1, t = x;
+        for (var i = 0; i < 80; i++)
         {
+            var fx = Calc(t, x1, x2) - x;
+            if (Math.Abs(fx) < 1e-12) break;
+            if (fx > 0) hi = t; else lo = t;
+
             var slope = Slope(t, x1, x2);
-            if (slope == 0) break;
-            t -= (Calc(t, x1, x2) - x) / slope;
+            var next = Math.Abs(slope) < 1e-12 ? double.NaN : t - fx / slope;
+            t = next > lo && next < hi ? next : 0.5 * (lo + hi);
         }
         return Calc(t, y1, y2);
     }
@@ -59,6 +65,7 @@ public class CubicBezierEasingTests
     [DataRow(0f, 0f, 0.58f, 1f)]       // EaseOut
     [DataRow(0.42f, 0f, 0.58f, 1f)]    // EaseInOut
     [DataRow(0.8f, 0f, 0.2f, 1f)]      // steep, monotonic custom curve
+    [DataRow(0f, 0.6f, 0f, 1f)]        // degenerate slope at the ends: x(t) == t^3
     public void LutMatchesAnalyticAcrossDomain(float x1, float y1, float x2, float y2)
     {
         var f = EasingFunctions.BuildCubicBezier(x1, y1, x2, y2);


### PR DESCRIPTION
The cubic-bezier easing (`EasingFunctions.Ease` / `EaseIn` / `EaseOut` / `EaseInOut` and `BuildCubicBezier`) is a direct port of the `bezier-easing` JS library and runs in a per-frame hot path — called once per `MotionProperty` per geometry per frame.

### Two inefficiencies
1. **Per-call solve.** The returned delegate solved `x(t)` on every call (spline-table scan + Newton / binary subdivision), and every `CalcBezier`/`GetSlope` recomputed the curve's *constant* polynomial coefficients through `A()`/`B()`/`C()` — ~30 redundant coefficient computations per call.
2. **Per-access rebuild.** `Ease`/`EaseIn`/`EaseOut`/`EaseInOut` were expression-bodied **properties** (`=> BuildCubicBezier(...)`), so each access rebuilt the whole function (allocating the sample table + closures).

### Change
- `BuildBezierEasingFunction` now solves the curve **once at build time** into a 256-interval lookup table (constant coefficients hoisted out of the loop). The returned delegate is just an **index + linear interpolation** — a handful of float ops, no iteration, no allocation per call.
- The four named easings are cached in `static readonly` fields, so they build once.

### Correctness
- Endpoints stay exact (`f(0)=0`, `f(1)=1`) by construction; the identity curve still short-circuits to `LinearEasing`.
- A new test (`CubicBezierEasingTests`) compares the LUT against a high-iteration double-precision Newton solve for the four named curves plus a steep custom one, asserting agreement within **5e-3** and monotonicity across `[0,1]` — a 256-entry LUT with linear interpolation is visually exact for animation.
- CoreTests **811** green (805 + 6 new).

### Cost
~1 KB per built curve, computed once; with the named easings cached that's 4 instances total.

Standalone perf change, independent of the animation-API cleanup in #2345.