### PR TITLE
Decouple visual states from motion properties

### DIFF
--- a/src/LiveChartsCore/VisualStates/VisualStatesDictionary.cs
+++ b/src/LiveChartsCore/VisualStates/VisualStatesDictionary.cs
@@ -53,15 +53,19 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
         foreach (var setter in state.Values)
         {
             var definition = animatable.GetPropertyDefinition(setter.PropertyName);
-            var property = definition?.GetMotion(animatable);
-            if (definition is null || property is null) continue;
+            if (definition is null) continue;
 
             // if the value is already saved, it means that the original value
             // was already saved by this or another state
             if (!animatable._statesTracker.OriginalValues.ContainsKey(definition))
             {
-                // save the original value
-                animatable._statesTracker.OriginalValues[definition] = property.ToValue;
+                // Save the original value. Prefer the motion's target (ToValue) so a property that is
+                // mid-animation restores to where it was heading, not its interpolated mid-flight value.
+                // A property without a motion (e.g. registered via [StateProperty]) snapshots its
+                // current value through the definition getter — states no longer require a motion.
+                var motion = definition.GetMotion(animatable);
+                animatable._statesTracker.OriginalValues[definition] =
+                    motion is not null ? motion.ToValue : definition.GetValue(animatable);
             }
 
             // set the state value
@@ -91,8 +95,7 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
         foreach (var setter in state.Values)
         {
             var definition = animatable.GetPropertyDefinition(setter.PropertyName);
-            var property = definition?.GetMotion(animatable);
-            if (definition is null || property is null) continue;
+            if (definition is null) continue;
 
             var foundValue = false;
             object? value = null;
@@ -146,8 +149,7 @@ public class VisualStatesDictionary : Dictionary<string, DrawnPropertiesDictiona
             foreach (var setter in state.Values)
             {
                 var definition = animatable.GetPropertyDefinition(setter.PropertyName);
-                var property = definition?.GetMotion(animatable);
-                if (definition is null || property is null) continue;
+                if (definition is null) continue;
 
                 // set the original value
                 if (animatable._statesTracker.OriginalValues.TryGetValue(definition, out var originalValue))

--- a/tests/CoreTests/CoreObjectsTests/MotionlessStatePropertyTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/MotionlessStatePropertyTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Motion;
+using LiveChartsCore.VisualStates;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static LiveChartsCore.VisualStates.VisualStatesDictionary;
+
+namespace CoreTests.CoreObjectsTests;
+
+// Visual states no longer require a property to be a motion property: a PropertyDefinition with a null
+// motionGetter (the shape a future [StateProperty] attribute will emit) can be targeted by a state.
+// The original value is snapshotted through the definition getter instead of a motion's ToValue, so
+// the property is set on apply and restored on clear, exactly like a motion-backed one.
+[TestClass]
+public class MotionlessStatePropertyTests
+{
+    // an Animatable whose "Label" is a plain property (no motion) registered as a motionless definition.
+    private sealed class TestAnimatable : Animatable
+    {
+        public string? Label { get; set; }
+
+        private static readonly Dictionary<string, PropertyDefinition> s_definitions = new()
+        {
+            ["Label"] = new PropertyDefinition(
+                "Label",
+                typeof(string),
+                getter: g => ((TestAnimatable)g).Label,
+                setter: (g, v) => ((TestAnimatable)g).Label = (string?)v,
+                motionGetter: _ => null) // <- no motion property backs this definition
+        };
+
+        protected override Dictionary<string, PropertyDefinition> GetPropertyDefinitions() => s_definitions;
+    }
+
+    private static VisualStatesDictionary StateSetting(string name, string property, object value) =>
+        new()
+        {
+            [name] = new DrawnPropertiesDictionary(
+                new Dictionary<string, DrawnPropertySetter> { [property] = new DrawnPropertySetter(property, value) },
+                isInternalSet: false)
+        };
+
+    [TestMethod]
+    public void SetState_AppliesAndClearState_RestoresAMotionlessProperty()
+    {
+        var states = StateSetting("Hover", "Label", "hovered");
+        var target = new TestAnimatable { Label = "default" };
+
+        states.SetState("Hover", target);
+        Assert.AreEqual("hovered", target.Label, "a state must set a motionless registered property.");
+
+        states.ClearState("Hover", target);
+        Assert.AreEqual("default", target.Label, "clearing must restore the snapshotted original value.");
+    }
+
+    [TestMethod]
+    public void ClearStates_RestoresAMotionlessProperty()
+    {
+        var states = StateSetting("Hover", "Label", "hovered");
+        var target = new TestAnimatable { Label = "default" };
+
+        states.SetState("Hover", target);
+        states.ClearStates(target);
+
+        Assert.AreEqual("default", target.Label);
+    }
+
+    [TestMethod]
+    public void Layered_MotionlessStates_RestoreInOrder()
+    {
+        var states = new VisualStatesDictionary
+        {
+            ["Hover"] = new DrawnPropertiesDictionary(
+                new Dictionary<string, DrawnPropertySetter> { ["Label"] = new DrawnPropertySetter("Label", "hover") },
+                isInternalSet: false),
+            ["Selected"] = new DrawnPropertiesDictionary(
+                new Dictionary<string, DrawnPropertySetter> { ["Label"] = new DrawnPropertySetter("Label", "selected") },
+                isInternalSet: false)
+        };
+
+        var target = new TestAnimatable { Label = "default" };
+
+        states.SetState("Hover", target);
+        states.SetState("Selected", target);
+        Assert.AreEqual("selected", target.Label);
+
+        // removing the top state falls back to the still-active one, not the original.
+        states.ClearState("Selected", target);
+        Assert.AreEqual("hover", target.Label);
+
+        // removing the last active state restores the original snapshot.
+        states.ClearState("Hover", target);
+        Assert.AreEqual("default", target.Label);
+    }
+}


### PR DESCRIPTION
## Context

Visual states could only target **motion** properties. `SetState` bailed when a property had no motion, and snapshotted the original value from the motion's `ToValue`:

```csharp
var property = definition?.GetMotion(animatable);
if (definition is null || property is null) continue;   // hard requirement
OriginalValues[definition] = property.ToValue;          // only real use of the motion
```

That forced reference-typed, non-animating properties (e.g. a paint reference) to be carried as motion properties purely so a state could target them — the motion machinery used only for registration, never for interpolation.

## Change

A `PropertyDefinition` already carries getter/setter; the motion was only used to read the value to restore. So:

- Snapshot the original via the motion's `ToValue` **when a motion exists** (preserves today's behavior — a property mid-animation restores to its target, not a mid-flight value), and fall back to `definition.GetValue(animatable)` otherwise.
- Drop the null-motion bail in `SetState`/`ClearState`/`ClearStates`.

A definition with a `null` motionGetter can now be targeted by a state. `SetTransition`/`CompleteTransition` already skip motionless definitions, so animation APIs are unaffected.

This is **step 1 of 3** toward registering state-targetable properties without making them motion properties:
1. **(this PR)** decouple states from the motion requirement;
2. add a `[StateProperty]` generator attribute that emits a motionless `PropertyDefinition` + registration;
3. migrate the reference-typed paint properties (`Fill`/`Stroke`/`Paint`, `PathEffect`/`ImageFilter`) off `ByReferenceMotionProperty`.

## Tests

`MotionlessStatePropertyTests` registers a `PropertyDefinition` with a null motionGetter and drives a state on it: apply + restore via `ClearState` and `ClearStates`, plus layered states restoring in order. The set/layered cases fail before this change, all pass after.

- Full CoreTests **839/839**; snapshots **175/175** — existing motion-backed states (incl. the `Fill`-via-motion snapshot) behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)