### PR TITLE
Add a post phase to the series theme builders

### DIFF
--- a/src/LiveChartsCore/Themes/LiveChartsStylerExtensions.cs
+++ b/src/LiveChartsCore/Themes/LiveChartsStylerExtensions.cs
@@ -72,6 +72,20 @@ public static class LiveChartsthemeExtensions
     }
 
     /// <summary>
+    /// Defines a style builder for <see cref="ISeries"/> objects that runs AFTER the
+    /// type-specific builders, when the series' paints and other defaults are already
+    /// assigned. Use it for rules that decorate or read the fully styled series.
+    /// </summary>
+    /// <param name="theme">The theme.</param>
+    /// <param name="predicate">The predicate.</param>
+    /// <returns></returns>
+    public static Theme HasPostRuleForAnySeries(this Theme theme, Action<ISeries> predicate)
+    {
+        theme.SeriesPostBuilder.Add(predicate);
+        return theme;
+    }
+
+    /// <summary>
     ///  Defines a style builder for <see cref="IPieSeries"/> objects.
     /// </summary>
     /// <param name="theme">The theme.</param>

--- a/src/LiveChartsCore/Themes/Theme.cs
+++ b/src/LiveChartsCore/Themes/Theme.cs
@@ -126,6 +126,13 @@ public class Theme
     public List<Action<ISeries>> SeriesBuilder { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets the post series builder. These rules run AFTER the type-specific builders
+    /// (so a series' paints and other defaults are already assigned), which makes this the place
+    /// for rules that decorate or read the final styled series.
+    /// </summary>
+    public List<Action<ISeries>> SeriesPostBuilder { get; set; } = [];
+
+    /// <summary>
     /// Gets or sets the pie series builder.
     /// </summary>
     /// <value>
@@ -490,6 +497,10 @@ public class Theme
         {
             foreach (var rule in SankeySeriesBuilder) rule((ISankeySeries)series);
         }
+
+        // Runs last, after the type-specific builders assigned the series' paints / defaults,
+        // so post rules can decorate or read the fully styled series.
+        foreach (var rule in SeriesPostBuilder) rule(series);
     }
 
     /// <summary>

--- a/tests/CoreTests/CoreObjectsTests/ThemeSeriesPostRuleTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/ThemeSeriesPostRuleTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using LiveChartsCore.Kernel.Sketches;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.Themes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.CoreObjectsTests;
+
+[TestClass]
+public class ThemeSeriesPostRuleTests
+{
+    [TestMethod]
+    public void PostRuleRunsAfterAnyAndTypeSpecificRules()
+    {
+        // HasPostRuleForAnySeries must run last so it can read what the type-specific builders
+        // assigned (e.g. the series' Stroke/Fill). Pin the order: any-series -> type-specific -> post.
+        var theme = new Theme();
+        var order = new List<string>();
+
+        _ = theme.HasRuleForAnySeries(_ => order.Add("any"));
+        _ = theme.HasRuleForLineSeries(_ => order.Add("line"));
+        _ = theme.HasPostRuleForAnySeries(_ => order.Add("post"));
+
+        theme.ApplyStyleToSeries(new LineSeries<double>());
+
+        CollectionAssert.AreEqual(new[] { "any", "line", "post" }, order);
+    }
+
+    [TestMethod]
+    public void PostRuleSeesPaintsAssignedByTypeSpecificRule()
+    {
+        // The motivating case: a post rule decorating the final paints. The type-specific rule
+        // assigns Stroke; the post rule must observe that assignment, not Paint.Default.
+        var theme = new Theme();
+
+        _ = theme.HasRuleForLineSeries(s => s.Stroke = new SolidColorPaint());
+
+        var sawStroke = false;
+        _ = theme.HasPostRuleForAnySeries(s =>
+            sawStroke = s is IStrokedAndFilled { Stroke: not null });
+
+        theme.ApplyStyleToSeries(new LineSeries<double>());
+
+        Assert.IsTrue(sawStroke, "the post rule must see the Stroke assigned by the line-series rule");
+    }
+}


### PR DESCRIPTION
## What

Adds a post phase to `Theme` for series rules:

- `Theme.SeriesPostBuilder` (an `Action<ISeries>` list)
- `HasPostRuleForAnySeries(...)` extension
- it runs at the **end** of `ApplyStyleToSeries`, after the type-specific builders

## Why

`ApplyStyleToSeries` runs in a fixed order: any-series rules first → type-specific rules last. The type-specific builders (`HasRuleForLineSeries`, `HasRuleForBarSeries`, …) are where a series' `Stroke`/`Fill` get assigned. There was no phase for a rule that needs to run *after* that — e.g. one that **decorates or reads the final paints**. Such a rule registered via `HasRuleForAnySeries` runs too early and sees `Paint.Default`.

The post phase gives decorators a correct, order-independent place to run, and it covers every series type in one rule (no need to enumerate each type-specific builder).

## Compatibility

Purely additive — existing rule order is unchanged; the new list simply runs last and is empty unless used.

## Tests

`ThemeSeriesPostRuleTests`:
- pins the order any-series → type-specific → post;
- verifies a post rule observes a `Stroke` assigned by a type-specific rule (not `Paint.Default`).

Full CoreTests green (825/825, net8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)