### PR TITLE
Floor a per-element drop shadow at the paint's own shadow

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -24,6 +24,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
 using SkiaSharp;
 
 namespace LiveChartsCore.SkiaSharpView.Drawing;
@@ -299,10 +300,31 @@ public class SkiaSharpDrawingContext(
             var shadow = element.DropShadow!;
             originalFilter = ActiveSkiaPaint.ImageFilter;
 
+            // A per-element shadow that is animating away interpolates toward a transparent,
+            // zero-radius shadow. If the paint itself carries a base drop shadow (e.g. an
+            // always-on glow), floor the element shadow at that base — radius AND color — so it
+            // eases down to the base instead of fading to nothing and popping back when the
+            // transition completes (it becomes null, and the paint's own filter takes over).
+            // ActiveLvcPaint is the paint currently drawing this element, so the base is
+            // automatically the correct fallback per draw pass (fill vs stroke).
+            var sigmaX = shadow.SigmaX;
+            var sigmaY = shadow.SigmaY;
+            var color = new SKColor(shadow.Color.R, shadow.Color.G, shadow.Color.B, shadow.Color.A);
+            if (ActiveLvcPaint is SkiaPaint { ImageFilter: DropShadow baseShadow })
+            {
+                // Floor the radius at the base, and use the base color throughout. The element's
+                // own color is interpolating toward transparent, so blending it in would still
+                // fade out; using the base color keeps the glow solid all the way down to the base
+                // (the radius is what conveys the hover grow/shrink anyway).
+                sigmaX = System.Math.Max(sigmaX, baseShadow.SigmaX);
+                sigmaY = System.Math.Max(sigmaY, baseShadow.SigmaY);
+                color = baseShadow.Color;
+            }
+
             ActiveSkiaPaint.ImageFilter = SKImageFilter.CreateDropShadow(
                 shadow.Dx, shadow.Dy,
-                shadow.SigmaX, shadow.SigmaY,
-                new(shadow.Color.R, shadow.Color.G, shadow.Color.B, shadow.Color.A));
+                sigmaX, sigmaY,
+                color);
         }
 
         element.Draw(this);

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -301,28 +301,31 @@ public class SkiaSharpDrawingContext(
             originalFilter = ActiveSkiaPaint.ImageFilter;
 
             // A per-element shadow that is animating away interpolates toward a transparent,
-            // zero-radius shadow. If the paint itself carries a base drop shadow (e.g. an
-            // always-on glow), floor the element shadow at that base — radius AND color — so it
-            // eases down to the base instead of fading to nothing and popping back when the
-            // transition completes (it becomes null, and the paint's own filter takes over).
-            // ActiveLvcPaint is the paint currently drawing this element, so the base is
-            // automatically the correct fallback per draw pass (fill vs stroke).
+            // zero-radius, zero-offset shadow. If the paint itself carries a base drop shadow
+            // (e.g. an always-on glow), floor the element shadow at that base — radius, color AND
+            // offset — so it eases down to the base instead of fading/sliding to nothing and
+            // popping back when the transition completes (it becomes null, and the paint's own
+            // filter takes over). ActiveLvcPaint is the paint currently drawing this element, so
+            // the base is automatically the correct fallback per draw pass (fill vs stroke).
+            var dx = shadow.Dx;
+            var dy = shadow.Dy;
             var sigmaX = shadow.SigmaX;
             var sigmaY = shadow.SigmaY;
             var color = new SKColor(shadow.Color.R, shadow.Color.G, shadow.Color.B, shadow.Color.A);
             if (ActiveLvcPaint is SkiaPaint { ImageFilter: DropShadow baseShadow })
             {
-                // Floor the radius at the base, and use the base color throughout. The element's
-                // own color is interpolating toward transparent, so blending it in would still
-                // fade out; using the base color keeps the glow solid all the way down to the base
-                // (the radius is what conveys the hover grow/shrink anyway).
-                sigmaX = System.Math.Max(sigmaX, baseShadow.SigmaX);
-                sigmaY = System.Math.Max(sigmaY, baseShadow.SigmaY);
+                // Grow the radius from the base; take the offset and color from the base. The
+                // element's own color/offset are interpolating toward nothing, so blending them in
+                // would still fade/slide out — the radius is what conveys the grow/shrink anyway.
+                sigmaX = Math.Max(sigmaX, baseShadow.SigmaX);
+                sigmaY = Math.Max(sigmaY, baseShadow.SigmaY);
+                dx = baseShadow.Dx;
+                dy = baseShadow.Dy;
                 color = baseShadow.Color;
             }
 
             ActiveSkiaPaint.ImageFilter = SKImageFilter.CreateDropShadow(
-                shadow.Dx, shadow.Dy,
+                dx, dy,
                 sigmaX, sigmaY,
                 color);
         }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
