### PR TITLE
Add an imperative behavior to visual states

### DIFF
--- a/src/LiveChartsCore/VisualStates/IStateBehavior.cs
+++ b/src/LiveChartsCore/VisualStates/IStateBehavior.cs
@@ -1,0 +1,61 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore.Drawing;
+
+namespace LiveChartsCore.VisualStates;
+
+/// <summary>
+/// Defines an imperative side of a visual state, for work that a value setter can not express.
+/// </summary>
+/// <remarks>
+/// A value setter assigns a registered motion property by name (and is restored automatically when
+/// the state is cleared); some effects can not be modeled that way — for example animating a fill
+/// color requires reaching into the paint's own motion property instead of replacing the paint
+/// reference. A behavior runs arbitrary work when the state is applied and pairs it with the work to
+/// undo it when the state is removed.
+/// <para>
+/// A single behavior instance is shared by every target the owning state is applied to (one state
+/// definition per series is applied to each point), so a behavior must be stateless. If it needs to
+/// remember a per-target value in order to restore it, key that value on the target (for example via
+/// a <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey, TValue}"/>) rather than in
+/// an instance field.
+/// </para>
+/// <para>
+/// A behavior should mutate the per-target visual it is handed, not a shared/theme paint instance;
+/// mutating a shared paint would affect every point that draws with it.
+/// </para>
+/// </remarks>
+public interface IStateBehavior
+{
+    /// <summary>
+    /// Called once when the state becomes active on the given target.
+    /// </summary>
+    /// <param name="target">The target the state was applied to.</param>
+    void OnStateApplied(Animatable target);
+
+    /// <summary>
+    /// Called once when the state is removed from the given target; should undo <see cref="OnStateApplied"/>.
+    /// </summary>
+    /// <param name="target">The target the state was removed from.</param>
+    void OnStateRemoved(Animatable target);
+}

--- a/src/LiveChartsCore/VisualStates/SetterExtensions.cs
+++ b/src/LiveChartsCore/VisualStates/SetterExtensions.cs
@@ -36,11 +36,17 @@ public static class SetterExtensions
     /// <param name="series">The series.</param>
     /// <param name="stateName">The state name.</param>
     /// <param name="setters">The setters collection.</param>
+    /// <param name="behaviors">
+    /// Optional imperative behaviors for the state, for effects a value setter can not express (for
+    /// example animating a fill color). Each is applied when the state becomes active and reversed
+    /// when it is removed. Use <see cref="StateBehavior"/> for an inline, delegate-based behavior.
+    /// </param>
     /// <returns>The series.</returns>
     public static ISeries HasState(
         this ISeries series,
         string stateName,
-        (string, object)[] setters)
+        (string, object)[] setters,
+        params IStateBehavior[] behaviors)
     {
         var statesDictionary = setters.ToDictionary(
             x => x.Item1,
@@ -57,7 +63,7 @@ public static class SetterExtensions
                 // if both are defined by the user or both are defined by the theme
 
                 series.VisualStates[stateName] =
-                    new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet);
+                    new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet, behaviors);
             }
             else
             {
@@ -66,7 +72,7 @@ public static class SetterExtensions
                 if (propertiesDictionary.isInternalSet && !isInternalSet)
                 {
                     series.VisualStates[stateName] =
-                        new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet);
+                        new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet, behaviors);
                 }
             }
         }
@@ -75,7 +81,7 @@ public static class SetterExtensions
             // if the state is not defined, we can add it
 
             series.VisualStates[stateName] =
-                new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet);
+                new VisualStatesDictionary.DrawnPropertiesDictionary(statesDictionary, isInternalSet, behaviors);
         }
 
         return series;

