### PR TITLE
Remove the theme-level draw-margin-frame rule

### DIFF
--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -835,8 +835,7 @@ public class CartesianChartEngine(
             _drawnSeries.Add(series.SeriesId);
         }
 
-        var actualDrawMarginFrame = _chartView.DrawMarginFrame?.ChartElementSource
-            ?? theme.DrawMarginFrameGetter?.Invoke();
+        var actualDrawMarginFrame = _chartView.DrawMarginFrame?.ChartElementSource;
 
         if (_previousDrawMarginFrame is not null && _chartView.DrawMarginFrame != _previousDrawMarginFrame)
         {
@@ -847,17 +846,8 @@ public class CartesianChartEngine(
         }
         if (actualDrawMarginFrame is not null)
         {
-            var ce = actualDrawMarginFrame;
-            if (ce._theme != themeId)
-            {
-                ce._isInternalSet = true;
-                theme.ApplyStyleToDrawMarginFrame((CoreDrawMarginFrame)ce);
-                ce._theme = themeId;
-                ce._isInternalSet = false;
-            }
-
             if (actualDrawMarginFrame.IsVisible) AddVisual(actualDrawMarginFrame);
-            _previousDrawMarginFrame = ce;
+            _previousDrawMarginFrame = actualDrawMarginFrame;
         }
 
         CollectVisuals();

--- a/src/LiveChartsCore/Themes/LiveChartsStylerExtensions.cs
+++ b/src/LiveChartsCore/Themes/LiveChartsStylerExtensions.cs
@@ -60,20 +60,6 @@ public static class LiveChartsthemeExtensions
     }
 
     /// <summary>
-    /// Defines a style builder for <see cref="CoreDrawMarginFrame"/> objects.
-    /// </summary>
-    /// <param name="theme">The theme.</param>
-    /// <param name="getter">The getter.</param>
-    /// <param name="predicate">The predicate.</param>
-    /// <returns></returns>
-    public static Theme HasRuleForDrawMarginFrame(this Theme theme, Func<CoreDrawMarginFrame?> getter, Action<CoreDrawMarginFrame> predicate)
-    {
-        theme.DrawMarginFrameGetter = getter;
-        theme.DrawMarginFrameBuilder.Add(predicate);
-        return theme;
-    }
-
-    /// <summary>
     ///  Defines a style builder for <see cref="ISeries"/> objects.
     /// </summary>
     /// <param name="theme">The theme.</param>

--- a/src/LiveChartsCore/Themes/Theme.cs
+++ b/src/LiveChartsCore/Themes/Theme.cs
@@ -118,19 +118,6 @@ public class Theme
     public List<Action<IPlane>> AxisBuilder { get; set; } = [];
 
     /// <summary>
-    /// Gets or sets the draw margin frame getter.
-    /// </summary>
-    /// <value>
-    /// The draw margin frame builder.
-    /// </value>
-    public Func<CoreDrawMarginFrame?>? DrawMarginFrameGetter { get; set; }
-
-    /// <summary>
-    /// Gets or sets the draw margin frame builder.
-    /// </summary>
-    public List<Action<CoreDrawMarginFrame>> DrawMarginFrameBuilder { get; set; } = [];
-
-    /// <summary>
     /// Gets or sets the series builder.
     /// </summary>
     /// <value>
@@ -503,15 +490,6 @@ public class Theme
         {
             foreach (var rule in SankeySeriesBuilder) rule((ISankeySeries)series);
         }
-    }
-
-    /// <summary>
-    /// Build a draw amrgin frame based on the theme.
-    /// </summary>
-    public void ApplyStyleToDrawMarginFrame(CoreDrawMarginFrame drawMarginFrame)
-    {
-        foreach (var rule in DrawMarginFrameBuilder)
-            rule(drawMarginFrame);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Removes the theme API for building/styling the draw-margin frame:

- `Theme.HasRuleForDrawMarginFrame(getter, predicate)`
- `Theme.DrawMarginFrameGetter`
- `Theme.DrawMarginFrameBuilder`
- `Theme.ApplyStyleToDrawMarginFrame(...)`

## Why

It is redundant. The draw-margin frame is a cartesian-view concept, and a theme can set it directly from a `HasRuleForChart` rule:

```csharp
theme.HasRuleForChart(chart =>
{
    if (chart is not ICartesianChartView cartesian) return;
    cartesian.DrawMarginFrame = new DrawMarginFrame { Stroke = new SolidColorPaint(...) };
});
```

That path is actually better: chart rules run while `_isApplyingTheme` is set, so the generated dependency-property setter routes through `SetThemedValue` and **won't clobber a frame the user set** in XAML/code. The old getter/builder bypassed that.

Nothing in the library, the default theme, the tests or the samples used `HasRuleForDrawMarginFrame`. The cartesian engine now reads the frame solely from `IChartView.DrawMarginFrame` (no theme getter fallback, no theme styling pass).

## Breaking change

The four members above are removed from the public surface. Migration is the `HasRuleForChart` snippet above.

## Tests

CoreTests green (813/813, net8.0). No test referenced the removed API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)