### PR TITLE
refactor: paints animate via their own motion properties; remove Paint.Transitionate

### DIFF
--- a/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
+++ b/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
@@ -190,8 +190,8 @@ namespace {containingType.ContainingNamespace};
             "LiveChartsCore.Drawing.LvcPoint" => "LiveChartsCore.Motion.PointMotionProperty",
             "LiveChartsCore.Drawing.LvcSize" => "LiveChartsCore.Motion.SizeMotionProperty",
             "LiveChartsCore.Drawing.Padding" => "LiveChartsCore.Motion.PaddingMotionProperty",
-            "LiveChartsCore.Painting.Paint" => "LiveChartsCore.Motion.NonAnimatableMotionProperty<LiveChartsCore.Painting.Paint>",
-            "LiveChartsCore.Painting.Paint?" => "LiveChartsCore.Motion.NonAnimatableMotionProperty<LiveChartsCore.Painting.Paint?>",
+            "LiveChartsCore.Painting.Paint" => "LiveChartsCore.Motion.ByReferenceMotionProperty<LiveChartsCore.Painting.Paint>",
+            "LiveChartsCore.Painting.Paint?" => "LiveChartsCore.Motion.ByReferenceMotionProperty<LiveChartsCore.Painting.Paint?>",
             "LiveChartsCore.Drawing.LvcDropShadow" +
             "" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "LiveChartsCore.Drawing.LvcDropShadow?" => "LiveChartsCore.Motion.DropShadowMotionProperty",

--- a/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
+++ b/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
@@ -190,8 +190,8 @@ namespace {containingType.ContainingNamespace};
             "LiveChartsCore.Drawing.LvcPoint" => "LiveChartsCore.Motion.PointMotionProperty",
             "LiveChartsCore.Drawing.LvcSize" => "LiveChartsCore.Motion.SizeMotionProperty",
             "LiveChartsCore.Drawing.Padding" => "LiveChartsCore.Motion.PaddingMotionProperty",
-            "LiveChartsCore.Painting.Paint" => "LiveChartsCore.Motion.PaintMotionProperty",
-            "LiveChartsCore.Painting.Paint?" => "LiveChartsCore.Motion.PaintMotionProperty",
+            "LiveChartsCore.Painting.Paint" => "LiveChartsCore.Motion.NonAnimatableMotionProperty<LiveChartsCore.Painting.Paint>",
+            "LiveChartsCore.Painting.Paint?" => "LiveChartsCore.Motion.NonAnimatableMotionProperty<LiveChartsCore.Painting.Paint?>",
             "LiveChartsCore.Drawing.LvcDropShadow" +
             "" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "LiveChartsCore.Drawing.LvcDropShadow?" => "LiveChartsCore.Motion.DropShadowMotionProperty",

--- a/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
+++ b/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
@@ -194,6 +194,8 @@ namespace {containingType.ContainingNamespace};
             "" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "LiveChartsCore.Drawing.LvcDropShadow?" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "SkiaSharp.SKMatrix" => "LiveChartsCore.SkiaSharpView.Motion.SKMatrixMotionProperty",
+            "SkiaSharp.SKColor" => "LiveChartsCore.SkiaSharpView.Motion.SKColorMotionProperty",
+            "SkiaSharp.SKColor?" => "LiveChartsCore.SkiaSharpView.Motion.SKColorMotionProperty",
             _ => "UnsuportedType"
         };
     }

--- a/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
+++ b/generators/LiveChartsGenerators/Templates/MotionPropertyTemplates.cs
@@ -182,6 +182,8 @@ namespace {containingType.ContainingNamespace};
         return type.ToDisplayString() switch
         {
             "float" => "LiveChartsCore.Motion.FloatMotionProperty",
+            "float[]" => "LiveChartsCore.Motion.FloatArrayMotionProperty",
+            "float[]?" => "LiveChartsCore.Motion.FloatArrayMotionProperty",
             "double" => "LiveChartsCore.Motion.DoubleMotionProperty",
             "double?" => "LiveChartsCore.Motion.NullableDoubleMotionProperty",
             "LiveChartsCore.Drawing.LvcColor" => "LiveChartsCore.Motion.ColorMotionProperty",
@@ -194,8 +196,10 @@ namespace {containingType.ContainingNamespace};
             "" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "LiveChartsCore.Drawing.LvcDropShadow?" => "LiveChartsCore.Motion.DropShadowMotionProperty",
             "SkiaSharp.SKMatrix" => "LiveChartsCore.SkiaSharpView.Motion.SKMatrixMotionProperty",
+            "SkiaSharp.SKPoint" => "LiveChartsCore.SkiaSharpView.Motion.SKPointMotionProperty",
             "SkiaSharp.SKColor" => "LiveChartsCore.SkiaSharpView.Motion.SKColorMotionProperty",
             "SkiaSharp.SKColor?" => "LiveChartsCore.SkiaSharpView.Motion.SKColorMotionProperty",
+            "SkiaSharp.SKColor[]" => "LiveChartsCore.SkiaSharpView.Motion.SKColorArrayMotionProperty",
             _ => "UnsuportedType"
         };
     }

