### PR TITLE
Fix: axis zero line drawn behind separators

### DIFF
--- a/src/LiveChartsCore/Painting/PaintConstants.cs
+++ b/src/LiveChartsCore/Painting/PaintConstants.cs
@@ -59,9 +59,11 @@ internal static class PaintConstants
     internal const double AxisSubticksPaintZIndex = -0.85;
 
     /// <summary>
-    /// Default z-index for axis zero line paint.
+    /// Default z-index for axis zero line paint. Sits just above the separators and
+    /// subseparators (both -1) so the zero line is not hidden behind the grid, while
+    /// staying below the ticks and labels.
     /// </summary>
-    internal const double AxisZeroPaintZIndex = -1;
+    internal const double AxisZeroPaintZIndex = -0.95;
 
     /// <summary>
     /// Default z-index for axis bands paint — above the draw margin frame fill (-3),

--- a/tests/CoreTests/CoreObjectsTests/AxisZeroLineZIndexTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/AxisZeroLineZIndexTests.cs
@@ -1,0 +1,42 @@
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+[TestClass]
+public class AxisZeroLineZIndexTests
+{
+    [TestMethod]
+    public void ZeroLineDrawsAboveSeparatorsAndSubseparators()
+    {
+        // The zero line shared the separators' z-index (-1), so it was hidden behind the grid.
+        // After measure the paints carry their default z-index; the zero line must win.
+        var yAxis = new Axis
+        {
+            MinLimit = -10,
+            MaxLimit = 10,
+            SeparatorsPaint = new SolidColorPaint(SKColors.Gray),
+            SubseparatorsPaint = new SolidColorPaint(SKColors.LightGray),
+            ZeroPaint = new SolidColorPaint(SKColors.Black),
+        };
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 400,
+            Series = [new LineSeries<double> { Values = [-5, 0, 5] }],
+            YAxes = [yAxis],
+        };
+
+        _ = chart.GetImage();
+
+        Assert.IsTrue(yAxis.ZeroPaint!.ZIndex > yAxis.SeparatorsPaint!.ZIndex,
+            "the zero line must draw above the separators");
+        Assert.IsTrue(yAxis.ZeroPaint!.ZIndex > yAxis.SubseparatorsPaint!.ZIndex,
+            "the zero line must draw above the subseparators");
+    }
+}


### PR DESCRIPTION
## Bug

When an axis has both a `ZeroPaint` and a `SeparatorsPaint`, the zero line renders **behind** the separators (most visible on the Y axis).

## Cause

`AxisZeroPaintZIndex` was `-1` — identical to `AxisSeparatorsPaintZIndex` and `AxisSubseparatorsPaintZIndex` (both `-1`). With equal z-indexes the draw order falls back to insertion order, and the zero line loses.

## Fix

Bump `AxisZeroPaintZIndex` to `-0.95` so the zero line sits just above the grid (separators/subseparators at `-1`) while remaining below the ticks (`-0.8` / `-0.85`) and labels (`-0.9`).

## Tests

- New `AxisZeroLineZIndexTests` asserts (after measure) the zero line's z-index is greater than the separators' and subseparators'. Fails before this change (`-1 > -1` is false), passes after.
- Full CoreTests green; SnapshotTests green (174/174, including the axis snapshots that use `ZeroPaint`) — no existing baseline changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)