### PR TITLE
Make geometry paint references state properties instead of motion properties

### DIFF
--- a/src/LiveChartsCore/Drawing/BaseLabelGeometry.cs
+++ b/src/LiveChartsCore/Drawing/BaseLabelGeometry.cs
@@ -120,13 +120,13 @@ public abstract partial class BaseLabelGeometry : Animatable, IDrawnElement
     public partial Padding Padding { get; set; }
 
     /// <inheritdoc cref="IDrawnElement.Paint"/>
-    [MotionProperty(HasExplicitAcessors = true)]
-    public partial Paint? Paint
+    [StateProperty]
+    public Paint? Paint
     {
-        get => _PaintMotionProperty.GetMovement(this);
+        get;
         set
         {
-            _PaintMotionProperty.SetMovement(value, this);
+            field = value;
             value?.PaintStyle = PaintStyle.Text;
         }
     }

--- a/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
+++ b/src/LiveChartsCore/Drawing/BaseVectorGeometry.cs
@@ -100,26 +100,26 @@ public abstract partial class BaseVectorGeometry : Animatable, IDrawnElement
     partial void OnSkewTransformChanged(LvcPoint value) => HasTransform = true;
 
     /// <inheritdoc cref="IDrawnElement.Stroke"/>
-    [MotionProperty(HasExplicitAcessors = true)]
-    public partial Paint? Stroke
+    [StateProperty]
+    public Paint? Stroke
     {
-        get => _StrokeMotionProperty.GetMovement(this);
+        get;
         set
         {
             value?.PaintStyle = PaintStyle.Stroke;
-            _StrokeMotionProperty.SetMovement(value, this);
+            field = value;
         }
     }
 
     /// <inheritdoc cref="IDrawnElement.Fill"/>
-    [MotionProperty(HasExplicitAcessors = true)]
-    public partial Paint? Fill
+    [StateProperty]
+    public Paint? Fill
     {
-        get => _FillMotionProperty.GetMovement(this);
+        get;
         set
         {
             value?.PaintStyle = PaintStyle.Fill;
-            _FillMotionProperty.SetMovement(value, this);
+            field = value;
         }
     }
 

--- a/src/LiveChartsCore/Drawing/DrawnGeometry.cs
+++ b/src/LiveChartsCore/Drawing/DrawnGeometry.cs
@@ -97,26 +97,26 @@ public abstract partial class DrawnGeometry : Animatable, IDrawnElement
     partial void OnSkewTransformChanged(LvcPoint value) => HasTransform = true;
 
     /// <inheritdoc cref="IDrawnElement.Stroke"/>
-    [MotionProperty(HasExplicitAcessors = true)]
-    public partial Paint? Stroke
+    [StateProperty]
+    public Paint? Stroke
     {
-        get => _StrokeMotionProperty.GetMovement(this);
+        get;
         set
         {
             value?.PaintStyle = PaintStyle.Stroke;
-            _StrokeMotionProperty.SetMovement(value, this);
+            field = value;
         }
     }
 
     /// <inheritdoc cref="IDrawnElement.Fill"/>
-    [MotionProperty(HasExplicitAcessors = true)]
-    public partial Paint? Fill
+    [StateProperty]
+    public Paint? Fill
     {
-        get => _FillMotionProperty.GetMovement(this);
+        get;
         set
         {
             value?.PaintStyle = PaintStyle.Fill;
-            _FillMotionProperty.SetMovement(value, this);
+            field = value;
         }
     }
 

--- a/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/PaintReferenceMotionTests.cs
@@ -9,42 +9,57 @@ using SkiaSharp;
 
 namespace CoreTests.CoreObjectsTests;
 