--- a/src/LiveChartsCore/VisualStates/StateBehavior.cs
+++ b/src/LiveChartsCore/VisualStates/StateBehavior.cs
@@ -1,0 +1,49 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using LiveChartsCore.Drawing;
+
+namespace LiveChartsCore.VisualStates;
+
+/// <summary>
+/// An inline <see cref="IStateBehavior"/> built from a pair of delegates, for one-off behaviors that
+/// do not warrant a dedicated type.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="StateBehavior"/> class. The same instance is shared by
+/// every target the owning state is applied to, so the delegates must be stateless; see
+/// <see cref="IStateBehavior"/> for how to keep per-target state.
+/// </remarks>
+/// <param name="onStateApplied">The action to run when the state is applied.</param>
+/// <param name="onStateRemoved">The action to run when the state is removed; should undo the apply action.</param>
+public sealed class StateBehavior(
+    Action<Animatable>? onStateApplied = null,
+    Action<Animatable>? onStateRemoved = null)
+        : IStateBehavior
+{
+    /// <inheritdoc cref="IStateBehavior.OnStateApplied(Animatable)"/>
+    public void OnStateApplied(Animatable target) => onStateApplied?.Invoke(target);
+
+    /// <inheritdoc cref="IStateBehavior.OnStateRemoved(Animatable)"/>
+    public void OnStateRemoved(Animatable target) => onStateRemoved?.Invoke(target);
+}

--- a/src/LiveChartsCore/VisualStates/VisualStatesDictionary.cs
+++ b/src/LiveChartsCore/VisualStates/VisualStatesDictionary.cs
@@ -70,6 +70,10 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
 
         if (!animatable._statesTracker.ActiveStates.Add(stateName)) return;
         animatable._statesTracker.ActiveStatesList.Add(stateName);
+
+        // run the imperative side of the state, once, on activation.
+        foreach (var behavior in state.Behaviors)
+            behavior.OnStateApplied(animatable);
     }
 
     /// <summary>
@@ -120,6 +124,10 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
 
         _ = animatable._statesTracker.ActiveStates.Remove(stateName);
         _ = animatable._statesTracker.ActiveStatesList.Remove(stateName);
+
+        // undo the imperative side of the state (we only get here when the state was active).
+        foreach (var behavior in state.Behaviors)
+            behavior.OnStateRemoved(animatable);
     }
 
     /// <summary>
@@ -148,6 +156,10 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
                     _ = animatable._statesTracker.OriginalValues.Remove(definition);
                 }
             }
+
+            // undo the imperative side of every active state.
+            foreach (var behavior in state.Behaviors)
+                behavior.OnStateRemoved(animatable);
         }
 
         animatable._statesTracker.ActiveStates.Clear();
@@ -172,11 +184,21 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
     /// </summary>
     /// <param name="baseDictionary">The base dictionary.</param>
     /// <param name="isInternalSet">Indicates whether the object was created by a theme.</param>
+    /// <param name="behaviors">The imperative behaviors run when the state is applied/removed.</param>
     public class DrawnPropertiesDictionary(
         Dictionary<string, DrawnPropertySetter> baseDictionary,
-        bool isInternalSet)
+        bool isInternalSet,
+        IReadOnlyList<IStateBehavior>? behaviors = null)
             : Dictionary<string, DrawnPropertySetter>(baseDictionary)
     {
         internal bool isInternalSet { get; } = isInternalSet;
+
+        /// <summary>
+        /// Gets the imperative behaviors of the state. These run alongside the value setters: each is
+        /// applied when the state becomes active and reversed when the state is removed. They are kept
+        /// separate from the value setters because they are not keyed by a property name and so do not
+        /// take part in the value-setter restore/layering.
+        /// </summary>
+        public IReadOnlyList<IStateBehavior> Behaviors { get; } = behaviors ?? [];
     }
 }