--- a/samples/ConsoleEngineSample/LiveChartsCore.Console/Drawing/ConsoleDrawingContext.cs
+++ b/samples/ConsoleEngineSample/LiveChartsCore.Console/Drawing/ConsoleDrawingContext.cs
@@ -90,7 +90,6 @@ public class ConsoleDrawingContext(CoreMotionCanvas motionCanvas, ConsoleSurface
     internal override void SelectPaint(Paint paint)
     {
         ActiveLvcPaint = paint;
-        PaintMotionProperty.s_activePaint = paint;
         paint.OnPaintStarted(this, null);
     }
 
@@ -98,7 +97,6 @@ public class ConsoleDrawingContext(CoreMotionCanvas motionCanvas, ConsoleSurface
     {
         paint.OnPaintFinished(this, null);
         ActiveLvcPaint = null!;
-        PaintMotionProperty.s_activePaint = null!;
     }
 
     private void DrawByPaint(Paint paint, IDrawnElement<ConsoleDrawingContext> element, float opacity)

--- a/samples/ConsoleEngineSample/LiveChartsCore.Console/Painting/SolidColorPaint.cs
+++ b/samples/ConsoleEngineSample/LiveChartsCore.Console/Painting/SolidColorPaint.cs
@@ -21,17 +21,6 @@ public class SolidColorPaint : ConsolePaint
     internal override void OnPaintStarted(DrawingContext drawingContext, IDrawnElement? drawnElement) =>
         ((ConsoleDrawingContext)drawingContext).ActiveColor = Color;
 
-    internal override Paint Transitionate(float progress, Paint target)
-    {
-        if (target is not SolidColorPaint to) return target;
-        Color = new LvcColor(
-            (byte)(Color.R + progress * (to.Color.R - Color.R)),
-            (byte)(Color.G + progress * (to.Color.G - Color.G)),
-            (byte)(Color.B + progress * (to.Color.B - Color.B)),
-            (byte)(Color.A + progress * (to.Color.A - Color.A)));
-        return this;
-    }
-
     internal override void ApplyOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement)
     {
         // skipped — single-cell color cannot meaningfully alpha-blend without a per-pixel

--- a/samples/VorticeSample/LiveChartsCore.Vortice/Drawing/VorticeDrawingContext.cs
+++ b/samples/VorticeSample/LiveChartsCore.Vortice/Drawing/VorticeDrawingContext.cs
@@ -156,7 +156,6 @@ public class VorticeDrawingContext(
     internal override void SelectPaint(Paint paint)
     {
         ActiveLvcPaint = paint;
-        PaintMotionProperty.s_activePaint = paint;
 
         paint.OnPaintStarted(this, null);
     }
@@ -167,7 +166,6 @@ public class VorticeDrawingContext(
 
         ActiveLvcPaint = null!;
         ActiveBrush = null!;
-        PaintMotionProperty.s_activePaint = null!;
     }
 
     private void DrawByPaint(Paint paint, IDrawnElement<VorticeDrawingContext> element, float opacity)

--- a/samples/VorticeSample/LiveChartsCore.Vortice/Painting/SolidColorPaint.cs
+++ b/samples/VorticeSample/LiveChartsCore.Vortice/Painting/SolidColorPaint.cs
@@ -69,21 +69,6 @@ public class SolidColorPaint : VorticePaint
         vorticeContext.ActiveBrush = _brush;
     }
 
-    internal override Paint Transitionate(float progress, Paint target)
-    {
-        if (target is not SolidColorPaint toPaint) return target;
-
-        Color = new Color4(
-            (byte)(Color.R + progress * (toPaint.Color.R - Color.R)),
-            (byte)(Color.G + progress * (toPaint.Color.G - Color.G)),
-            (byte)(Color.B + progress * (toPaint.Color.B - Color.B)),
-            (byte)(Color.A + progress * (toPaint.Color.A - Color.A)));
-
-        ((ID2D1SolidColorBrush)_brush!).Color = Color;
-
-        return this;
-    }
-
     internal override void ApplyOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement)
     {
         _brush.Opacity = opacity;

--- a/src/LiveChartsCore/Motion/ByReferenceMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/ByReferenceMotionProperty.cs
@@ -23,17 +23,18 @@
 namespace LiveChartsCore.Motion;
 
 /// <summary>
-/// A motion property whose value is never interpolated: assigning a new value snaps to it.
-/// Used for properties where animation lives inside the value itself rather than by blending one
-/// value instance into another — for example a <see cref="Painting.Paint"/> reference, whose own
-/// properties are motion properties.
+/// A motion property that holds its value by reference: the value is not interpolated, so assigning
+/// a new value snaps to it. Used for properties where animation lives inside the value itself (for
+/// example a <see cref="Painting.Paint"/> reference, whose own properties are motion properties)
+/// rather than by blending one value instance into another. How a change of the reference behaves
+/// (snap vs. animate) is left to the owner — e.g. via the generated <c>On…Changed</c> hook.
 /// </summary>
 /// <typeparam name="T">The property type.</typeparam>
 /// <remarks>
-/// Initializes a new instance of the <see cref="NonAnimatableMotionProperty{T}"/> class.
+/// Initializes a new instance of the <see cref="ByReferenceMotionProperty{T}"/> class.
 /// </remarks>
 /// <param name="defaultValue">The default value.</param>
-public class NonAnimatableMotionProperty<T>(T defaultValue = default!)
+public class ByReferenceMotionProperty<T>(T defaultValue = default!)
     : MotionProperty<T>(defaultValue)
 {
     /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>

--- a/src/LiveChartsCore/Motion/FloatArrayMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/FloatArrayMotionProperty.cs
@@ -1,0 +1,55 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace LiveChartsCore.Motion;
+
+/// <summary>
+/// Defines the <see cref="float"/> array motion property class. Each element is interpolated
+/// independently.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="FloatArrayMotionProperty"/> class.
+/// </remarks>
+/// <param name="defaultValue">The default value.</param>
+public class FloatArrayMotionProperty(float[]? defaultValue = null)
+    : MotionProperty<float[]?>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    // Only equal-length, non-null arrays interpolate; otherwise the transition is skipped and
+    // the target value is used directly (a change to a different-length array, or to/from null,
+    // snaps).
+    protected override bool CanTransitionate =>
+        FromValue is not null && ToValue is not null && FromValue.Length == ToValue.Length;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
+    protected override float[] OnGetMovement(float progress)
+    {
+        var from = FromValue!;
+        var to = ToValue!;
+
+        var result = new float[to.Length];
+        for (var i = 0; i < to.Length; i++)
+            result[i] = from[i] + progress * (to[i] - from[i]);
+
+        return result;
+    }
+}

--- a/src/LiveChartsCore/Motion/MotionProperty.cs
+++ b/src/LiveChartsCore/Motion/MotionProperty.cs
@@ -119,6 +119,15 @@ public abstract class MotionProperty<T>(T defaultValue) : IMotionProperty
             if (LogGet == animatable)
                 System.Diagnostics.Debug.WriteLine($"[MOTION GET] invalid transition state.");
 #endif
+            // The value cannot be interpolated, so it snaps to the target; the "transition" is
+            // therefore already done. Mark it complete so a non-animatable property (e.g. a paint
+            // reference) does not stay stuck at IsCompleted == false after SetMovement.
+            if (!IsCompleted)
+            {
+                IsCompleted = true;
+                OnCompleted();
+            }
+
             return ToValue;
         }
 

--- a/src/LiveChartsCore/Motion/NonAnimatableMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/NonAnimatableMotionProperty.cs
@@ -1,4 +1,4 @@
-﻿// The MIT License(MIT)
+// The MIT License(MIT)
 //
 // Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
 //
@@ -20,27 +20,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using LiveChartsCore.Painting;
-
 namespace LiveChartsCore.Motion;
 
 /// <summary>
-/// Defines a motion property that holds a <see cref="Paint"/> reference.
+/// A motion property whose value is never interpolated: assigning a new value snaps to it.
+/// Used for properties where animation lives inside the value itself rather than by blending one
+/// value instance into another — for example a <see cref="Painting.Paint"/> reference, whose own
+/// properties are motion properties.
 /// </summary>
+/// <typeparam name="T">The property type.</typeparam>
 /// <remarks>
-/// A paint reference is not interpolated: changing the reference snaps to the new paint.
-/// Animation now lives inside the paint itself (its own properties are motion properties,
-/// e.g. <c>SolidColorPaint.Color</c>), so a paint animates by mutating its own state
-/// on the same instance rather than by blending one paint instance into another.
+/// Initializes a new instance of the <see cref="NonAnimatableMotionProperty{T}"/> class.
 /// </remarks>
 /// <param name="defaultValue">The default value.</param>
-public class PaintMotionProperty(Paint defaultValue = null!)
-    : MotionProperty<Paint?>(defaultValue)
+public class NonAnimatableMotionProperty<T>(T defaultValue = default!)
+    : MotionProperty<T>(defaultValue)
 {
     /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
     protected override bool CanTransitionate => false;
 
     /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
     // Never invoked: CanTransitionate is false, so GetMovement returns the value directly.
-    protected override Paint? OnGetMovement(float progress) => ToValue;
+    protected override T OnGetMovement(float progress) => ToValue;
 }

--- a/src/LiveChartsCore/Motion/PaintMotionProperty.cs
+++ b/src/LiveChartsCore/Motion/PaintMotionProperty.cs
@@ -25,29 +25,22 @@ using LiveChartsCore.Painting;
 namespace LiveChartsCore.Motion;
 
 /// <summary>
-/// Defines the float motion property class.
+/// Defines a motion property that holds a <see cref="Paint"/> reference.
 /// </summary>
 /// <remarks>
-/// Initializes a new instance of the <see cref="PaintMotionProperty"/> class.
+/// A paint reference is not interpolated: changing the reference snaps to the new paint.
+/// Animation now lives inside the paint itself (its own properties are motion properties,
+/// e.g. <c>SolidColorPaint.Color</c>), so a paint animates by mutating its own state
+/// on the same instance rather than by blending one paint instance into another.
 /// </remarks>
 /// <param name="defaultValue">The default value.</param>
 public class PaintMotionProperty(Paint defaultValue = null!)
     : MotionProperty<Paint?>(defaultValue)
 {
-    internal static Paint? s_activePaint;
-
     /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
-    protected override bool CanTransitionate =>
-        (FromValue ?? s_activePaint) is not null &&
-        (ToValue ?? s_activePaint) is not null;
+    protected override bool CanTransitionate => false;
 
     /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
-    protected override Paint OnGetMovement(float progress)
-    {
-        // ! canot be null here because of the check in CanTransitionate
-        var from = FromValue ?? s_activePaint!.CloneTask();
-        var to = ToValue ?? s_activePaint!.CloneTask();
-
-        return from.Transitionate(progress, to);
-    }
+    // Never invoked: CanTransitionate is false, so GetMovement returns the value directly.
+    protected override Paint? OnGetMovement(float progress) => ToValue;
 }

--- a/src/LiveChartsCore/Painting/DrawnTask.cs
+++ b/src/LiveChartsCore/Painting/DrawnTask.cs
@@ -55,7 +55,5 @@ public class DrawnTask : Paint
 
     internal override void RestoreOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement) { }
 
