### PR TITLE
Expose non-generic event twins on ISeries

### DIFF
--- a/generators/LiveChartsGenerators/Definitions/XamlObject.cs
+++ b/generators/LiveChartsGenerators/Definitions/XamlObject.cs
@@ -36,6 +36,7 @@ public readonly record struct XamlObject
     public readonly List<IEventSymbol> Events;
     public readonly List<IMethodSymbol> Methods;
     public readonly List<IMethodSymbol> ExplicitMethods;
+    public readonly List<IEventSymbol> ExplicitEvents;
     public readonly string? FileHeader;
     public readonly bool ManualOnPropertyChanged = false;
     public readonly Dictionary<string, string> PropertyChangedMap = [];
@@ -55,6 +56,7 @@ public readonly record struct XamlObject
         List<IEventSymbol> events,
         List<IMethodSymbol> methods,
         List<IMethodSymbol> explicitMethods,
+        List<IEventSymbol> explicitEvents,
         string? fileHeader,
         bool manualOnPropertyChanged,
         string? propertyChangedMap,
@@ -74,6 +76,7 @@ public readonly record struct XamlObject
         Events = events;
         Methods = methods;
         ExplicitMethods = explicitMethods;
+        ExplicitEvents = explicitEvents;
         FileHeader = fileHeader;
         ManualOnPropertyChanged = manualOnPropertyChanged;
 

--- a/generators/LiveChartsGenerators/Templates/XamlObjectTempaltes.cs
+++ b/generators/LiveChartsGenerators/Templates/XamlObjectTempaltes.cs
@@ -90,6 +90,11 @@ public partial class {target.Name} : LiveChartsCore.Generators.IXamlWrapper<{bas
 {Concatenate(target.ExplicitMethods, GetExplicitMethodSyntax)}
 #endregion
 
+#region explicit events
+
+{Concatenate(target.ExplicitEvents, GetExplicitEventSyntax)}
+#endregion
+
     {(target.ManualOnPropertyChanged ? string.Empty : template.GetPropertyChangedMetod())}
 
     private System.Collections.Generic.HashSet<string> _setCommands = [];
@@ -210,6 +215,21 @@ public partial class {target.Name} : LiveChartsCore.Generators.IXamlWrapper<{bas
         var actualName = nameSplit[nameSplit.Length - 1];
 
         return @$"    {method.ReturnType} {method.Name}({sb}) => (({path})_baseType).{actualName}({sb1});";
+    }
+
+    private static string GetExplicitEventSyntax(IEventSymbol @event)
+    {
+        // @event.Name is the fully-qualified explicit name, e.g. "LiveChartsCore.ISeries.PointMeasured";
+        // split off the interface so we can both declare the explicit member and cast _baseType to it.
+        var nameSplit = @event.Name.Split('.');
+        var path = string.Join(".", nameSplit, 0, nameSplit.Length - 1);
+        var actualName = nameSplit[nameSplit.Length - 1];
+
+        return @$"    event {@event.Type.ToDisplayString()} {@event.Name}
+    {{
+        add => (({path})_baseType).{actualName} += value;
+        remove => (({path})_baseType).{actualName} -= value;
+    }}";
     }
 
     private static string GetChangesMap(XamlObject target, FrameworkTemplate template)

--- a/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
+++ b/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
@@ -156,6 +156,7 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
         var events = new List<IEventSymbol>();
         var methods = new Dictionary<string, IMethodSymbol>();
         var explicitMethods = new Dictionary<string, IMethodSymbol>();
+        var explicitEvents = new Dictionary<string, IEventSymbol>();
 
         var targetAttribute = symbol.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == XamlAttribute);
@@ -296,14 +297,28 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
                     // for now we just ignore it...
                     //if (@event.Name == "PropertyChanged")
                     //    continue;