-// A paint reference is not interpolated (animation lives inside the paint). Assigning a new paint
-// to a geometry's Fill snaps to it, and the motion must report completion even with an animation
-// configured — a non-interpolated transition is trivially done.
+// A paint reference is not interpolated (animation lives inside the paint). A geometry's Fill is a
+// visual-state target (a registered PropertyDefinition) but NOT a motion property: assigning a new
+// paint snaps to it, and the definition exposes no motion. (Paint.Transitionate, the old in-place
+// two-paint blend, was removed earlier; the by-reference motion backing was removed in this change.)
 [TestClass]
 public class PaintReferenceMotionTests
 {
     [TestMethod]
-    public void Fill_SnapsToNewPaintAndReportsCompleted()
+    public void Fill_SnapsToNewPaint_AndIsNotBackedByAMotion()
     {
         var geometry = new RectangleGeometry();
-        var animatable = (Animatable)geometry;
         var paintA = new SolidColorPaint(SKColors.Red);
         var paintB = new SolidColorPaint(SKColors.Blue);
 
-        geometry.SetTransition(
-            new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1)), DrawnGeometry.FillProperty);
+        geometry.Fill = paintA;
+        Assert.AreSame(paintA, geometry.Fill);
+
+        // assigning a new paint snaps to it — references are never blended.
+        geometry.Fill = paintB;
+        Assert.AreSame(paintB, geometry.Fill);
+
+        // Fill is registered (states can target it) but motionless: it must not animate, so the
+        // definition has no motion — which also means no FromValue pins the previous paint instance.
+        var definition = geometry.GetPropertyDefinition(nameof(DrawnGeometry.Fill))!;
+        Assert.IsNull(
+            definition.GetMotion(geometry),
+            "a paint reference must be a state property, not a motion property.");
+    }
+
+    // ByReferenceMotionProperty is no longer used to back the geometry paint references, but it remains
+    // public API. Pin its contract directly: it snaps to the assigned value and reports completion even
+    // with an animation configured (a non-interpolated transition is trivially done — the early-return
+    // path must still run OnCompleted, the base regression behind the original fix).
+    [TestMethod]
+    public void ByReferenceMotionProperty_Snaps_AndReportsCompleted()
+    {
+        var host = new RectangleGeometry();
+        var property = new ByReferenceMotionProperty<object?>
+        {
+            Animation = new Animation(EasingFunctions.Lineal, TimeSpan.FromSeconds(1))
+        };
 
         CoreMotionCanvas.DebugElapsedMilliseconds = 0;
-        animatable.IsValid = true;
-        geometry.Fill = paintA;
-        geometry.CompleteTransition(DrawnGeometry.FillProperty);
-
-        // Assign a new paint while a transition + animation are configured.
-        CoreMotionCanvas.DebugElapsedMilliseconds = 500;
-        animatable.IsValid = true;
-        geometry.Fill = paintB;
+        var target = new object();
+        property.SetMovement(target, host);
 
         try
         {
-            // The reference snaps to the new paint (no blending between instances).
-            Assert.AreSame(paintB, geometry.Fill);
-
-            // Regression: before the base fix the motion stayed IsCompleted == false forever because
-            // GetMovement returns early when it cannot interpolate, never running the completion path.
-            var motion = geometry.GetPropertyDefinition(nameof(DrawnGeometry.Fill))!.GetMotion(geometry);
-            Assert.IsTrue(motion.IsCompleted, "a non-interpolated paint transition must report completion.");
+            CoreMotionCanvas.DebugElapsedMilliseconds = 500;
+            Assert.AreSame(target, property.GetMovement(host), "a by-reference value snaps to the target.");
+            Assert.IsTrue(property.IsCompleted, "a non-interpolated transition must report completion.");
         }
         finally
         {


### PR DESCRIPTION
## Context

Step 3 (final) of decoupling visual states from animation (steps 1–2: #2358, #2359).

A geometry's `Fill`/`Stroke` (`DrawnGeometry`, `BaseVectorGeometry`) and `Paint` (`BaseLabelGeometry`) are **paint references**: they snap, they never interpolate — animation lives *inside* the paint (its `Color`, `StrokeThickness`, …). They were `[MotionProperty]` backed by `ByReferenceMotionProperty` only so a visual state could target them.

## Change

With states decoupled from motion (#2358) and `[StateProperty]` able to register a property without one (#2359), these become plain field-backed properties marked `[StateProperty]`:

- they keep their `PaintStyle` side-effect and stay state-targetable;
- they carry no motion machinery — which also removes the dead `FromValue` reference that pinned the previously-assigned paint after a swap (the lingering-reference issue we hit earlier).

### Effects/filters are deliberately untouched

`PathEffect`/`ImageFilter` are **not** migrated. They genuinely interpolate — their motion property's `OnGetMovement` calls `Transitionate(...)` each frame (that's how an animated dash/blur self-marches). They remain `[MotionProperty]`; `Transitionate` stays exactly as their interpolation evaluator. Only the snap-only paint *references* moved.

`ByReferenceMotionProperty` is kept (public API; the generator's `Paint` mapping is left in place for back-compat), it just no longer backs the OSS geometry paints.

## Tests

- `PaintReferenceMotionTests` updated: a geometry's `Fill` snaps to a new paint and its `PropertyDefinition` now exposes **no** motion (fails if reverted to a motion property). Added direct coverage of `ByReferenceMotionProperty`'s snap + report-completion contract, since it's still public but no longer exercised through `Fill`.
- Full CoreTests **840/840**; snapshots **175/175** (behavior-preserving); generator tests **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)