@@ -48,9 +48,10 @@ public class DropShadow(
 
     private float Dx { get; set; } = dx;
     private float Dy { get; set; } = dy;
-    private float SigmaX { get; set; } = sigmaX;
-    private float SigmaY { get; set; } = sigmaY;
-    private SKColor Color { get; set; } = color;
+    // internal so the drawing context can floor a per-element shadow at the paint's own shadow.
+    internal float SigmaX { get; set; } = sigmaX;
+    internal float SigmaY { get; set; } = sigmaY;
+    internal SKColor Color { get; set; } = color;
 
     /// <inheritdoc cref="ImageFilter.Clone"/>
     public override ImageFilter Clone() =>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
@@ -46,9 +46,9 @@ public class DropShadow(
 {
     internal static object s_key = new();
 
-    private float Dx { get; set; } = dx;
-    private float Dy { get; set; } = dy;
     // internal so the drawing context can floor a per-element shadow at the paint's own shadow.
+    internal float Dx { get; set; } = dx;
+    internal float Dy { get; set; } = dy;
     internal float SigmaX { get; set; } = sigmaX;
     internal float SigmaY { get; set; } = sigmaY;
     internal SKColor Color { get; set; } = color;

--- a/tests/SnapshotTests/DropShadowFloorTests.cs
+++ b/tests/SnapshotTests/DropShadowFloorTests.cs
@@ -27,7 +27,8 @@ public sealed class DropShadowFloorTests
                 Stroke = null,
                 Fill = new SolidColorPaint(SKColors.Red)
                 {
-                    ImageFilter = new DropShadow(0, 0, 20, 20, SKColors.Red)
+                    // an offset base shadow, so the floor must also pin Dx/Dy, not just radius/color.
+                    ImageFilter = new DropShadow(8, 8, 20, 20, SKColors.Red)
                 },
             };
 

--- a/tests/SnapshotTests/DropShadowFloorTests.cs
+++ b/tests/SnapshotTests/DropShadowFloorTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using SkiaSharp;
+
+namespace SnapshotTests;
+
+[TestClass]
+public sealed class DropShadowFloorTests
+{
+    // When a paint carries its own drop shadow (e.g. an always-on glow), a per-element shadow
+    // that is weaker than it must render AS the paint's shadow — the floor. This is what keeps a
+    // hover-grown per-point shadow from fading to nothing (and popping back to the paint shadow)
+    // as it animates away. So a weak per-element shadow must look identical to no per-element
+    // shadow at all (which already shows the paint shadow).
+    [TestMethod]
+    public void WeakPerElementShadowIsFlooredAtThePaintShadow()
+    {
+        SKImage Render(LvcDropShadow? geometryShadow)
+        {
+            var series = new ColumnSeries<int>
+            {
+                Values = [5],
+                Stroke = null,
+                Fill = new SolidColorPaint(SKColors.Red)
+                {
+                    ImageFilter = new DropShadow(0, 0, 20, 20, SKColors.Red)
+                },
+            };
+
+            var chart = new SKCartesianChart
+            {
+                Series = [series],
+                XAxes = [new Axis()],
+                YAxes = [new Axis()],
+                Width = 300,
+                Height = 300,
+            };
+
+            _ = chart.GetImage(); // first measure creates the point geometry
+            series.everFetched.First().Context.Visual!.DropShadow = geometryShadow;
+            return chart.GetImage();
+        }
+
+        // a) no per-element shadow → the paint's drop shadow shows.
+        using var paintShadowOnly = Render(null);
+        // b) a per-element shadow far weaker than the paint's (a faded hover tail).
+        using var weakElementShadow = Render(new LvcDropShadow(0, 0, 1, 1, new LvcColor(255, 0, 0, 30)));
+
+        var result = Extensions.Compare(
+            paintShadowOnly, weakElementShadow, perChannelTolerance: 4, maxDifferentPixelsRatio: 0.005);
+
+        Assert.IsTrue(
+            result.IsSuccessful,
+            "a per-element shadow weaker than the paint's shadow must render as the paint's shadow: " + result.Message);
+    }
+}


### PR DESCRIPTION
## Bug

When a paint carries its own drop shadow (e.g. an always-on glow) **and** a geometry grows a per-point drop shadow on a visual state (hover), un-hovering looks like `6 → 16 → 0 → pop 6`: the glow fades to nothing, then snaps back. Hover-in dips the same way.

## Cause

A geometry's `DropShadow` motion interpolates toward `LvcDropShadow.Empty` — a **transparent, zero-radius** shadow — when it's set back to null. So during the transition both the radius *and* the color fade out. The moment it completes (value is null), `DrawElement` falls back to the paint's own image filter, which is still the solid base → the pop.

## Fix

In `SkiaSharpDrawingContext.DrawElement`, when the active paint carries a `DropShadow` filter, floor the per-element shadow at that base — **radius and color** — so it eases down to the base instead of to nothing:

```csharp
if (ActiveLvcPaint is SkiaPaint { ImageFilter: DropShadow baseShadow })
{
    sigmaX = Math.Max(sigmaX, baseShadow.SigmaX);
    sigmaY = Math.Max(sigmaY, baseShadow.SigmaY);
    color  = baseShadow.Color;
}
```

`ActiveLvcPaint` is the paint currently drawing the element, so the base is automatically the right fallback per pass (fill vs stroke) — something a back-reference on the geometry couldn't do, since a geometry is drawn by multiple paints. `DropShadow.SigmaX/SigmaY/Color` are made `internal` for this.

**Scope:** only drop-shadow-over-drop-shadow. No base filter, a non-shadow filter, or no per-element shadow all render exactly as before.

**Note:** during the transition the per-element shadow renders in the *base paint's* color (the element's own color is the thing interpolating to transparent, so blending it would still fade). Identical when both are the series color; only visible if a base shadow and a state shadow use different colors.

## Tests

- New `DropShadowFloorTests`: a column whose Fill paint has a drop shadow renders identically with no per-element shadow vs. a much weaker per-element shadow (the weak one is floored to the paint's). Fails before this change.
- SnapshotTests 175/175, CoreTests 825/825 — no existing baseline changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)