### PR TITLE
Honor RemoveOnCompleted on paints assigned directly to a geometry

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Drawing/SkiaSharpDrawingContext.cs
@@ -285,6 +285,20 @@ public class SkiaSharpDrawingContext(
 
         ActiveSkiaPaint = originalPaint;
         ActiveLvcPaint = originalTask;
+
+        // Honor RemoveOnCompleted for a per-element override paint: once its transition is done, detach
+        // it from the element and release its native resources, so the element draws with its paint task
+        // again (or not at all) on the next frame. The frame loop only acts on RemoveOnCompleted for
+        // registered tasks and geometries — a per-element paint is neither, so without this an override
+        // assigned per hover would never be cleaned up and would orphan its SKPaint until finalization.
+        if (paint != MeasureTask.Instance && paint.RemoveOnCompleted && paint.IsValid)
+        {
+            if (ReferenceEquals(element.Fill, paint)) element.Fill = null;
+            else if (ReferenceEquals(element.Stroke, paint)) element.Stroke = null;
+            else if (ReferenceEquals(element.Paint, paint)) element.Paint = null;
+
+            paint.DisposeTask();
+        }
     }
 
     private void DrawElement(IDrawnElement<SkiaSharpDrawingContext> element, float opacity)

--- a/tests/CoreTests/CoreObjectsTests/PerElementPaintDisposalTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/PerElementPaintDisposalTests.cs
@@ -1,0 +1,115 @@
+using System;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.CoreObjectsTests;
+
+// A paint assigned directly to a geometry (an override on IDrawnElement.Fill/Stroke/Paint, not a
+// registered paint task) is never visited by the frame loop's RemoveOnCompleted handling, which only
+// acts on tasks and geometries. So a per-element override — e.g. one created per hover — was never
+// detached or disposed, orphaning its native SKPaint until finalization. The drawing context now
+// honors RemoveOnCompleted on per-element paints: once the paint's transition completes it is detached
+// from the element and its task disposed.
+[TestClass]
+public class PerElementPaintDisposalTests
+{
+    private sealed class TrackingPaint(SKColor color) : SolidColorPaint(color)
+    {
+        public int DisposeCount { get; private set; }
+
+        internal override void DisposeTask()
+        {
+            DisposeCount++;
+            base.DisposeTask();
+        }
+    }
+
+    [TestMethod]
+    public void PerElementFill_WithRemoveOnCompleted_IsDetachedAndDisposed_WhenTransitionCompletes()
+    {
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+            var canvas = new CoreMotionCanvas();
+
+            var fill = new TrackingPaint(SKColors.Red);
+            fill.SetTransition(
+                new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)),
+                SolidColorPaint.ColorProperty);
+            fill.RemoveOnCompleted = true;
+
+            var rectangle = new RectangleGeometry { X = 0, Y = 0, Width = 10, Height = 10, Fill = fill };
+            _ = canvas.AddGeometry(rectangle);
+
+            // start the transition at t = 0
+            fill.Color = SKColors.Blue;
+
+            // mid-animation: the override is still attached and must not be disposed yet.
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            DrawFrame(canvas, surface);
+            Assert.AreSame(
+                fill, rectangle.Fill,
+                "a RemoveOnCompleted per-element paint must stay attached while it is still animating.");
+            Assert.AreEqual(0, fill.DisposeCount, "...and must not be disposed mid-transition.");
+
+            // past the end: the transition completes, so the override must be detached and disposed.
+            CoreMotionCanvas.DebugElapsedMilliseconds = 2000;
+            DrawFrame(canvas, surface);
+            Assert.IsNull(
+                rectangle.Fill,
+                "a completed RemoveOnCompleted per-element paint must be detached from the element.");
+            Assert.AreEqual(
+                1, fill.DisposeCount,
+                "...and its task disposed exactly once (no orphaned SKPaint).");
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    [TestMethod]
+    public void PerElementFill_WithoutRemoveOnCompleted_StaysAttached_AfterTransitionCompletes()
+    {
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+
+        try
+        {
+            using var surface = SKSurface.Create(new SKImageInfo(100, 100));
+            var canvas = new CoreMotionCanvas();
+
+            var fill = new TrackingPaint(SKColors.Red);
+            fill.SetTransition(
+                new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)),
+                SolidColorPaint.ColorProperty);
+
+            var rectangle = new RectangleGeometry { X = 0, Y = 0, Width = 10, Height = 10, Fill = fill };
+            _ = canvas.AddGeometry(rectangle);
+
+            fill.Color = SKColors.Blue;
+
+            CoreMotionCanvas.DebugElapsedMilliseconds = 2000;
+            DrawFrame(canvas, surface);
+
+            // default behavior is unchanged: without RemoveOnCompleted the override is kept.
+            Assert.AreSame(fill, rectangle.Fill);
+            Assert.AreEqual(0, fill.DisposeCount);
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
+    private static void DrawFrame(CoreMotionCanvas canvas, SKSurface surface) =>
+        canvas.DrawFrame(new SkiaSharpDrawingContext(canvas, surface.Canvas, SKColor.Empty));
+}


### PR DESCRIPTION
## Problem

A paint assigned directly to a geometry — an override on `IDrawnElement.Fill`/`Stroke`/`Paint`, not a registered paint task — is **never visited by the frame loop's `RemoveOnCompleted` handling**, which only acts on tasks and geometries (`CoreMotionCanvas`).

So setting `RemoveOnCompleted = true` on a per-element paint did nothing. A common pattern — assigning a fresh override paint per interaction (e.g. a hover that animates a single point's fill) — would never detach or dispose the old override, **orphaning its native `SKPaint`** until finalization. Not a permanent leak, but needless churn, and the `RemoveOnCompleted` knob silently lied.

```csharp
// per hover: a new override paint is created and assigned…
var p = new SolidColorPaint(seriesFill.Color);
p.SetTransition(animation, SolidColorPaint.ColorProperty);
drawn.Fill = p;
p.Color = SKColors.Yellow;
// …on un-hover the user reasonably expects this to clean it up — but it was a no-op:
drawn.Fill.RemoveOnCompleted = true;
```

## Fix

At the per-element draw chokepoint (`DrawByPaint`), once an override paint's transition completes and `RemoveOnCompleted` is set, detach it from the element (`Fill`/`Stroke`/`Paint = null`) and dispose its task. The element then draws with its paint task again — or nothing — on the next frame, and no `SKPaint` is orphaned. The user's `RemoveOnCompleted = true` now does exactly what it reads like.

Default behavior (no `RemoveOnCompleted`) is unchanged: the override is kept.

## Tests

`PerElementPaintDisposalTests` drives the motion clock by hand:
- with `RemoveOnCompleted`: the override stays attached + undisposed mid-transition, then is detached (`Fill == null`) and disposed exactly once on completion — **fails before the fix**;
- without it: the override is kept (default unchanged).

Full CoreTests: **838/838**. Snapshots: **175/175** (no pixel regression).

## Notes

Builds on #2356 (which made per-element paints animate in the first place). Consistent with how `RemoveOnCompleted` already works for tasks/geometries — it's an explicit opt-in, so a per-element paint deliberately shared across geometries with this flag is the caller's responsibility, same as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)