-    internal override Paint Transitionate(float progress, Paint target) => this;
-
     internal override void DisposeTask() { }
 }

--- a/src/LiveChartsCore/Painting/MeasureTask.cs
+++ b/src/LiveChartsCore/Painting/MeasureTask.cs
@@ -42,7 +42,5 @@ internal class MeasureTask : Paint
 
     internal override void RestoreOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement) { }
 
-    internal override Paint Transitionate(float progress, Paint target) => this;
-
     internal override void DisposeTask() { }
 }

--- a/src/LiveChartsCore/Painting/Paint.cs
+++ b/src/LiveChartsCore/Painting/Paint.cs
@@ -195,8 +195,6 @@ public abstract partial class Paint : Animatable
     internal void ReleaseCanvas(CoreMotionCanvas canvas) =>
         _ = _geometriesByCanvas.Remove(canvas);
 
-    internal abstract Paint Transitionate(float progress, Paint target);
-
     internal HashSet<IDrawnElement> GetGeometries(CoreMotionCanvas canvas) =>
         GetGeometriesByCanvas(canvas) ?? [];
 
@@ -224,7 +222,6 @@ public abstract partial class Paint : Animatable
         internal override void OnPaintFinished(DrawingContext context, IDrawnElement? drawnElement) { }
         internal override void OnPaintStarted(DrawingContext drawingContext, IDrawnElement? drawnElement) { }
         internal override void RestoreOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement) { }
-        internal override Paint Transitionate(float progress, Paint target) => this;
         internal override void DisposeTask() { }
     }
 }

--- a/src/LiveChartsCore/Painting/Paint.cs
+++ b/src/LiveChartsCore/Painting/Paint.cs
@@ -22,9 +22,8 @@
 
 #pragma warning disable IDE0290 // Use primary ctor... why suggest this?? you cant do it in this case
 
-using System;
-using System.Collections.Generic;
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Generators;
 using LiveChartsCore.Motion;
 
 namespace LiveChartsCore.Painting;
@@ -44,16 +43,14 @@ public abstract partial class Paint : Animatable
     /// <param name="strokeMiter">The stroke miter.</param>
     public Paint(float strokeThickness = 1f, float strokeMiter = 0)
     {
-        StrokeThickness = strokeThickness;
-        StrokeMiter = strokeMiter;
+        _StrokeThicknessMotionProperty = new(strokeThickness);
+        _StrokeMiterMotionProperty = new(strokeMiter);
     }
 
     /// <summary>
     /// Gets the default paint.
     /// </summary>
     public static Paint Default { get; } = new DefaultPaint();
-
-
 
     /// <summary>
     /// Gets or sets the index of the z.
@@ -94,12 +91,14 @@ public abstract partial class Paint : Animatable
     /// <summary>
     /// Gets or sets the stroke thickness.
     /// </summary>
-    public float StrokeThickness { get; set; }
+    [MotionProperty]
+    public partial float StrokeThickness { get; set; }
 
     /// <summary>
     /// Gets or sets the stroke miter.
     /// </summary>