--- a/tests/CoreTests/CoreObjectsTests/StateBehaviorTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/StateBehaviorTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.VisualStates;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static LiveChartsCore.VisualStates.VisualStatesDictionary;
+
+namespace CoreTests.CoreObjectsTests;
+
+// Visual states can carry an imperative IStateBehavior alongside their value setters. These tests
+// pin the contract: a behavior is applied once when its state becomes active and reversed once when
+// the state is removed, it never fires for a state that was not active, and it coexists with value
+// setters (which keep their own save/restore). A SolidColorPaint is used as a convenient Animatable
+// target since it exposes registered motion properties (e.g. StrokeThickness).
+[TestClass]
+public class StateBehaviorTests
+{
+    private sealed class RecordingBehavior : IStateBehavior
+    {
+        public int Applied { get; private set; }
+        public int Removed { get; private set; }
+        public Animatable? LastTarget { get; private set; }
+
+        public void OnStateApplied(Animatable target) { Applied++; LastTarget = target; }
+        public void OnStateRemoved(Animatable target) { Removed++; LastTarget = target; }
+    }
+
+    private static VisualStatesDictionary StatesWith(
+        string name, IStateBehavior behavior, params (string, object)[] setters)
+    {
+        var setterMap = new Dictionary<string, DrawnPropertySetter>();
+        foreach (var (property, value) in setters)
+            setterMap[property] = new DrawnPropertySetter(property, value);
+
+        return new VisualStatesDictionary
+        {
+            [name] = new DrawnPropertiesDictionary(setterMap, isInternalSet: false, behaviors: [behavior])
+        };
+    }
+
+    [TestMethod]
+    public void Behavior_FiresOnceOnApply_AndOnceOnRemove()
+    {
+        var behavior = new RecordingBehavior();
+        var states = StatesWith("Hover", behavior);
+        var target = new SolidColorPaint();
+
+        states.SetState("Hover", target);
+        states.SetState("Hover", target); // re-applying an already-active state must not re-fire
+
+        Assert.AreEqual(1, behavior.Applied);
+        Assert.AreEqual(0, behavior.Removed);
+        Assert.AreSame(target, behavior.LastTarget);
+
+        states.ClearState("Hover", target);
+        states.ClearState("Hover", target); // clearing an inactive state must not re-fire
+
+        Assert.AreEqual(1, behavior.Applied);
+        Assert.AreEqual(1, behavior.Removed);
+    }
+
+    [TestMethod]
+    public void Behavior_NotRemoved_WhenStateNeverApplied()
+    {
+        var behavior = new RecordingBehavior();
+        var states = StatesWith("Hover", behavior);
+        var target = new SolidColorPaint();
+
+        states.ClearState("Hover", target);
+
+        Assert.AreEqual(0, behavior.Applied);
+        Assert.AreEqual(0, behavior.Removed);
+    }
+
+    [TestMethod]
+    public void StateBehavior_LambdaAdapter_InvokesDelegates()
+    {
+        var applied = 0;
+        var removed = 0;
+        Animatable? appliedTarget = null;
+
+        var behavior = new StateBehavior(
+            onStateApplied: a => { applied++; appliedTarget = a; },
+            onStateRemoved: _ => removed++);
+
+        var states = StatesWith("Hover", behavior);
+        var target = new SolidColorPaint();
+
+        states.SetState("Hover", target);
+        Assert.AreEqual(1, applied);
+        Assert.AreSame(target, appliedTarget);
+
+        states.ClearState("Hover", target);
+        Assert.AreEqual(1, removed);
+    }
+
+    [TestMethod]
+    public void StateBehavior_NullDelegates_AreNoOps()
+    {
+        var states = StatesWith("Hover", new StateBehavior());
+        var target = new SolidColorPaint();
+
+        states.SetState("Hover", target);
+        states.ClearState("Hover", target); // must not throw
+    }
+
+    [TestMethod]
+    public void Behavior_RunsAlongsideValueSetters()
+    {
+        var behavior = new RecordingBehavior();
+        var target = new SolidColorPaint { StrokeThickness = 2f };
+        var states = StatesWith("Hover", behavior, (nameof(Paint.StrokeThickness), 10f));
+
+        states.SetState("Hover", target);
+        Assert.AreEqual(1, behavior.Applied);
+        Assert.AreEqual(10f, ThicknessTarget(target), 0.001f); // value setter applied
+
+        states.ClearState("Hover", target);
+        Assert.AreEqual(1, behavior.Removed);
+        Assert.AreEqual(2f, ThicknessTarget(target), 0.001f); // value setter restored to the original
+    }
+
+    [TestMethod]
+    public void ClearStates_ReversesEveryActiveBehavior()
+    {
+        var hover = new RecordingBehavior();
+        var selected = new RecordingBehavior();
+        var target = new SolidColorPaint();
+
+        var states = new VisualStatesDictionary
+        {
+            ["Hover"] = new DrawnPropertiesDictionary(
+                new Dictionary<string, DrawnPropertySetter>(), isInternalSet: false, behaviors: [hover]),
+            ["Selected"] = new DrawnPropertiesDictionary(
+                new Dictionary<string, DrawnPropertySetter>(), isInternalSet: false, behaviors: [selected])
+        };
+
+        states.SetState("Hover", target);
+        states.SetState("Selected", target);
+        states.ClearStates(target);
+
+        Assert.AreEqual(1, hover.Applied);
+        Assert.AreEqual(1, hover.Removed);
+        Assert.AreEqual(1, selected.Applied);
+        Assert.AreEqual(1, selected.Removed);
+    }
+
+    // reads the end value of the stroke-thickness motion property without depending on the motion clock.
+    private static float ThicknessTarget(SolidColorPaint paint) =>
+        (float)paint.GetPropertyDefinition(nameof(Paint.StrokeThickness))!.GetMotion(paint)!.ToValue!;
+}