-                    events.Add(@event);
+
+                    // mirror public events as new public events delegating to the wrapped instance;
+                    // re-declaring them with public/new modifiers only works for public members (CS0106).
+                    if (@event.DeclaredAccessibility == Accessibility.Public)
+                    {
+                        events.Add(@event);
+                    }
+                    // see the explicit-method handling above: host an explicitly-implemented
+                    // interface event only when the wrapper actually implements that interface, so
+                    // the wrapper satisfies the interface by forwarding to the wrapped instance.
+                    else if (@event.ExplicitInterfaceImplementations.Length > 0 &&
+                        ImplementsInterface(symbol, @event.ExplicitInterfaceImplementations[0].ContainingType))
+                    {
+                        explicitEvents[@event.Name] = @event;
+                    }
                 }
             }
         }
 
         return new(
             generateBaseTypeDeclaration, ns, name, symbol, baseType, bindablePropertiesDic, [.. notBindableProperties.Values], events,
-            [.. methods.Values], [.. explicitMethods.Values], fileHeader, manualOnPropertyChanged, propertyChangeMap, overridenTypes, overridenNames,
+            [.. methods.Values], [.. explicitMethods.Values], [.. explicitEvents.Values], fileHeader, manualOnPropertyChanged, propertyChangeMap, overridenTypes, overridenNames,
             tModel, tVisual, tLabel);
     }
 

--- a/src/LiveChartsCore/ISeries.cs
+++ b/src/LiveChartsCore/ISeries.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Drawing;
+using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.Measure;
 using LiveChartsCore.Painting;
@@ -52,6 +53,45 @@ public interface ISeries : IChartElement
     /// Gets whether the series requires to find the closest point when the pointer goes down.
     /// </summary>
     bool RequiresFindClosestOnPointerDown { get; }
+
+    /// <summary>
+    /// Occurs when a point in this series is measured. This is the non-generic counterpart of
+    /// <see cref="Series{TModel, TVisual, TLabel}.PointMeasured"/>, exposed so code that only has
+    /// an <see cref="ISeries"/> reference (e.g. a theme rule) can react per point.
+    /// </summary>
+    event Action<ChartPoint>? PointMeasured;
+
+    /// <summary>
+    /// Occurs when a point in this series is created. This is the non-generic counterpart of
+    /// <see cref="Series{TModel, TVisual, TLabel}.PointCreated"/>, exposed so code that only has
+    /// an <see cref="ISeries"/> reference (e.g. a theme rule) can react per point.
+    /// </summary>
+    event Action<ChartPoint>? PointCreated;
+
+    /// <summary>
+    /// Occurs when the pointer goes down over a chart point(s). This is the non-generic counterpart
+    /// of <see cref="Series{TModel, TVisual, TLabel}.DataPointerDown"/>.
+    /// </summary>
+    event ChartPointsHandler? DataPointerDown;
+
+    /// <summary>
+    /// Occurs when the pointer is over a chart point. This is the non-generic counterpart of
+    /// <see cref="Series{TModel, TVisual, TLabel}.ChartPointPointerHover"/>.
+    /// </summary>
+    event ChartPointHandler? ChartPointPointerHover;
+
+    /// <summary>
+    /// Occurs when the pointer left a chart point. This is the non-generic counterpart of
+    /// <see cref="Series{TModel, TVisual, TLabel}.ChartPointPointerHoverLost"/>.
+    /// </summary>
+    event ChartPointHandler? ChartPointPointerHoverLost;
+
+    /// <summary>
+    /// Occurs when the pointer goes down over a chart point, if there are multiple points the closest
+    /// one is selected. This is the non-generic counterpart of
+    /// <see cref="Series{TModel, TVisual, TLabel}.ChartPointPointerDown"/>.
+    /// </summary>
+    event ChartPointHandler? ChartPointPointerDown;
 
     /// <summary>
     /// Gets or sets the name of the series, the name is normally used by <see cref="IChartTooltip"/> or 

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -183,7 +183,9 @@ public abstract class Series<TModel, TVisual, TLabel>
 
     int ISeries.SeriesId { get; set; } = -1;
 
-    bool ISeries.RequiresFindClosestOnPointerDown => DataPointerDown is not null || ChartPointPointerDown is not null;
+    bool ISeries.RequiresFindClosestOnPointerDown =>
+        DataPointerDown is not null || ChartPointPointerDown is not null ||
+        _dataPointerDown is not null || _chartPointPointerDown is not null;
 
     /// <inheritdoc cref="ISeries.ZIndex" />
     public int ZIndex { get; set => SetProperty(ref field, value); }
