### PR TITLE
Animate paints assigned directly to a geometry

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -264,10 +264,22 @@ public class SkiaSharpDrawingContext(
         if (paint != MeasureTask.Instance)
         {
             ActiveLvcPaint = paint;
+
+            // A per-element paint (an override the geometry carries, not a registered paint task) is
+            // visited only here, so the frame loop never resets its validity latch the way it does for
+            // tasks and geometries. Reset it before reading; OnPaintStarted re-flags it false while the
+            // paint is still animating, and leaves it true once the transition completes.
+            paint.IsValid = true;
             paint.OnPaintStarted(this, element);
         }
 
         DrawElement(element, opacity);
+
+        // Fold the per-element paint's validity into the element so an animating override keeps the
+        // canvas redrawing until its transition completes (the frame loop only checks geometries and
+        // registered tasks, never per-element paints). The measure pass does not paint, so skip it.
+        if (paint != MeasureTask.Instance)
+            element.IsValid = element.IsValid && paint.IsValid;
 
         paint.OnPaintFinished(this, element);
 

--- a/tests/CoreTests/CoreObjectsTests/PerElementPaintAnimationTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/PerElementPaintAnimationTests.cs
@@ -1,0 +1,70 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// A paint assigned directly to a geometry (an override on IDrawnElement.Fill/Stroke, not a registered
+// paint task) advances its own motion clock while drawing, but the frame loop only folds geometries and
+// registered tasks into its "needs another frame?" decision. Without help, an animating per-element
+// paint would freeze after the first frame — it only progressed while some *other* animation (or mouse
+// movement) kept the canvas dirty. The drawing context folds the per-element paint's validity into the
+// element so the override animates on its own, then lets the canvas settle once the transition completes.
+[TestClass]
+public class PerElementPaintAnimationTests
+{
+    [TestMethod]
+    public void AnimatingPerElementFill_KeepsCanvasInvalid_ThenSettles()
+    {
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+            var canvas = new CoreMotionCanvas();
+
+            // a per-element fill with a 1s color transition red -> blue
+            var fill = new SolidColorPaint(SKColors.Red);
+            fill.SetTransition(
+                new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)),
+                SolidColorPaint.ColorProperty);
+
+            // the geometry carries the paint as its own Fill (not a registered series paint task);
+            // its own geometry properties are static, so only the fill animates.
+            var rectangle = new RectangleGeometry { X = 0, Y = 0, Width = 10, Height = 10, Fill = fill };
+            _ = canvas.AddGeometry(rectangle);
+
+            // start the transition at t = 0
+            fill.Color = SKColors.Blue;
+
+            // mid-animation: the canvas must report it needs another frame even though nothing else
+            // is animating. Before the per-element fold, this latched valid and the color froze.
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            DrawFrame(canvas, surface);
+            Assert.IsFalse(
+                canvas.IsValid,
+                "an animating per-element Fill must keep the canvas wanting frames on its own.");
+
+            // past the end: the transition completes, so the canvas must settle (no perpetual redraw).
+            CoreMotionCanvas.DebugElapsedMilliseconds = 2000;
+            DrawFrame(canvas, surface);
+            Assert.IsTrue(
+                canvas.IsValid,
+                "once the per-element Fill transition completes, the canvas must settle.");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    private static void DrawFrame(CoreMotionCanvas canvas, SKSurface surface) =>
+        canvas.DrawFrame(new SkiaSharpDrawingContext(canvas, surface.Canvas, SKColor.Empty));
+}


### PR DESCRIPTION
## Problem

A paint assigned directly to a geometry — an override on `IDrawnElement.Fill`/`Stroke`/`Paint`, rather than a registered paint task — can be given a transition (`SetTransition`) and a new target value, but the animation **freezes after the first frame**. It only advances while *something else* keeps the canvas dirty (another animation in flight, or pointer movement).

### Root cause

The frame loop decides whether to draw another frame purely from registered tasks and geometries:

```csharp
isValid = isValid && geometry.IsValid;   // CoreMotionCanvas
isValid = isValid && task.IsValid;
```

A per-element override paint is neither. When the geometry draws, the paint advances its own motion clock and sets its `IsValid` to `false` (mid-transition) — but that flag is never folded back into the element or the frame, so the canvas settles and the animation stalls.

## Fix

One spot — `DrawByPaint`, the single chokepoint both per-element draw paths funnel through:

- **Reset** the per-element paint's validity before reading it (the frame loop never visits it the way it resets tasks/geometries, so its flag is otherwise a latch that never clears).
- **Fold** the paint's validity into the element afterwards, so an animating override keeps the canvas redrawing until its transition completes — then settles.

It generalizes for free: per-element `Color`, `Stroke`, `PathEffect` and `ImageFilter` animations all participate now, not just fill color. No new public API — `SetTransition` stays the scheduling primitive.

### Usage that now works

```csharp
var p = new SolidColorPaint(seriesFill.Color);
p.SetTransition(new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)), SolidColorPaint.ColorProperty);
drawn.Fill = p;
p.Color = SKColors.Yellow;   // animates on its own; previously only moved while the pointer did
```

## Tests

- New `PerElementPaintAnimationTests` drives the motion clock by hand and asserts the canvas keeps wanting frames mid-transition with **no other animation running**, then settles once it completes. Fails before the fix, passes after.
- Full CoreTests: **836/836**. Snapshot suite: **175/175** (no pixel regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)