-    public float StrokeMiter { get; set; }
+    [MotionProperty]
+    public partial float StrokeMiter { get; set; }
 
     /// <summary>
     /// Gets a value indicating whether this instance is empty.

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -240,7 +240,6 @@ public class SkiaSharpDrawingContext(
     {
         ActiveLvcPaint = paint;
         //ActiveSkiaPaint = paint.SKPaint; set by paint.OnPaintStarted
-        PaintMotionProperty.s_activePaint = paint;
 
         paint.OnPaintStarted(this, null);
     }
@@ -251,7 +250,6 @@ public class SkiaSharpDrawingContext(
 
         ActiveLvcPaint = null!;
         ActiveSkiaPaint = null!;
-        PaintMotionProperty.s_activePaint = null!;
     }
 
     private void DrawByPaint(Paint paint, IDrawnElement<SkiaSharpDrawingContext> element, float opacity)

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorArrayMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorArrayMotionProperty.cs
@@ -1,0 +1,61 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Motion;
+using SkiaSharp;
+
+namespace LiveChartsCore.SkiaSharpView.Motion;
+
+/// <summary>
+/// Defines the <see cref="SKColor"/> array motion property class. Each element is interpolated
+/// independently (per channel).
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SKColorArrayMotionProperty"/> class.
+/// </remarks>
+/// <param name="defaultValue">The default value.</param>
+public class SKColorArrayMotionProperty(SKColor[] defaultValue = null!)
+    : MotionProperty<SKColor[]>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    // Only equal-length, non-null arrays interpolate; otherwise the transition is skipped and
+    // the target value is used directly (a change to a different-length array snaps).
+    protected override bool CanTransitionate =>
+        FromValue is not null && ToValue is not null && FromValue.Length == ToValue.Length;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
+    protected override SKColor[] OnGetMovement(float progress)
+    {
+        var from = FromValue;
+        var to = ToValue;
+
+        var result = new SKColor[to.Length];
+        for (var i = 0; i < to.Length; i++)
+            result[i] = new SKColor(
+                (byte)(from[i].Red + progress * (to[i].Red - from[i].Red)),
+                (byte)(from[i].Green + progress * (to[i].Green - from[i].Green)),
+                (byte)(from[i].Blue + progress * (to[i].Blue - from[i].Blue)),
+                (byte)(from[i].Alpha + progress * (to[i].Alpha - from[i].Alpha)));
+
+        return result;
+    }
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorArrayMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorArrayMotionProperty.cs
@@ -33,8 +33,8 @@ namespace LiveChartsCore.SkiaSharpView.Motion;
 /// Initializes a new instance of the <see cref="SKColorArrayMotionProperty"/> class.
 /// </remarks>
 /// <param name="defaultValue">The default value.</param>
-public class SKColorArrayMotionProperty(SKColor[] defaultValue = null!)
-    : MotionProperty<SKColor[]>(defaultValue)
+public class SKColorArrayMotionProperty(SKColor[]? defaultValue = null)
+    : MotionProperty<SKColor[]>(defaultValue ?? [])
 {
     /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
     // Only equal-length, non-null arrays interpolate; otherwise the transition is skipped and

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKColorMotionProperty.cs
@@ -1,0 +1,50 @@
+﻿// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Motion;
+using SkiaSharp;
+
+namespace LiveChartsCore.SkiaSharpView.Motion;
+
+/// <summary>
+/// Defines the color motion property class.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SKColorMotionProperty"/> class.
+/// </remarks>
+/// <param name="defaultValue">The default value.</param>
+public class SKColorMotionProperty(SKColor defaultValue = new SKColor())
+    : MotionProperty<SKColor>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    protected override bool CanTransitionate => true;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
+    protected override SKColor OnGetMovement(float progress)
+    {
+        return new SKColor(
+            (byte)(FromValue.Red + progress * (ToValue.Red - FromValue.Red)),
+            (byte)(FromValue.Green + progress * (ToValue.Green - FromValue.Green)),
+            (byte)(FromValue.Blue + progress * (ToValue.Blue - FromValue.Blue)),
+            (byte)(FromValue.Alpha + progress * (ToValue.Alpha - FromValue.Alpha)));
+    }
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKPointMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Motion/SKPointMotionProperty.cs
@@ -1,0 +1,45 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Motion;
+using SkiaSharp;
+
+namespace LiveChartsCore.SkiaSharpView.Motion;
+
+/// <summary>
+/// Defines the <see cref="SKPoint"/> motion property class.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SKPointMotionProperty"/> class.
+/// </remarks>
+/// <param name="defaultValue">The default value.</param>
+public class SKPointMotionProperty(SKPoint defaultValue = new SKPoint())
+    : MotionProperty<SKPoint>(defaultValue)
+{
+    /// <inheritdoc cref="MotionProperty{T}.CanTransitionate"/>
+    protected override bool CanTransitionate => true;
+
+    /// <inheritdoc cref="MotionProperty{T}.OnGetMovement(float)" />
+    protected override SKPoint OnGetMovement(float progress) =>
+        new(FromValue.X + progress * (ToValue.X - FromValue.X),
+            FromValue.Y + progress * (ToValue.Y - FromValue.Y));
+}

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffectMotionProperty.cs
@@ -26,8 +26,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting.Effects;
 
 /// <summary>
 /// A motion property that animates a <see cref="PathEffect"/>, interpolating between two effects
-/// with <see cref="PathEffect.Transitionate(float, PathEffect)"/> — the same way
-/// <see cref="PaintMotionProperty"/> animates whole paints. Assigning a new effect can soft-
+/// with <see cref="PathEffect.Transitionate(float, PathEffect)"/>. Assigning a new effect can soft-
 /// transition; a self-animating effect (one carrying a looping <see cref="PathEffect.Animation"/>)
 /// keeps the rail running indefinitely, so the paint never needs an "is animating" flag.
 /// </summary>

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -154,47 +154,6 @@ public class LinearGradientPaint(
         _skiaPaint.ColorFilter = null;
     }
 
-    internal override Paint Transitionate(float progress, Paint target)
-    {
-        if (target is not LinearGradientPaint toPaint) return target;
-
-        if (toPaint.GradientStops.Length != GradientStops.Length)
-            throw new NotImplementedException(
-                $"Transitions between {nameof(GradientStops)} must be of the same length.");
-
-        for (var i = 0; i < GradientStops.Length; i++)
-            GradientStops[i] = new SKColor(
-                (byte)(GradientStops[i].Red + progress * (toPaint.GradientStops[i].Red - GradientStops[i].Red)),
-                (byte)(GradientStops[i].Green + progress * (toPaint.GradientStops[i].Green - GradientStops[i].Green)),
-                (byte)(GradientStops[i].Blue + progress * (toPaint.GradientStops[i].Blue - GradientStops[i].Blue)),
-                (byte)(GradientStops[i].Alpha + progress * (toPaint.GradientStops[i].Alpha - GradientStops[i].Alpha)));
-
-        StartPoint = new SKPoint(
-            StartPoint.X + progress * (toPaint.StartPoint.X - StartPoint.X),
-            StartPoint.Y + progress * (toPaint.StartPoint.Y - StartPoint.Y));
-
-        EndPoint = new SKPoint(
-            EndPoint.X + progress * (toPaint.EndPoint.X - EndPoint.X),
-            EndPoint.Y + progress * (toPaint.EndPoint.Y - EndPoint.Y));
-
-        if (ColorPos is not null && toPaint.ColorPos is not null)
-        {
-            if (ColorPos is null || ColorPos.Length != toPaint.ColorPos.Length)
-                throw new NotImplementedException(
-                    $"Transitions between {nameof(ColorPos)} must be of the same length.");
-
-            for (var i = 0; i < ColorPos.Length; i++)
-                ColorPos[i] = ColorPos[i] + progress * (toPaint.ColorPos[i] - ColorPos[i]);
-        }
-
-        _shader?.Dispose();
-        _shader = null;
-
-        _skiaPaint?.Shader = GetShader();
-
-        return this;
-    }
-
     internal override void DisposeTask()
     {
         base.DisposeTask();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/LinearGradientPaint.cs
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Generators;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;
@@ -32,41 +32,23 @@ namespace LiveChartsCore.SkiaSharpView.Painting;
 /// Defines a set of geometries that will be painted using a linear gradient shader.
 /// </summary>
 /// <seealso cref="SkiaPaint" />
-/// <remarks>
-/// Initializes a new instance of the <see cref="LinearGradientPaint"/> class.
-/// </remarks>
-/// <param name="gradientStops">The gradient stops.</param>
-/// <param name="startPoint">
-/// The start point, both X and Y in the range of 0 to 1, where 0 is the start of the axis and 1 the end.
-/// </param>
-/// <param name="endPoint">
-/// The end point, both X and Y in the range of 0 to 1, where 0 is the start of the axis and 1 the end.
-/// </param>
-/// <param name="colorPos">
-/// An array of floats in the range of 0 to 1.
-/// These floats indicate the relative positions of the colors, you can set that argument to null to equally
-/// space the colors, default is null.
-/// </param>
-/// <param name="tileMode">
-/// The shader tile mode, default is <see cref="SKShaderTileMode.Clamp"/>.
-/// </param>
-public class LinearGradientPaint(
-    SKColor[] gradientStops,
-    SKPoint startPoint,
-    SKPoint endPoint,
-    float[]? colorPos = null,
-    SKShaderTileMode tileMode = SKShaderTileMode.Clamp)
-        : SkiaPaint
+public partial class LinearGradientPaint : SkiaPaint
 {
+    private readonly SKShaderTileMode _tileMode;
     private SKShader? _shader;
     internal SKColorFilter? _opacityFilter;
     internal float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
 
-    private SKColor[] GradientStops { get; set; } = gradientStops;
-    private SKPoint StartPoint { get; set; } = startPoint;
-    private SKPoint EndPoint { get; set; } = endPoint;
-    private float[]? ColorPos { get; set; } = colorPos;
+    // Inputs used to build the cached shader; the shader is rebuilt when any of these change.
+    // While animating, the motion getters return a fresh interpolated array/point each frame
+    // (so a rebuild happens every frame); once settled they return the stored values and the
+    // cached shader is reused.
+    private SKColor[]? _builtStops;
+    private float[]? _builtColorPos;
+    private SKPoint _builtStart;
+    private SKPoint _builtEnd;
+    private SKRect _builtClip;
 
     /// <summary>
     /// Default start point.
@@ -77,6 +59,62 @@ public class LinearGradientPaint(
     /// Default end point.
     /// </summary>
     public static readonly SKPoint DefaultEndPoint = new(1, 0.5f);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LinearGradientPaint"/> class.
+    /// </summary>
+    /// <param name="gradientStops">The gradient stops.</param>
+    /// <param name="startPoint">
+    /// The start point, both X and Y in the range of 0 to 1, where 0 is the start of the axis and 1 the end.
+    /// </param>
+    /// <param name="endPoint">
+    /// The end point, both X and Y in the range of 0 to 1, where 0 is the start of the axis and 1 the end.
+    /// </param>
+    /// <param name="colorPos">
+    /// An array of floats in the range of 0 to 1.
+    /// These floats indicate the relative positions of the colors, you can set that argument to null to equally
+    /// space the colors, default is null.
+    /// </param>
+    /// <param name="tileMode">
+    /// The shader tile mode, default is <see cref="SKShaderTileMode.Clamp"/>.
+    /// </param>
+    public LinearGradientPaint(
+        SKColor[] gradientStops,
+        SKPoint startPoint,
+        SKPoint endPoint,
+        float[]? colorPos = null,
+        SKShaderTileMode tileMode = SKShaderTileMode.Clamp)
+    {
+        _GradientStopsMotionProperty = new(gradientStops);
+        _StartPointMotionProperty = new(startPoint);
+        _EndPointMotionProperty = new(endPoint);
+        _ColorPosMotionProperty = new(colorPos);
+        _tileMode = tileMode;
+    }
+
+    /// <summary>
+    /// Gets or sets the gradient stops.
+    /// </summary>
+    [MotionProperty]
+    public partial SKColor[] GradientStops { get; set; }
+
+    /// <summary>
+    /// Gets or sets the start point, both X and Y in the range of 0 to 1.
+    /// </summary>
+    [MotionProperty]
+    public partial SKPoint StartPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end point, both X and Y in the range of 0 to 1.
+    /// </summary>
+    [MotionProperty]
+    public partial SKPoint EndPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the relative positions of the colors, in the range of 0 to 1, or null to space them equally.
+    /// </summary>
+    [MotionProperty]
+    public partial float[]? ColorPos { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LinearGradientPaint"/> class.
@@ -110,7 +148,7 @@ public class LinearGradientPaint(
     /// <inheritdoc cref="Paint.CloneTask" />
     public override Paint CloneTask()
     {
-        var clone = new LinearGradientPaint(GradientStops, StartPoint, EndPoint, ColorPos, tileMode);
+        var clone = new LinearGradientPaint(GradientStops, StartPoint, EndPoint, ColorPos, _tileMode);
         Map(this, clone);
 
         return clone;
@@ -168,8 +206,25 @@ public class LinearGradientPaint(
 
     private SKShader GetShader()
     {
-        if (_shader is not null)
+        // Read the (possibly interpolated) values once; the getters advance any active transition.
+        var stops = GradientStops;
+        var colorPos = ColorPos;
+        var startPoint = StartPoint;
+        var endPoint = EndPoint;
+
+        if (_shader is not null &&
+            ReferenceEquals(stops, _builtStops) &&
+            ReferenceEquals(colorPos, _builtColorPos) &&
+            startPoint == _builtStart &&
+            endPoint == _builtEnd &&
+            _activeClip == _builtClip)
             return _shader;
+
+        _builtStops = stops;
+        _builtColorPos = colorPos;
+        _builtStart = startPoint;
+        _builtEnd = endPoint;
+        _builtClip = _activeClip;
 
         var xf = _activeClip.Location.X;
         var xt = xf + _activeClip.Width;
@@ -177,10 +232,12 @@ public class LinearGradientPaint(
         var yf = _activeClip.Location.Y;
         var yt = yf + _activeClip.Height;
 
-        var start = new SKPoint(xf + (xt - xf) * StartPoint.X, yf + (yt - yf) * StartPoint.Y);
-        var end = new SKPoint(xf + (xt - xf) * EndPoint.X, yf + (yt - yf) * EndPoint.Y);
+        var start = new SKPoint(xf + (xt - xf) * startPoint.X, yf + (yt - yf) * startPoint.Y);
+        var end = new SKPoint(xf + (xt - xf) * endPoint.X, yf + (yt - yf) * endPoint.Y);
+
+        _shader?.Dispose();
 
         return
-            _shader = SKShader.CreateLinearGradient(start, end, GradientStops, ColorPos, tileMode);
+            _shader = SKShader.CreateLinearGradient(start, end, stops, colorPos, _tileMode);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -195,10 +195,7 @@ public partial class RadialGradientPaint : SkiaPaint
         _builtClip = _activeClip;
 
         var center = new SKPoint(_activeClip.Location.X + centerPos.X * _activeClip.Width, _activeClip.Location.Y + centerPos.Y * _activeClip.Height);
-        var r = _activeClip.Location.X + _activeClip.Width > _activeClip.Location.Y + _activeClip.Height
-            ? _activeClip.Location.Y + _activeClip.Height
-            : _activeClip.Location.X + _activeClip.Width;
-        r *= radius;
+        var r = Math.Min(_activeClip.Width, _activeClip.Height) * radius;
 
         _shader?.Dispose();
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Generators;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;
@@ -32,17 +32,20 @@ namespace LiveChartsCore.SkiaSharpView.Painting;
 /// Defines a set of geometries that will be painted using a radial gradient shader.
 /// </summary>
 /// <seealso cref="SkiaPaint" />
-public class RadialGradientPaint : SkiaPaint
+public partial class RadialGradientPaint : SkiaPaint
 {
+    private readonly SKShaderTileMode _tileMode;
     private SKShader? _shader;
     internal SKColorFilter? _opacityFilter;
     internal float _opacityFilterAlpha = -1f;
     private SKRect _activeClip = new();
-    private readonly SKColor[] _gradientStops;
-    private SKPoint _center;
-    private float _radius;
-    private readonly float[]? _colorPos;
-    private readonly SKShaderTileMode _tileMode;
+
+    // Inputs used to build the cached shader; see LinearGradientPaint for the caching rationale.
+    private SKColor[]? _builtStops;
+    private float[]? _builtColorPos;
+    private SKPoint _builtCenter;
+    private float _builtRadius = -1f;
+    private SKRect _builtClip;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RadialGradientPaint"/> class.
@@ -70,13 +73,36 @@ public class RadialGradientPaint : SkiaPaint
         float[]? colorPos = null,
         SKShaderTileMode tileMode = SKShaderTileMode.Clamp)
     {
-        _gradientStops = gradientStops;
-        center ??= new SKPoint(0.5f, 0.5f);
-        _center = center.Value;
-        _radius = radius;
-        _colorPos = colorPos;
+        _GradientStopsMotionProperty = new(gradientStops);
+        _CenterMotionProperty = new(center ?? new SKPoint(0.5f, 0.5f));
+        _RadiusMotionProperty = new(radius);
+        _ColorPosMotionProperty = new(colorPos);
         _tileMode = tileMode;
     }
+
+    /// <summary>
+    /// Gets or sets the gradient stops.
+    /// </summary>
+    [MotionProperty]
+    public partial SKColor[] GradientStops { get; set; }
+
+    /// <summary>
+    /// Gets or sets the center point of the gradient, both X and Y in the range of 0 to 1.
+    /// </summary>
+    [MotionProperty]
+    public partial SKPoint Center { get; set; }
+
+    /// <summary>
+    /// Gets or sets the radius, in the range of 0 to 1, where 1 is the minimum of the chart Width and Height.
+    /// </summary>
+    [MotionProperty]
+    public partial float Radius { get; set; }
+
+    /// <summary>
+    /// Gets or sets the relative positions of the colors, in the range of 0 to 1, or null to space them equally.
+    /// </summary>
+    [MotionProperty]
+    public partial float[]? ColorPos { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RadialGradientPaint"/> class.
@@ -89,7 +115,7 @@ public class RadialGradientPaint : SkiaPaint
     /// <inheritdoc cref="Paint.CloneTask" />
     public override Paint CloneTask()
     {
-        var clone = new RadialGradientPaint(_gradientStops, _center, _radius, _colorPos, _tileMode);
+        var clone = new RadialGradientPaint(GradientStops, Center, Radius, ColorPos, _tileMode);
         Map(this, clone);
 
         return clone;
@@ -147,16 +173,35 @@ public class RadialGradientPaint : SkiaPaint
 
     private SKShader GetShader()
     {
-        if (_shader is not null)
+        // Read the (possibly interpolated) values once; the getters advance any active transition.
+        var stops = GradientStops;
+        var colorPos = ColorPos;
+        var centerPos = Center;
+        var radius = Radius;
+
+        if (_shader is not null &&
+            ReferenceEquals(stops, _builtStops) &&
+            ReferenceEquals(colorPos, _builtColorPos) &&
+            centerPos == _builtCenter &&
+            radius == _builtRadius &&
+            _activeClip == _builtClip)
             return _shader;
 
-        var center = new SKPoint(_activeClip.Location.X + _center.X * _activeClip.Width, _activeClip.Location.Y + _center.Y * _activeClip.Height);
+        _builtStops = stops;
+        _builtColorPos = colorPos;
+        _builtCenter = centerPos;
+        _builtRadius = radius;
+        _builtClip = _activeClip;
+
+        var center = new SKPoint(_activeClip.Location.X + centerPos.X * _activeClip.Width, _activeClip.Location.Y + centerPos.Y * _activeClip.Height);
         var r = _activeClip.Location.X + _activeClip.Width > _activeClip.Location.Y + _activeClip.Height
             ? _activeClip.Location.Y + _activeClip.Height
             : _activeClip.Location.X + _activeClip.Width;
-        r *= _radius;
+        r *= radius;
+
+        _shader?.Dispose();
 
         return
-            _shader = SKShader.CreateRadialGradient(center, r, _gradientStops, _colorPos, _tileMode);
+            _shader = SKShader.CreateRadialGradient(center, r, stops, colorPos, _tileMode);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -133,43 +133,6 @@ public class RadialGradientPaint : SkiaPaint
         _skiaPaint.ColorFilter = null;
     }
 
-    internal override Paint Transitionate(float progress, Paint target)
-    {
-        if (target is not RadialGradientPaint toPaint) return target;
-
-        if (toPaint._gradientStops.Length != _gradientStops.Length)
-            throw new ArgumentException("The gradient stops must be the same length.");
-
-        for (var i = 0; i < _gradientStops.Length; i++)
-            _gradientStops[i] = new SKColor(
-                (byte)(_gradientStops[i].Red + progress * (toPaint._gradientStops[i].Red - _gradientStops[i].Red)),
-                (byte)(_gradientStops[i].Green + progress * (toPaint._gradientStops[i].Green - _gradientStops[i].Green)),
-                (byte)(_gradientStops[i].Blue + progress * (toPaint._gradientStops[i].Blue - _gradientStops[i].Blue)),
-                (byte)(_gradientStops[i].Alpha + progress * (toPaint._gradientStops[i].Alpha - _gradientStops[i].Alpha)));
-
-        _center = new SKPoint(
-            _center.X + progress * (toPaint._center.X - _center.X),
-            _center.Y + progress * (toPaint._center.Y - _center.Y));
-
-        _radius = _radius + progress * (toPaint._radius - _radius);
-
-        if (_colorPos is not null && toPaint._colorPos is not null)
-        {
-            if (_colorPos is null || _colorPos.Length != _colorPos.Length)
-                throw new ArgumentException("The color positions must be the same length.");
-
-            for (var i = 0; i < _colorPos.Length; i++)
-                _colorPos[i] = _colorPos[i] + progress * (_colorPos[i] - _colorPos[i]);
-        }
-
-        _shader?.Dispose();
-        _shader = null;
-
-        _skiaPaint?.Shader = GetShader();
-
-        return this;
-    }
-
     internal override void DisposeTask()
     {
         base.DisposeTask();

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/RadialGradientPaint.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Generators;
 using LiveChartsCore.Painting;
@@ -183,7 +184,7 @@ public partial class RadialGradientPaint : SkiaPaint
             ReferenceEquals(stops, _builtStops) &&
             ReferenceEquals(colorPos, _builtColorPos) &&
             centerPos == _builtCenter &&
-            radius == _builtRadius &&
+            Math.Abs(radius - _builtRadius) < 1e-6f &&
             _activeClip == _builtClip)
             return _shader;
 

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Generators;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing;
 using SkiaSharp;
@@ -31,7 +32,7 @@ namespace LiveChartsCore.SkiaSharpView.Painting;
 /// Defines a set of geometries that will be painted using a solid color.
 /// </summary>
 /// <seealso cref="Paint" />
-public class SolidColorPaint : SkiaPaint
+public partial class SolidColorPaint : SkiaPaint
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SolidColorPaint"/> class.
@@ -58,7 +59,7 @@ public class SolidColorPaint : SkiaPaint
     public SolidColorPaint(SKColor color, float strokeWidth)
         : base(strokeWidth)
     {
-        Color = color;
+        _ColorMotionProperty = new(color);
     }
 
     /// <summary>
@@ -67,7 +68,8 @@ public class SolidColorPaint : SkiaPaint
     /// <value>
     /// The color.
     /// </value>
-    public SKColor Color { get; set; }
+    [MotionProperty]
+    public partial SKColor Color { get; set; }
 
     /// <inheritdoc cref="Paint.CloneTask" />
     public override Paint CloneTask()

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SolidColorPaint.cs
@@ -91,21 +91,6 @@ public partial class SolidColorPaint : SkiaPaint
         if (_skiaPaint.Color != Color) _skiaPaint.Color = Color;
     }
 
-    internal override Paint Transitionate(float progress, Paint target)
-    {
-        if (target is not SolidColorPaint toPaint) return target;
-
-        Color = new SKColor(
-            (byte)(Color.Red + progress * (toPaint.Color.Red - Color.Red)),
-            (byte)(Color.Green + progress * (toPaint.Color.Green - Color.Green)),
-            (byte)(Color.Blue + progress * (toPaint.Color.Blue - Color.Blue)),
-            (byte)(Color.Alpha + progress * (toPaint.Color.Alpha - Color.Alpha)));
-
-        _skiaPaint?.Color = Color;
-
-        return this;
-    }
-
     internal override void ApplyOpacityMask(DrawingContext context, float opacity, IDrawnElement? drawnElement)
     {
         var skiaContext = (SkiaSharpDrawingContext)context;

--- a/tests/CoreTests/CoreObjectsTests/GradientPaintAnimationTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/GradientPaintAnimationTests.cs
@@ -1,0 +1,218 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// The gradient paints animate their stops, points, radius and color positions in place via
+// motion properties. These tests drive the motion clock by hand and read the (public) animated
+// properties back to assert interpolation, completion, and the mismatched-length snap policy.
+[TestClass]
+public class GradientPaintAnimationTests
+{
+    [TestMethod]
+    public void GradientStops_InterpolatePerChannelAndComplete()
+    {
+        var from = new[] { new SKColor(0, 0, 0, 255), new SKColor(0, 0, 0, 255) };
+        var to = new[] { new SKColor(200, 100, 50, 255), new SKColor(100, 200, 150, 255) };
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new LinearGradientPaint(from);
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), LinearGradientPaint.GradientStopsProperty);
+
+        DrawFrame(0);
+        paint.GradientStops = from;
+        paint.CompleteTransition(LinearGradientPaint.GradientStopsProperty);
+
+        paint.GradientStops = to;
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            animatable.IsValid = true;
+            var mid = paint.GradientStops;
+
+            for (var i = 0; i < to.Length; i++)
+            {
+                AssertChannel(from[i].Red, to[i].Red, 0.5f, mid[i].Red);
+                AssertChannel(from[i].Green, to[i].Green, 0.5f, mid[i].Green);
+                AssertChannel(from[i].Blue, to[i].Blue, 0.5f, mid[i].Blue);
+            }
+            Assert.IsFalse(animatable.IsValid, "paint must still be animating mid-flight.");
+
+            DrawFrame(2000);
+            CollectionAssert.AreEqual(to, paint.GradientStops);
+
+            var motion = paint.GetPropertyDefinition(nameof(LinearGradientPaint.GradientStops))!.GetMotion(paint);
+            Assert.IsTrue(motion.IsCompleted, "the gradient-stops transition must complete.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+
+        void DrawFrame(long time)
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = time;
+            animatable.IsValid = true;
+            _ = paint.GradientStops;
+        }
+    }
+
+    [TestMethod]
+    public void GradientStops_MismatchedLengthSnapsToTarget()
+    {
+        var from = new[] { new SKColor(0, 0, 0, 255), new SKColor(0, 0, 0, 255) };
+        var to = new[] { SKColors.Red, SKColors.Green, SKColors.Blue };
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new LinearGradientPaint(from);
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), LinearGradientPaint.GradientStopsProperty);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        animatable.IsValid = true;
+        paint.GradientStops = from;
+        paint.CompleteTransition(LinearGradientPaint.GradientStopsProperty);
+
+        // A change to a different-length array cannot interpolate: it snaps to the target value
+        // immediately rather than throwing or blending.
+        paint.GradientStops = to;
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500; // mid "transition"
+            animatable.IsValid = true;
+            CollectionAssert.AreEqual(to, paint.GradientStops);
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    [TestMethod]
+    public void StartPoint_Interpolates()
+    {
+        var from = new SKPoint(0, 0);
+        var to = new SKPoint(1, 1);
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new LinearGradientPaint([SKColors.Red, SKColors.Blue]);
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), LinearGradientPaint.StartPointProperty);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        animatable.IsValid = true;
+        paint.StartPoint = from;
+        paint.CompleteTransition(LinearGradientPaint.StartPointProperty);
+
+        paint.StartPoint = to;
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            animatable.IsValid = true;
+            var mid = paint.StartPoint;
+            Assert.AreEqual(0.5f, mid.X, 0.001f);
+            Assert.AreEqual(0.5f, mid.Y, 0.001f);
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    [TestMethod]
+    public void ColorPos_InterpolatesThenNullSnaps()
+    {
+        var from = new[] { 0f, 1f };
+        var to = new[] { 0.2f, 0.8f };
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new LinearGradientPaint([SKColors.Red, SKColors.Blue], LinearGradientPaint.DefaultStartPoint, LinearGradientPaint.DefaultEndPoint, from);
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), LinearGradientPaint.ColorPosProperty);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        animatable.IsValid = true;
+        paint.ColorPos = from;
+        paint.CompleteTransition(LinearGradientPaint.ColorPosProperty);
+
+        paint.ColorPos = to;
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            animatable.IsValid = true;
+            var mid = paint.ColorPos!;
+            Assert.AreEqual(0.1f, mid[0], 0.001f);
+            Assert.AreEqual(0.9f, mid[1], 0.001f);
+
+            // A transition to null cannot interpolate: it snaps.
+            paint.ColorPos = null;
+            CoreMotionCanvas.DebugElapsedMilliseconds = 600;
+            animatable.IsValid = true;
+            Assert.IsNull(paint.ColorPos);
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    [TestMethod]
+    public void RadialGradient_CenterInterpolates()
+    {
+        var from = new SKPoint(0f, 0f);
+        var to = new SKPoint(1f, 1f);
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new RadialGradientPaint([SKColors.Red, SKColors.Blue], from);
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), RadialGradientPaint.CenterProperty);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        animatable.IsValid = true;
+        paint.Center = from;
+        paint.CompleteTransition(RadialGradientPaint.CenterProperty);
+
+        paint.Center = to;
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            animatable.IsValid = true;
+            var mid = paint.Center;
+            Assert.AreEqual(0.5f, mid.X, 0.001f);
+            Assert.AreEqual(0.5f, mid.Y, 0.001f);
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    private static void AssertChannel(byte from, byte to, float progress, byte actual)
+    {
+        var expected = (byte)(from + progress * (to - from));
+        Assert.IsTrue(
+            Math.Abs(actual - expected) <= 1,
+            $"channel expected ~{expected} but was {actual} at progress {progress}.");
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
@@ -51,4 +51,45 @@ public class PaintReferenceMotionTests
             CoreMotionCanvas.DebugElapsedMilliseconds = -1;
         }
     }
+
+    // Replacing a geometry's fill must NOT mutate the previous paint instance. Regression guard for
+    // the in-place blend this PR removes: the old Paint.Transitionate lerped the previous paint's
+    // color in place, corrupting visual-state paints shared across points (e.g. ConditionalDraw's
+    // shared red paint stopped being red after the first clear). With references snapping, the
+    // previous paint is left untouched.
+    [TestMethod]
+    public void ReplacingFill_DoesNotMutateThePreviousPaint()
+    {
+        var red = new SKColor(255, 0, 0);
+        var shared = new SolidColorPaint(red); // stands in for a state paint shared across points
+        var geometry = new RectangleGeometry();
+        var animatable = (Animatable)geometry;
+
+        // Animate the geometry the way a series does, so any transition machinery is exercised.
+        geometry.SetTransition(new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)));
+
+        try
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+            animatable.IsValid = true;
+            geometry.Fill = shared;
+            Assert.AreSame(shared, geometry.Fill);
+
+            // Replace the fill (as clearing/changing a state does) and drive a full second of frames.
+            geometry.Fill = new SolidColorPaint(new SKColor(0, 0, 255));
+            for (long t = 0; t <= 1000; t += 100)
+            {
+                CoreMotionCanvas.DebugElapsedMilliseconds = t;
+                animatable.IsValid = true;
+                _ = geometry.Fill;
+            }
+
+            Assert.AreEqual(red, shared.Color,
+                "replacing a geometry's fill must not mutate the previous paint instance.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
 }

--- a/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
@@ -1,0 +1,54 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// A paint reference is not interpolated (animation lives inside the paint). Assigning a new paint
+// to a geometry's Fill snaps to it, and the motion must report completion even with an animation
+// configured — a non-interpolated transition is trivially done.
+[TestClass]
+public class PaintReferenceMotionTests
+{
+    [TestMethod]
+    public void Fill_SnapsToNewPaintAndReportsCompleted()
+    {
+        var geometry = new RectangleGeometry();
+        var animatable = (Animatable)geometry;
+        var paintA = new SolidColorPaint(SKColors.Red);
+        var paintB = new SolidColorPaint(SKColors.Blue);
+
+        geometry.SetTransition(
+            new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)), DrawnGeometry.FillProperty);
+
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        animatable.IsValid = true;
+        geometry.Fill = paintA;
+        geometry.CompleteTransition(DrawnGeometry.FillProperty);
+
+        // Assign a new paint while a transition + animation are configured.
+        CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+        animatable.IsValid = true;
+        geometry.Fill = paintB;
+
+        try
+        {
+            // The reference snaps to the new paint (no blending between instances).
+            Assert.AreSame(paintB, geometry.Fill);
+
+            // Regression: before the base fix the motion stayed IsCompleted == false forever because
+            // GetMovement returns early when it cannot interpolate, never running the completion path.
+            var motion = geometry.GetPropertyDefinition(nameof(DrawnGeometry.Fill))!.GetMotion(geometry);
+            Assert.IsTrue(motion.IsCompleted, "a non-interpolated paint transition must report completion.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+}

--- a/tests/CoreTests/CoreObjectsTests/SolidColorPaintAnimationTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/SolidColorPaintAnimationTests.cs
@@ -1,0 +1,137 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// Paints animate by mutating their own state on the same instance (their interpolable
+// properties are motion properties). These tests drive the motion clock by hand and assert
+// that Color and StrokeThickness interpolate from the previous value toward the new one and
+// then settle — i.e. the paint stops invalidating once the transition completes.
+[TestClass]
+public class SolidColorPaintAnimationTests
+{
+    [TestMethod]
+    public void Color_InterpolatesBetweenValuesAndCompletes()
+    {
+        var from = new SKColor(0, 0, 0, 255);
+        var to = new SKColor(200, 100, 50, 255);
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new SolidColorPaint();
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), SolidColorPaint.ColorProperty);
+
+        void DrawFrame(long time)
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = time;
+            animatable.IsValid = true;
+            _ = paint.Color; // reading the getter advances the transition with the current clock
+        }
+
+        // Baseline: snap the color to `from` so the next assignment animates from a known value.
+        DrawFrame(0);
+        paint.Color = from;
+        paint.CompleteTransition(SolidColorPaint.ColorProperty);
+
+        // Start the transition `from` -> `to` at t = 0.
+        paint.Color = to;
+
+        try
+        {
+            // Mid-flight samples: each channel is a linear blend, and the paint is still invalid
+            // (the getter flags it so the canvas keeps drawing).
+            foreach (var t in new long[] { 250, 500, 750 })
+            {
+                CoreMotionCanvas.DebugElapsedMilliseconds = t;
+                animatable.IsValid = true;
+                var c = paint.Color;
+                var p = t / (float)duration.TotalMilliseconds;
+
+                AssertChannel(from.Red, to.Red, p, c.Red);
+                AssertChannel(from.Green, to.Green, p, c.Green);
+                AssertChannel(from.Blue, to.Blue, p, c.Blue);
+                Assert.AreEqual(255, c.Alpha);
+                Assert.IsFalse(animatable.IsValid, $"paint must still be animating at t={t}.");
+            }
+
+            // Past the end the color equals the target and the transition is completed
+            // (the paint no longer invalidates itself, so the canvas can stop drawing).
+            DrawFrame(2000);
+            Assert.AreEqual(to, paint.Color);
+
+            var motion = paint.GetPropertyDefinition(nameof(SolidColorPaint.Color))!.GetMotion(paint);
+            Assert.IsTrue(motion.IsCompleted, "the color transition must complete at the end.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    [TestMethod]
+    public void StrokeThickness_InterpolatesBetweenValuesAndCompletes()
+    {
+        const float from = 2f;
+        const float to = 10f;
+        var duration = TimeSpan.FromSeconds(1);
+
+        var paint = new SolidColorPaint();
+        var animatable = (Animatable)paint;
+
+        paint.SetTransition(
+            new Animation(EasingFunctions.Lineal, duration), Paint.StrokeThicknessProperty);
+
+        DrawFrame(0);
+        paint.StrokeThickness = from;
+        paint.CompleteTransition(Paint.StrokeThicknessProperty);
+
+        paint.StrokeThickness = to;
+
+        try
+        {
+            foreach (var t in new long[] { 250, 500, 750 })
+            {
+                CoreMotionCanvas.DebugElapsedMilliseconds = t;
+                animatable.IsValid = true;
+                var value = paint.StrokeThickness;
+                var p = t / (float)duration.TotalMilliseconds;
+
+                Assert.AreEqual(from + p * (to - from), value, 0.001f);
+                Assert.IsFalse(animatable.IsValid, $"paint must still be animating at t={t}.");
+            }
+
+            DrawFrame(2000);
+            Assert.AreEqual(to, paint.StrokeThickness, 0.001f);
+
+            var motion = paint.GetPropertyDefinition(nameof(Paint.StrokeThickness))!.GetMotion(paint);
+            Assert.IsTrue(motion.IsCompleted, "the stroke-thickness transition must complete at the end.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+
+        void DrawFrame(long time)
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = time;
+            animatable.IsValid = true;
+            _ = paint.StrokeThickness;
+        }
+    }
+
+    private static void AssertChannel(byte from, byte to, float progress, byte actual)
+    {
+        var expected = (byte)(from + progress * (to - from));
+        Assert.IsTrue(
+            Math.Abs(actual - expected) <= 1,
+            $"channel expected ~{expected} but was {actual} at progress {progress}.");
+    }
+}

--- a/tests/CoreTests/OtherTests/GradientPaintsTests.cs
+++ b/tests/CoreTests/OtherTests/GradientPaintsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using LiveChartsCore.Motion;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView;
@@ -77,55 +76,6 @@ public class GradientPaintsTests
     }
 
     [TestMethod]
-    public void LinearGradient_TransitionateBetweenSameLengthStopsBlendsValues()
-    {
-        var from = new LinearGradientPaint(
-            [new SKColor(0, 0, 0, 0), new SKColor(0, 0, 0, 0)],
-            new SKPoint(0, 0),
-            new SKPoint(0, 0));
-        var to = new LinearGradientPaint(
-            [new SKColor(100, 200, 50, 200), new SKColor(50, 100, 150, 100)],
-            new SKPoint(1, 1),
-            new SKPoint(1, 1),
-            colorPos: [0f, 1f]);
-
-        // ColorPos on `from` matches `to` length so the colorPos transition branch runs.
-        var fromWithColorPos = new LinearGradientPaint(
-            [new SKColor(0, 0, 0, 0), new SKColor(0, 0, 0, 0)],
-            new SKPoint(0, 0),
-            new SKPoint(0, 0),
-            colorPos: [0f, 1f]);
-
-        // Simple smoke-call: should not throw and should return `from` (in-place mutation).
-        var result = fromWithColorPos.Transitionate(0.5f, to);
-        Assert.AreSame(fromWithColorPos, result);
-
-        // Same-length stops without colorPos still works.
-        result = from.Transitionate(0.5f, to);
-        Assert.AreSame(from, result);
-    }
-
-    [TestMethod]
-    public void LinearGradient_TransitionateToDifferentTargetTypeReturnsTarget()
-    {
-        var gradient = new LinearGradientPaint(s_twoStops);
-        var solid = new SolidColorPaint(SKColors.Red);
-
-        // When the target is a different paint type, Transitionate must hand off the target.
-        var result = gradient.Transitionate(0.5f, solid);
-        Assert.AreSame(solid, result);
-    }
-
-    [TestMethod]
-    public void LinearGradient_TransitionateMismatchedStopsThrows()
-    {
-        var from = new LinearGradientPaint(s_twoStops);
-        var to = new LinearGradientPaint(s_threeStops);
-
-        Assert.ThrowsExactly<NotImplementedException>(() => _ = from.Transitionate(0.5f, to));
-    }
-
-    [TestMethod]
     public void RadialGradient_ConstructorOverloadsAllProduceUsablePaint()
     {
         var fromArray = new RadialGradientPaint(s_twoStops);
@@ -166,42 +116,6 @@ public class GradientPaintsTests
         using var image = chart.GetImage();
         Assert.IsNotNull(image);
         paint.DisposeTask();
-    }
-
-    [TestMethod]
-    public void RadialGradient_TransitionateBetweenSameLengthStopsBlendsValues()
-    {
-        var from = new RadialGradientPaint(
-            [new SKColor(0, 0, 0, 0), new SKColor(0, 0, 0, 0)],
-            new SKPoint(0, 0),
-            radius: 0f);
-        var to = new RadialGradientPaint(
-            [new SKColor(100, 200, 50, 200), new SKColor(50, 100, 150, 100)],
-            new SKPoint(1, 1),
-            radius: 1f,
-            colorPos: [0f, 1f]);
-
-        var result = from.Transitionate(0.5f, to);
-        Assert.AreSame(from, result);
-    }
-
-    [TestMethod]
-    public void RadialGradient_TransitionateToDifferentTargetTypeReturnsTarget()
-    {
-        var gradient = new RadialGradientPaint(s_twoStops);
-        var solid = new SolidColorPaint(SKColors.Red);
-
-        var result = gradient.Transitionate(0.5f, solid);
-        Assert.AreSame(solid, result);
-    }
-
-    [TestMethod]
-    public void RadialGradient_TransitionateMismatchedStopsThrows()
-    {
-        var from = new RadialGradientPaint(s_twoStops);
-        var to = new RadialGradientPaint(s_threeStops);
-
-        Assert.ThrowsExactly<ArgumentException>(() => _ = from.Transitionate(0.5f, to));
     }
 
     // The next three tests cover the opacity-filter cache + disposal contract introduced


### PR DESCRIPTION
## Summary

Makes paints animate the same way everything else in the library does — by mutating their own state on a single instance — and removes the separate, bespoke paint-transition mechanism.

Two commits:

1. **Paint properties become motion properties.** `StrokeThickness` / `StrokeMiter` on `Paint`, and `Color` on `SolidColorPaint`, are now `[MotionProperty]`, so changing them animates in place (consistent with how every geometry property already animates). Adds `SKColorMotionProperty` and the generator mapping for `SKColor` / `SKColor?`.

2. **Remove `Paint.Transitionate`.** A paint *reference* is no longer interpolated. Previously, changing a geometry's `Fill`/`Stroke` reference blended one paint instance into another via `Paint.Transitionate`, threading the active paint through a mutable **static** (`PaintMotionProperty.s_activePaint`) set/cleared inside the draw loop. That mechanism is deleted; `PaintMotionProperty` becomes non-transitioning (it snaps the reference).

## Why

- Removes a process-mutable static threaded through the render loop (a thread-safety smell, since chart updates can arrive from any thread).
- Removes ~117 lines of per-paint-type blend code that largely duplicated what motion properties do, and which snapped on type mismatch anyway.
- Unifies the animation model: paints animate by in-place state changes, like geometries — no second mechanism.

## Behavior changes (intentional)

A paint **reference swap** now snaps instead of cross-fading:

- `null → paint` / `paint → null` (appear/disappear) — previously faded, now snaps.
- Paint **type** change (e.g. solid → gradient) — already snapped; unchanged.
- Same-type **gradient** color change now snaps too, until a gradient stop-array motion property is added (follow-up).

Value animation *within* a paint (color, stroke thickness/miter) animates smoothly as before — now driven by the paint's own motion properties.

## Notes

- `DrawnGeometry.Fill`/`Stroke` remain registered motion properties (non-transitioning) so the property registry / visual-states / clone paths are unaffected; only the blending is removed.
- `PathEffect` and `ImageFilter` transitions are a separate mechanism and are untouched.

## Tests

- Core: **819/819** pass.
- Snapshot (image comparison): **175/175** pass — steady-state rendering is byte-identical.
- Removed the gradient `Transitionate` unit tests, which asserted the now-removed blend behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)