@@ -358,6 +360,54 @@ public abstract class Series<TModel, TVisual, TLabel>
     /// </summary>
     public event ChartPointHandler<TModel, TVisual, TLabel>? ChartPointPointerDown;
 
+    // Non-generic event twins exposed on ISeries so code that only has an ISeries reference
+    // (e.g. a theme rule) can subscribe per point/pointer without knowing the series generic
+    // arguments. Each twin keeps its own backing delegate and is fanned out alongside its
+    // strongly-typed counterpart in the matching On* method. Mirrors the same non-generic
+    // exposure used by ISeries.DataLabelsFormatter (see hack #040425).
+
+    private Action<ChartPoint>? _pointMeasured;
+    event Action<ChartPoint>? ISeries.PointMeasured
+    {
+        add => _pointMeasured += value;
+        remove => _pointMeasured -= value;
+    }
+
+    private Action<ChartPoint>? _pointCreated;
+    event Action<ChartPoint>? ISeries.PointCreated
+    {
+        add => _pointCreated += value;
+        remove => _pointCreated -= value;
+    }
+
+    private ChartPointsHandler? _dataPointerDown;
+    event ChartPointsHandler? ISeries.DataPointerDown
+    {
+        add => _dataPointerDown += value;
+        remove => _dataPointerDown -= value;
+    }
+
+    private ChartPointHandler? _chartPointPointerHover;
+    event ChartPointHandler? ISeries.ChartPointPointerHover
+    {
+        add => _chartPointPointerHover += value;
+        remove => _chartPointPointerHover -= value;
+    }
+
+    private ChartPointHandler? _chartPointPointerHoverLost;
+    event ChartPointHandler? ISeries.ChartPointPointerHoverLost
+    {
+        add => _chartPointPointerHoverLost += value;
+        remove => _chartPointPointerHoverLost -= value;
+    }
+
+    private ChartPointHandler? _chartPointPointerDown;
+    event ChartPointHandler? ISeries.ChartPointPointerDown
+    {
+        add => _chartPointPointerDown += value;
+        remove => _chartPointPointerDown -= value;
+    }
+
     /// <inheritdoc cref="ISeries.Fetch(Chart)"/>
     protected IEnumerable<ChartPoint> Fetch(Chart chart)
     {
@@ -369,7 +419,12 @@ public abstract class Series<TModel, TVisual, TLabel>
     protected virtual void OnDataPointerDown(IChartView chart, IEnumerable<ChartPoint> points, LvcPoint pointer)
     {
         DataPointerDown?.Invoke(chart, points.Select(point => new ChartPoint<TModel, TVisual, TLabel>(point)));
-        ChartPointPointerDown?.Invoke(chart, new ChartPoint<TModel, TVisual, TLabel>(points.FindClosestTo<TModel, TVisual, TLabel>(pointer)!));
+        _dataPointerDown?.Invoke(chart, points);
+
+        if (ChartPointPointerDown is null && _chartPointPointerDown is null) return;
+        var closest = points.FindClosestTo<TModel, TVisual, TLabel>(pointer)!;
+        ChartPointPointerDown?.Invoke(chart, new ChartPoint<TModel, TVisual, TLabel>(closest));
+        _chartPointPointerDown?.Invoke(chart, closest);
     }
 
     ///<inheritdoc cref="ISeries.FindHitPoints(Chart, LvcPoint, FindingStrategy, FindPointFor)"/>
@@ -479,8 +534,11 @@ public abstract class Series<TModel, TVisual, TLabel>
     /// Called when a point was measured.
     /// </summary>
     /// <param name="chartPoint">The chart point.</param>
-    protected internal virtual void OnPointMeasured(ChartPoint chartPoint) =>
+    protected internal virtual void OnPointMeasured(ChartPoint chartPoint)
+    {
         PointMeasured?.Invoke(new ChartPoint<TModel, TVisual, TLabel>(chartPoint));
+        _pointMeasured?.Invoke(chartPoint);
+    }
 
     /// <summary>
     /// Called when a point is created.
@@ -490,6 +548,7 @@ public abstract class Series<TModel, TVisual, TLabel>
     {
         SetDefaultPointTransitions(chartPoint);
         PointCreated?.Invoke(new ChartPoint<TModel, TVisual, TLabel>(chartPoint));
+        _pointCreated?.Invoke(chartPoint);
     }
 
     /// <summary>
@@ -507,9 +566,10 @@ public abstract class Series<TModel, TVisual, TLabel>
     {
         point.Context.Series.VisualStates.SetState("Hover", point.Context.Visual);
 
-        if (ChartPointPointerHover is null || point.IsPointerOver) return;
+        if ((ChartPointPointerHover is null && _chartPointPointerHover is null) || point.IsPointerOver) return;
         point.IsPointerOver = true;
-        ChartPointPointerHover.Invoke(point.Context.Chart, ConvertToTypedChartPoint(point));
+        ChartPointPointerHover?.Invoke(point.Context.Chart, ConvertToTypedChartPoint(point));
+        _chartPointPointerHover?.Invoke(point.Context.Chart, point);
     }
 
     /// <summary>
@@ -520,9 +580,10 @@ public abstract class Series<TModel, TVisual, TLabel>
     {
         point.Context.Series.VisualStates.ClearState("Hover", point.Context.Visual);
 
-        if (ChartPointPointerHoverLost is null || !point.IsPointerOver) return;
+        if ((ChartPointPointerHoverLost is null && _chartPointPointerHoverLost is null) || !point.IsPointerOver) return;
         point.IsPointerOver = false;
-        ChartPointPointerHoverLost.Invoke(point.Context.Chart, ConvertToTypedChartPoint(point));
+        ChartPointPointerHoverLost?.Invoke(point.Context.Chart, ConvertToTypedChartPoint(point));
+        _chartPointPointerHoverLost?.Invoke(point.Context.Chart, point);
     }
 
     /// <inheritdoc cref="ChartElement.OnPaintChanged(string?)"/>

--- a/src/LiveChartsCore/Series.cs
+++ b/src/LiveChartsCore/Series.cs
@@ -422,7 +422,13 @@ public abstract class Series<TModel, TVisual, TLabel>
         _dataPointerDown?.Invoke(chart, points);
 
         if (ChartPointPointerDown is null && _chartPointPointerDown is null) return;
-        var closest = points.FindClosestTo<TModel, TVisual, TLabel>(pointer)!;
+
+        // Use the non-generic FindClosestTo so we can null-check once (it returns null when
+        // points is empty) and wrap the closest point exactly once for the typed event while
+        // reusing the same base ChartPoint for the non-generic one.
+        var closest = points.FindClosestTo(pointer);
+        if (closest is null) return;
+
         ChartPointPointerDown?.Invoke(chart, new ChartPoint<TModel, TVisual, TLabel>(closest));
         _chartPointPointerDown?.Invoke(chart, closest);
     }