### PR DESCRIPTION
## What

Visual-state **value setters** can only assign registered motion properties by name (and they auto-restore on clear). Some effects can't be expressed that way — e.g. animating a fill color needs to reach into the paint's own motion property rather than swap the paint reference (a reference swap snaps, it doesn't animate).

This adds an **imperative** side to a visual state:

- **`IStateBehavior`** — paired `OnStateApplied(Animatable)` / `OnStateRemoved(Animatable)`. Pairing both halves in one object recovers the save/restore symmetry value setters already get for free.
- **`StateBehavior`** — the inline, delegate-based form for one-offs.
- **`HasState`** gains a `params IStateBehavior[] behaviors` argument; `DrawnPropertiesDictionary` carries them. Behaviors are kept separate from the value-setter map because they aren't keyed by a property name, so they don't take part in the value-setter restore/layering.

Lifecycle: a behavior is applied **once** when its state becomes active and reversed **once** when the state is removed; it never fires for a state that wasn't active.

## Usage

```csharp
// inline
series.HasState("Hover",
    [(nameof(DrawnGeometry.Opacity), 0.8f)],
    new StateBehavior(
        onStateApplied: a => /* animate a per-target visual */,
        onStateRemoved: a => /* undo it */));

// or a dedicated reusable IStateBehavior type
series.HasState("Hover", [], new MyHoverBehavior());
```

A behavior instance is shared across every target its state is applied to, so it must be stateless; per-target memory (for restore) should be keyed on the target (e.g. a `ConditionalWeakTable`), and it should mutate the per-target visual it is handed rather than a shared paint. This is documented on the interface.

## Tests

`StateBehaviorTests` pins the contract: applied once / reversed once, no fire when never active, repeat set/clear idempotency, the delegate adapter (incl. null delegates as no-ops), coexistence with value-setter restore, and `ClearStates` reversing every active behavior.

- Core builds clean; **835/835 CoreTests pass**; SkiaSharp view builds clean.

## Notes

Additive and back-compatible — existing `HasState(name, setters)` call sites bind unchanged. This PR is just the extensibility seam; no built-in concrete behaviors are shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)