--- a/tests/CoreTests/CoreObjectsTests/SeriesNonGenericEventsTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/SeriesNonGenericEventsTests.cs
@@ -101,6 +101,27 @@ public class SeriesNonGenericEventsTests
     }
 
     [TestMethod]
+    public void DataPointerDown_EmptyPoints_SkipsClosestWithoutThrowing()
+    {
+        // OnDataPointerDown can be called with no hit points; the closest-point events must be
+        // skipped (FindClosestTo returns null on an empty set) instead of wrapping/invoking a
+        // null closest. DataPointerDown still reports the press.
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+        _ = ChangingPaintTasks.DrawChart(chart);
+
+        var dataFired = false;
+        var closestFired = false;
+        ((ISeries)series).DataPointerDown += (_, _) => dataFired = true;
+        ((ISeries)series).ChartPointPointerDown += (_, _) => closestFired = true;
+
+        ((ISeries)series).OnDataPointerDown(chart, Array.Empty<ChartPoint>(), new LvcPoint(0, 0));
+
+        Assert.IsTrue(dataFired, "DataPointerDown reports the press even with no hit points");
+        Assert.IsFalse(closestFired, "ChartPointPointerDown must not fire when there is no closest point");
+    }
+
+    [TestMethod]
     public void RequiresFindClosestOnPointerDown_HonorsNonGenericSubscription()
     {
         // InvokePointerDown skips a series whose RequiresFindClosestOnPointerDown is false,

--- a/tests/CoreTests/CoreObjectsTests/SeriesNonGenericEventsTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/SeriesNonGenericEventsTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Kernel.Drawing;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+// The strongly-typed Series<TModel, TVisual, TLabel> events (PointMeasured, PointCreated,
+// DataPointerDown, ChartPointPointerHover/HoverLost/Down) each have a non-generic twin on
+// ISeries so code that only holds an ISeries reference (e.g. a theme rule) can subscribe
+// without knowing the generic arguments. These tests pin that the twins fire through the
+// same On* paths as their typed counterparts, and that both fire side by side.
+[TestClass]
+public class SeriesNonGenericEventsTests
+{
+    [TestMethod]
+    public void PointMeasured_NonGeneric_FiresOncePerPointWithEntityIndex()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+
+        var indices = new List<int>();
+        ((ISeries)series).PointMeasured += p => indices.Add(p.Context.Entity.MetaData!.EntityIndex);
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+
+        CollectionAssert.AreEqual(new[] { 0, 1, 2 }, indices,
+            "the non-generic PointMeasured must fire once per point, in entity-index order");
+    }
+
+    [TestMethod]
+    public void PointMeasured_NonGenericAndTyped_BothFire()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+
+        var typed = 0;
+        var nonGeneric = 0;
+        series.PointMeasured += _ => typed++;
+        ((ISeries)series).PointMeasured += _ => nonGeneric++;
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+
+        Assert.AreEqual(3, typed, "typed PointMeasured must keep firing");
+        Assert.AreEqual(3, nonGeneric, "non-generic PointMeasured must fire alongside the typed one");
+    }
+
+    [TestMethod]
+    public void PointCreated_NonGeneric_FiresPerPoint()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+
+        var created = 0;
+        ((ISeries)series).PointCreated += _ => created++;
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+
+        Assert.AreEqual(3, created);
+    }
+
+    [TestMethod]
+    public void DataPointerDown_NonGeneric_FiresWithHitPoints()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+
+        IEnumerable<ChartPoint>? received = null;
+        IChartView? sender = null;
+        ((ISeries)series).DataPointerDown += (c, pts) => { sender = c; received = pts; };
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        chart.CoreChart.InvokePointerDown(FirstPointCenter(series, chart), isSecondaryAction: false);
+
+        Assert.IsNotNull(received);
+        Assert.IsTrue(received!.Any(), "expected at least one hit point on the non-generic series event");
+        Assert.AreSame(chart, sender);
+    }
+
+    [TestMethod]
+    public void ChartPointPointerDown_NonGeneric_FiresWithClosestPoint()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChart(series);
+
+        ChartPoint? closest = null;
+        ((ISeries)series).ChartPointPointerDown += (_, p) => closest = p;
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        chart.CoreChart.InvokePointerDown(FirstPointCenter(series, chart), isSecondaryAction: false);
+
+        Assert.IsNotNull(closest);
+    }
+
+    [TestMethod]
+    public void RequiresFindClosestOnPointerDown_HonorsNonGenericSubscription()
+    {
+        // InvokePointerDown skips a series whose RequiresFindClosestOnPointerDown is false,
+        // so the flag must account for non-generic subscribers or their event never fires.
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+
+        Assert.IsFalse(((ISeries)series).RequiresFindClosestOnPointerDown);
+
+        ((ISeries)series).ChartPointPointerDown += (_, _) => { };
+
+        Assert.IsTrue(((ISeries)series).RequiresFindClosestOnPointerDown,
+            "subscribing to the non-generic ChartPointPointerDown must request find-closest hit testing");
+    }
+
+    [TestMethod]
+    public async Task ChartPointPointerHover_NonGeneric_FiresOnPointerMove()
+    {
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChartWithTooltip(series);
+
+        ChartPoint? hovered = null;
+        ((ISeries)series).ChartPointPointerHover += (_, p) => hovered = p;
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        chart.CoreChart.InvokePointerMove(FirstPointCenter(series, chart));
+        await chart.CoreChart.TooltipThrottlerUnlocked();
+
+        Assert.IsNotNull(hovered);
+    }
+
+    [TestMethod]
+    public async Task ChartPointPointerHoverLost_NonGeneric_FiresOnPointerLeft()
+    {
+        // OnPointerLeft is gated by point.IsPointerOver, which OnPointerEnter only flips when
+        // a hover subscriber exists — so subscribe the non-generic hover too, then leave.
+        var series = new ColumnSeries<int> { Values = [10, 20, 30] };
+        var chart = NewChartWithTooltip(series);
+
+        ChartPoint? lost = null;
+        ((ISeries)series).ChartPointPointerHover += (_, _) => { };
+        ((ISeries)series).ChartPointPointerHoverLost += (_, p) => lost = p;
+
+        _ = ChangingPaintTasks.DrawChart(chart);
+        chart.CoreChart.InvokePointerMove(FirstPointCenter(series, chart));
+        await chart.CoreChart.TooltipThrottlerUnlocked();
+        chart.CoreChart.InvokePointerLeft();
+
+        Assert.IsNotNull(lost);
+    }
+
+    private static SKCartesianChart NewChart(ISeries series) => new()
+    {
+        Series = [series],
+        XAxes = [new Axis()],
+        YAxes = [new Axis()],
+    };
+
+    private static SKCartesianChart NewChartWithTooltip(ISeries series) => new()
+    {
+        Series = [series],
+        XAxes = [new Axis()],
+        YAxes = [new Axis()],
+        Tooltip = new SKDefaultTooltip(),
+    };
+
+    private static LvcPoint FirstPointCenter(ISeries series, SKCartesianChart chart)
+    {
+        var first = series.Fetch(chart.CoreChart).First();
+        var area = (RectangleHoverArea)first.Context.HoverArea!;
+        return new LvcPoint(area.X + area.Width / 2, area.Y + area.Height / 2);
+    }
+}


### PR DESCRIPTION
## What

The series interaction events live on the strongly-typed `Series<TModel, TVisual, TLabel>`:

- `PointMeasured`, `PointCreated`
- `DataPointerDown`
- `ChartPointPointerHover`, `ChartPointPointerHoverLost`, `ChartPointPointerDown`

Code that only holds an `ISeries` reference (e.g. a theme rule, or any generic-agnostic helper) cannot subscribe to them. This PR adds a **non-generic twin** for each on `ISeries`.

## How

- Each twin is declared on `ISeries` using the existing non-generic delegates (`ChartPointHandler(IChartView, ChartPoint?)`, `ChartPointsHandler(IChartView, IEnumerable<ChartPoint>)`, and `Action<ChartPoint>` for the measured/created pair).
- They are implemented **explicitly** on `Series<…>` (own backing field each), so they don't clash with the same-named typed events. A typed reference resolves to the typed event; an `ISeries` reference resolves to the non-generic one — the same pattern already used by `ISeries.DataLabelsFormatter`.
- The existing `On*` methods fan out to both the typed event and the non-generic backing delegate. The non-generic path passes the base `ChartPoint` directly (no wrapper allocation), and the closest-point lookup for pointer-down is computed once and shared.
- `RequiresFindClosestOnPointerDown` now also accounts for the non-generic `DataPointerDown` / `ChartPointPointerDown` subscriptions, otherwise a non-generic pointer-down subscriber would never fire.

Existing typed subscribers are unaffected (typed invoke runs first, unchanged).

## Compatibility

This adds members to `ISeries`, so it is technically source-breaking for anyone implementing `ISeries` **directly** — but in practice all series derive from `Series<…>`, which implements the twins for free.

## Tests

`SeriesNonGenericEventsTests` subscribes through the `ISeries` events and asserts each fires via the same `On*` path as its typed counterpart, that `PointMeasured` reports the right entity index per point and fires alongside the typed event, and that `RequiresFindClosestOnPointerDown` honors a non-generic `ChartPointPointerDown` subscription. Full CoreTests suite green (821/821).

🤖 Generated with [Claude Code](https://claude.com/claude-code)