### PR TITLE
Move native effect/filter ownership to the paint; effects become parameter-only

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/DashEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/DashEffect.cs
@@ -37,31 +37,26 @@ public class DashEffect(float[] dashArray, float phase = 0)
 {
     internal static object s_key = new();
 
-    private float[] DashArray { get; set; } = dashArray;
-    private float Phase { get; set; } = phase;
+    private float[] DashArray { get; } = dashArray;
+    private float Phase { get; } = phase;
 
-    /// <inheritdoc cref="PathEffect.Clone"/>
-    public override PathEffect Clone() => new DashEffect(DashArray, Phase);
-
-    /// <inheritdoc cref="PathEffect.CreateEffect()"/>
-    public override void CreateEffect() =>
-        _sKPathEffect = SKPathEffect.CreateDash(DashArray, Phase);
+    /// <inheritdoc cref="PathEffect.CreateNative()"/>
+    public override SKPathEffect CreateNative() => SKPathEffect.CreateDash(DashArray, Phase);
 
     /// <inheritdoc cref="PathEffect.Transitionate(float, PathEffect)"/>
     public override PathEffect? Transitionate(float progress, PathEffect? target)
     {
         if (target is not DashEffect dashEffect) return target;
 
-        var clone = (DashEffect)Clone();
-
         if (DashArray.Length != dashEffect.DashArray.Length)
             throw new Exception("The dash arrays must have the same length");
 
-        for (var i = 0; i < DashArray.Length; i++)
-            clone.DashArray[i] = DashArray[i] + (dashEffect.DashArray[i] - DashArray[i]) * progress;
+        var dashArray = new float[DashArray.Length];
+        for (var i = 0; i < dashArray.Length; i++)
+            dashArray[i] = DashArray[i] + (dashEffect.DashArray[i] - DashArray[i]) * progress;
 
-        clone.Phase = Phase + (dashEffect.Phase - Phase) * progress;
+        var phase = Phase + (dashEffect.Phase - Phase) * progress;
 
-        return clone;
+        return new DashEffect(dashArray, phase);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/Effects/PathEffect.cs
@@ -35,35 +35,21 @@ public abstract class PathEffect(object key)
     {
         { DashEffect.s_key, new DashEffect([1, 0], 0) }
     };
-    /// <summary>
-    /// The native Skia path effect produced by <see cref="CreateEffect"/>.
-    /// </summary>
-    /// <remarks>
-    /// This field is <see langword="protected"/> <see langword="internal"/> so the owning
-    /// <see cref="SkiaPaint"/> can read it in this assembly, while a <see cref="PathEffect"/>
-    /// subclass in another assembly can set it from its <see cref="CreateEffect"/> override.
-    /// </remarks>
-    protected internal SKPathEffect? _sKPathEffect;
 
     /// <summary>
-    /// Creates a new object that is a copy of the current instance.
+    /// Builds the native Skia path effect from this effect's parameters. The returned object is owned
+    /// by the caller (the <see cref="SkiaPaint"/>), which caches and disposes it — the effect itself
+    /// holds no native resource, so it is a lightweight, shareable value.
     /// </summary>
-    /// <returns>
-    /// A new object that is a copy of this instance.
-    /// </returns>
-    public abstract PathEffect Clone();
+    /// <returns>A new native path effect.</returns>
+    public abstract SKPathEffect CreateNative();
 
     /// <summary>
-    /// Creates the path effect.
-    /// </summary>
-    public abstract void CreateEffect();
-
-    /// <summary>
-    /// Transitions the path effect to a new one.
+    /// Returns the effect interpolated toward <paramref name="target"/> at the given progress.
     /// </summary>
     /// <param name="progress">The progress.</param>
     /// <param name="target">The end target.</param>
-    /// <returns></returns>
+    /// <returns>A new interpolated effect.</returns>
     public abstract PathEffect? Transitionate(float progress, PathEffect? target);
 
     /// <summary>
@@ -87,11 +73,5 @@ public abstract class PathEffect(object key)
         to ??= s_defaultEffects.TryGetValue(key, out var dTo) ? dTo : from;
 
         return from!.Transitionate(progress, to);
-    }
-
-    internal virtual void Dispose()
-    {
-        _sKPathEffect?.Dispose();
-        _sKPathEffect = null;
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/Blur.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/Blur.cs
@@ -40,26 +40,19 @@ public class Blur(
 {
     internal static object s_key = new();
 
-    private float SigmaX { get; set; } = sigmaX;
-    private float SigmaY { get; set; } = sigmaY;
+    private float SigmaX { get; } = sigmaX;
+    private float SigmaY { get; } = sigmaY;
 
-    /// <inheritdoc cref="ImageFilter.Clone"/>
-    public override ImageFilter Clone() => new Blur(SigmaX, SigmaY);
-
-    /// <inheritdoc cref="ImageFilter.CreateFilter()"/>
-    public override void CreateFilter() =>
-        _sKImageFilter = SKImageFilter.CreateBlur(SigmaX, SigmaY);
+    /// <inheritdoc cref="ImageFilter.CreateNative()"/>
+    public override SKImageFilter CreateNative() => SKImageFilter.CreateBlur(SigmaX, SigmaY);
 
     /// <inheritdoc cref="ImageFilter.Transitionate(float, ImageFilter)"/>
     protected override ImageFilter Transitionate(float progress, ImageFilter target)
     {
         var blur = (Blur)target;
 
-        var clone = (Blur)Clone();
-
-        clone.SigmaX = SigmaX + (blur.SigmaX - SigmaX) * progress;
-        clone.SigmaY = SigmaY + (blur.SigmaY - SigmaY) * progress;
-
-        return clone;
+        return new Blur(
+            SigmaX + (blur.SigmaX - SigmaX) * progress,
+            SigmaY + (blur.SigmaY - SigmaY) * progress);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/DropShadow.cs
@@ -47,37 +47,30 @@ public class DropShadow(
     internal static object s_key = new();
 
     // internal so the drawing context can floor a per-element shadow at the paint's own shadow.
-    internal float Dx { get; set; } = dx;
-    internal float Dy { get; set; } = dy;
-    internal float SigmaX { get; set; } = sigmaX;
-    internal float SigmaY { get; set; } = sigmaY;
-    internal SKColor Color { get; set; } = color;
+    internal float Dx { get; } = dx;
+    internal float Dy { get; } = dy;
+    internal float SigmaX { get; } = sigmaX;
+    internal float SigmaY { get; } = sigmaY;
+    internal SKColor Color { get; } = color;
 
-    /// <inheritdoc cref="ImageFilter.Clone"/>
-    public override ImageFilter Clone() =>
-        new DropShadow(Dx, Dy, SigmaX, SigmaY, Color);
-
-    /// <inheritdoc cref="ImageFilter.CreateFilter()"/>
-    public override void CreateFilter() =>
-        _sKImageFilter = SKImageFilter.CreateDropShadow(Dx, Dy, SigmaX, SigmaY, Color);
+    /// <inheritdoc cref="ImageFilter.CreateNative()"/>
+    public override SKImageFilter CreateNative() =>
+        SKImageFilter.CreateDropShadow(Dx, Dy, SigmaX, SigmaY, Color);
 
     /// <inheritdoc cref="ImageFilter.Transitionate(float, ImageFilter)"/>
     protected override ImageFilter Transitionate(float progress, ImageFilter target)
     {
         var dropShadow = (DropShadow)target;
 
-        var clone = (DropShadow)Clone();
-
-        clone.Dx = Dx + (dropShadow.Dx - Dx) * progress;
-        clone.Dy = Dy + (dropShadow.Dy - Dy) * progress;
-        clone.SigmaX = SigmaX + (dropShadow.SigmaX - SigmaX) * progress;
-        clone.SigmaY = SigmaY + (dropShadow.SigmaY - SigmaY) * progress;
-        clone.Color = new SKColor(
-            (byte)(Color.Red + (dropShadow.Color.Red - Color.Red) * progress),
-            (byte)(Color.Green + (dropShadow.Color.Green - Color.Green) * progress),
-            (byte)(Color.Blue + (dropShadow.Color.Blue - Color.Blue) * progress),
-            (byte)(Color.Alpha + (dropShadow.Color.Alpha - Color.Alpha) * progress));
-
-        return clone;
+        return new DropShadow(
+            Dx + (dropShadow.Dx - Dx) * progress,
+            Dy + (dropShadow.Dy - Dy) * progress,
+            SigmaX + (dropShadow.SigmaX - SigmaX) * progress,
+            SigmaY + (dropShadow.SigmaY - SigmaY) * progress,
+            new SKColor(
+                (byte)(Color.Red + (dropShadow.Color.Red - Color.Red) * progress),
+                (byte)(Color.Green + (dropShadow.Color.Green - Color.Green) * progress),
+                (byte)(Color.Blue + (dropShadow.Color.Blue - Color.Blue) * progress),
+                (byte)(Color.Alpha + (dropShadow.Color.Alpha - Color.Alpha) * progress)));
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFilter.cs
@@ -41,25 +41,12 @@ public abstract class ImageFilter(object key)
         { Blur.s_key, new Blur(0,0) }
     };
     /// <summary>
-    /// The native Skia image filter produced by <see cref="CreateFilter"/>.
+    /// Builds the native Skia image filter from this filter's parameters. The returned object is owned
+    /// by the caller (the <see cref="SkiaPaint"/>), which caches and disposes it — the filter itself
+    /// holds no native resource, so it is a lightweight, shareable value.
     /// </summary>
-    /// <remarks>
-    /// This field is <see langword="protected"/> <see langword="internal"/> so the owning
-    /// <see cref="SkiaPaint"/> can read it in this assembly, while an <see cref="ImageFilter"/>
-    /// subclass in another assembly can set it from its <see cref="CreateFilter"/> override.
-    /// </remarks>
-    protected internal SKImageFilter? _sKImageFilter;
-
-    /// <summary>
-    /// Creates the image filter.
-    /// </summary>
-    public abstract void CreateFilter();
-
-    /// <summary>
-    /// Clones this instance.
-    /// </summary>
-    /// <returns></returns>
-    public abstract ImageFilter Clone();
+    /// <returns>A new native image filter.</returns>
+    public abstract SKImageFilter CreateNative();
 
     /// <summary>
     /// Adds a default filter.
@@ -90,11 +77,5 @@ public abstract class ImageFilter(object key)
         to ??= s_defaultFilters.TryGetValue(key, out var dTo) ? dTo : from;
 
         return from!.Transitionate(progress, to!);
-    }
-
-    internal virtual void Dispose()
-    {
-        _sKImageFilter?.Dispose();
-        _sKImageFilter = null;
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFiltersMergeOperation.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/ImageFilters/ImageFiltersMergeOperation.cs
@@ -37,25 +37,23 @@ public class ImageFiltersMergeOperation(ImageFilter[] imageFilters) : ImageFilte
 {
     internal static object s_key = new();
 
-    private ImageFilter[] Filters { get; set; } = imageFilters;
+    private ImageFilter[] Filters { get; } = imageFilters;
 
-    /// <inheritdoc cref="ImageFilter.Clone"/>
-    public override ImageFilter Clone() => new ImageFiltersMergeOperation(Filters);
-
-    /// <inheritdoc cref="ImageFilter.CreateFilter()"/>
-    public override void CreateFilter()
+    /// <inheritdoc cref="ImageFilter.CreateNative()"/>
+    public override SKImageFilter CreateNative()
     {
-        var imageFilters = new SKImageFilter[Filters.Length];
-        var i = 0;
+        var natives = new SKImageFilter[Filters.Length];
+        for (var i = 0; i < natives.Length; i++)
+            natives[i] = Filters[i].CreateNative();
 
-        foreach (var item in Filters)
-        {
-            item.CreateFilter();
-            if (item._sKImageFilter is null) throw new System.Exception("Image filter is not valid");
-            imageFilters[i++] = item._sKImageFilter;
-        }
+        var merged = SKImageFilter.CreateMerge(natives);
 
-        _sKImageFilter = SKImageFilter.CreateMerge(imageFilters);
+        // CreateMerge takes its own reference to each child, so the transient child handles can be
+        // released here; only the merged filter is returned, and the paint owns and disposes it.
+        foreach (var native in natives)
+            native.Dispose();
+
+        return merged;
     }
 
     /// <inheritdoc cref="ImageFilter.Transitionate(float, ImageFilter)"/>
@@ -66,7 +64,6 @@ public class ImageFiltersMergeOperation(ImageFilter[] imageFilters) : ImageFilte
         if (merge.Filters.Length != Filters.Length)
             throw new System.Exception("The image filters must have the same length");
 
-        var clone = (ImageFiltersMergeOperation)Clone();
         var filters = new ImageFilter[Filters.Length];
 
         var hasNull = false;
@@ -77,16 +74,7 @@ public class ImageFiltersMergeOperation(ImageFilter[] imageFilters) : ImageFilte
             if (transitionated is null) hasNull = true;
         }
 
-        clone.Filters = hasNull
-            ? [.. filters.Where(x => x is not null)]
-            : filters;
-
-        return clone;
-    }
-
-    internal override void Dispose()
-    {
-        foreach (var item in Filters)
-            item.Dispose();
+        return new ImageFiltersMergeOperation(
+            hasNull ? [.. filters.Where(x => x is not null)] : filters);
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/Painting/SkiaPaint.cs
@@ -53,6 +53,14 @@ public abstract partial class SkiaPaint(float strokeThickness = 1f, float stroke
     internal FontBuilderDelegate _fontBuilder = LiveChartsSkiaSharp.DefaultTextSettings.FontBuilder;
     internal SKPaint? _skiaPaint;
 
+    // The paint owns the native effect/filter: it builds one from the current (possibly interpolated)
+    // value, caches it, and rebuilds + disposes it when the source value changes. The PathEffect /
+    // ImageFilter objects themselves hold no native resource — they are lightweight parameter values.
+    private SKPathEffect? _skPathEffect;
+    private PathEffect? _pathEffectSource;
+    private SKImageFilter? _skImageFilter;
+    private ImageFilter? _imageFilterSource;
+
     /// <summary>
     /// Gets or sets the font family.
     /// </summary>
@@ -193,32 +201,39 @@ public abstract partial class SkiaPaint(float strokeThickness = 1f, float stroke
         paint.StrokeMiter = StrokeMiter;
         paint.StrokeWidth = StrokeThickness;
 
-        // Read the effect ONCE: when animating, the motion returns a fresh interpolated effect
-        // per call, so re-reading would build a different instance each access.
+        // Read the effect ONCE: when animating, the motion returns a fresh interpolated effect per
+        // call. Rebuild the native only when the source value actually changes (reference identity):
+        // a static effect returns the same instance every frame → reuse the cached native; an
+        // animating effect returns a new instance per frame → rebuild and dispose the previous one.
         var pathEffect = PathEffect;
-        if (pathEffect is not null)
+        if (pathEffect is null)
         {
-            // A fresh animated effect arrives each frame with no native effect yet → build it.
-            // A static effect is built once and cached, exactly as before.
-            if (pathEffect._sKPathEffect is null)
-                pathEffect.CreateEffect();
-
-            paint.PathEffect = pathEffect._sKPathEffect;
+            _skPathEffect?.Dispose();
+            _skPathEffect = null;
+            _pathEffectSource = null;
         }
+        else if (!ReferenceEquals(pathEffect, _pathEffectSource))
+        {
+            _skPathEffect?.Dispose();
+            _skPathEffect = pathEffect.CreateNative();
+            _pathEffectSource = pathEffect;
+        }
+        paint.PathEffect = _skPathEffect;
 
-        // Read once (the motion returns a fresh interpolated filter per call while animating).
         var imageFilter = ImageFilter;
-        if (imageFilter is not null)
+        if (imageFilter is null)
         {
-            if (imageFilter._sKImageFilter is null)
-                imageFilter.CreateFilter();
-
-            paint.ImageFilter = imageFilter._sKImageFilter;
+            _skImageFilter?.Dispose();
+            _skImageFilter = null;
+            _imageFilterSource = null;
         }
-        else
+        else if (!ReferenceEquals(imageFilter, _imageFilterSource))
         {
-            paint.ImageFilter = null; // filter removed → clear it from the cached/reused SKPaint
+            _skImageFilter?.Dispose();
+            _skImageFilter = imageFilter.CreateNative();
+            _imageFilterSource = imageFilter;
         }
+        paint.ImageFilter = _skImageFilter;
 
         if (drawnElement is not null)
             paint.StrokeWidth = drawnElement.StrokeThickness;
@@ -246,8 +261,15 @@ public abstract partial class SkiaPaint(float strokeThickness = 1f, float stroke
         if (_skiaPaint is not null && !IsGlobalSKTypeface)
             _skiaPaint.Typeface?.Dispose();
 
-        PathEffect?.Dispose();
-        ImageFilter?.Dispose();
+        // the paint owns the native effect/filter it built — release them deterministically. Also
+        // clear the source references so the next UpdateSkiaPaint rebuilds the native instead of
+        // reusing the (now disposed) one when the same effect/filter instance is still assigned.
+        _skPathEffect?.Dispose();
+        _skPathEffect = null;
+        _pathEffectSource = null;
+        _skImageFilter?.Dispose();
+        _skImageFilter = null;
+        _imageFilterSource = null;
 
         _skiaPaint?.Dispose();
         _skiaPaint = null;

--- a/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
+++ b/tests/CoreTests/CoreObjectsTests/AnimatedPaintEffectsTests.cs
@@ -23,14 +23,13 @@ public class AnimatedPaintEffectsTests
     public void ResetClock() => CoreMotionCanvas.DebugElapsedMilliseconds = -1;
 
     // A minimal path effect: Transitionate maps progress straight to a "phase" so the test can read
-    // the interpolated value. No native SKPathEffect needed (we don't draw).
+    // the interpolated value. CreateNative is never exercised here (we don't draw).
     private sealed class TestEffect : PathEffect
     {
         private static readonly object s_key = new();
         public float Phase { get; }
         public TestEffect(float phase) : base(s_key) => Phase = phase;
-        public override PathEffect Clone() => new TestEffect(Phase);
-        public override void CreateEffect() { }
+        public override SKPathEffect CreateNative() => SKPathEffect.CreateDash([1f, 0f], 0);
         public override PathEffect Transitionate(float progress, PathEffect? target) => new TestEffect(progress);
     }
 
@@ -39,8 +38,7 @@ public class AnimatedPaintEffectsTests
         private static readonly object s_key = new();
         public float Radius { get; }
         public TestFilter(float radius) : base(s_key) => Radius = radius;
-        public override ImageFilter Clone() => new TestFilter(Radius);
-        public override void CreateFilter() { }
+        public override SKImageFilter CreateNative() => SKImageFilter.CreateBlur(0, 0);
         protected override ImageFilter Transitionate(float progress, ImageFilter target) => new TestFilter(progress);
     }
 

--- a/tests/CoreTests/OtherTests/ImageFiltersTests.cs
+++ b/tests/CoreTests/OtherTests/ImageFiltersTests.cs
@@ -1,5 +1,7 @@
 using System;
+using LiveChartsCore.Motion;
 using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
 using LiveChartsCore.SkiaSharpView.SKCharts;
@@ -12,75 +14,34 @@ namespace CoreTests.OtherTests;
 public class ImageFiltersTests
 {
     [TestMethod]
-    public void Blur_CreateFilterPopulatesUnderlyingSKImageFilter()
+    public void Blur_CreateNativeBuildsAnSKImageFilter()
     {
         var blur = new Blur(2f, 3f);
 
-        Assert.IsNull(blur._sKImageFilter);
-        blur.CreateFilter();
-        Assert.IsNotNull(blur._sKImageFilter);
-
-        blur.Dispose();
-        Assert.IsNull(blur._sKImageFilter);
+        // the filter holds no native; it builds a fresh one that the caller (the paint) owns.
+        using var native = blur.CreateNative();
+        Assert.IsNotNull(native);
     }
 
     [TestMethod]
-    public void Blur_CloneIsAnIndependentInstanceOfTheSameType()
-    {
-        var blur = new Blur(2f, 3f);
-        var clone = blur.Clone();
-
-        Assert.AreNotSame(blur, clone);
-        Assert.IsInstanceOfType<Blur>(clone);
-    }
-
-    [TestMethod]
-    public void DropShadow_CreateFilterPopulatesUnderlyingSKImageFilter()
+    public void DropShadow_CreateNativeBuildsAnSKImageFilter()
     {
         var dropShadow = new DropShadow(1f, 2f, 3f, 4f, SKColors.Black);
 
-        Assert.IsNull(dropShadow._sKImageFilter);
-        dropShadow.CreateFilter();
-        Assert.IsNotNull(dropShadow._sKImageFilter);
-
-        dropShadow.Dispose();
+        using var native = dropShadow.CreateNative();
+        Assert.IsNotNull(native);
     }
 
     [TestMethod]
-    public void DropShadow_CloneIsAnIndependentInstanceOfTheSameType()
+    public void Merge_CreateNativeBuildsAMergedFilter()
     {
-        var dropShadow = new DropShadow(1f, 2f, 3f, 4f, SKColors.Black);
-        var clone = dropShadow.Clone();
+        var merged = new ImageFiltersMergeOperation(
+            [new Blur(2f, 2f), new DropShadow(1f, 1f, 1f, 1f, SKColors.Black)]);
 
-        Assert.AreNotSame(dropShadow, clone);
-        Assert.IsInstanceOfType<DropShadow>(clone);
-    }
-
-    [TestMethod]
-    public void Merge_CreateFilterCombinesEachChildFilter()
-    {
-        var blur = new Blur(2f, 2f);
-        var shadow = new DropShadow(1f, 1f, 1f, 1f, SKColors.Black);
-        var merged = new ImageFiltersMergeOperation([blur, shadow]);
-
-        merged.CreateFilter();
-
-        Assert.IsNotNull(merged._sKImageFilter);
-        // Children get their own SKImageFilter instances populated in the process.
-        Assert.IsNotNull(blur._sKImageFilter);
-        Assert.IsNotNull(shadow._sKImageFilter);
-
-        merged.Dispose();
-    }
-
-    [TestMethod]
-    public void Merge_CloneIsAnIndependentInstanceOfTheSameType()
-    {
-        var merged = new ImageFiltersMergeOperation([new Blur(1f, 1f), new Blur(2f, 2f)]);
-        var clone = merged.Clone();
-
-        Assert.AreNotSame(merged, clone);
-        Assert.IsInstanceOfType<ImageFiltersMergeOperation>(clone);
+        // builds each child native, merges them, and returns a single owned native (the transient
+        // child handles are released internally — the merge holds its own references).
+        using var native = merged.CreateNative();
+        Assert.IsNotNull(native);
     }
 
     [TestMethod]
@@ -135,6 +96,34 @@ public class ImageFiltersTests
         Assert.IsNotNull(blended);
         Assert.AreNotSame(from, blended);
         Assert.AreNotSame(to, blended);
+    }
+
+    [TestMethod]
+    public void Filter_NativeIsRebuilt_WhenPaintIsReusedAfterDispose()
+    {
+        // The paint owns and caches the native filter keyed on the source instance. After the paint
+        // is disposed (e.g. between renders) the cached native is gone, but the SAME filter instance
+        // is still assigned — the next paint pass must rebuild the native, not reuse the disposed one.
+        // Regression: forgetting to clear the source on dispose made the rebuild be skipped, dropping
+        // the filter entirely on the second render.
+        using var surface = SKSurface.Create(new SKImageInfo(10, 10));
+        var canvas = new CoreMotionCanvas();
+        var context = new SkiaSharpDrawingContext(canvas, surface.Canvas, SKColor.Empty);
+
+        var paint = new SolidColorPaint(SKColors.Red)
+        {
+            ImageFilter = new DropShadow(2f, 2f, 4f, 4f, SKColors.Black)
+        };
+
+        paint.OnPaintStarted(context, null);
+        Assert.IsNotNull(paint._skiaPaint!.ImageFilter, "the native filter must be built on first use.");
+
+        paint.DisposeTask();
+
+        paint.OnPaintStarted(context, null);
+        Assert.IsNotNull(
+            paint._skiaPaint!.ImageFilter,
+            "the native filter must be rebuilt after the paint was disposed, not left null.");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Plan / rationale

Path effects and image filters each used to **build and cache their own native Skia object** (`_sKPathEffect`/`_sKImageFilter`) and dispose it themselves. The smell: during **animation**, `Transitionate` returns a fresh interpolated instance every frame, each builds a **new native**, and the previous one is abandoned to the SkiaSharp finalizer — per-frame native churn with ownership scattered across throwaway instances (`From`/`To` also each held a native).

This moves to a clean, single-owner model:

- **Effects/filters become lightweight, parameter-only values.** `CreateEffect()`/`CreateFilter()` → `CreateNative()` which just *returns* a fresh native (caches nothing). `Clone()`, the native field, and `Dispose()` are removed. `Transitionate` stays as the interpolation evaluator, so subclassed/custom effects keep working (kept as reference types, no struct/boxing).
- **`SkiaPaint` owns the native.** It builds one from the current (possibly interpolated) value, **caches it keyed on the source instance** (reference identity), **reuses** it while the value is unchanged (static effect → built once), **rebuilds + disposes** the previous one when the value changes (animated effect), and disposes it in `DisposeTask`.
- Composite filters (`ImageFiltersMergeOperation`) build child natives, merge, and release the transient child handles — the merge holds its own refs; the paint owns only the returned native (also fixes the old merge that leaked its merged native).

Result: **no per-frame native churn, no finalizer reliance, one deterministic owner.** For a static effect, one native is built and reused exactly as before.

### ⚠️ Breaking API

`PathEffect`/`ImageFilter` public surface changes: `CreateEffect`/`CreateFilter` → `CreateNative` (returns the native), `Clone` removed, the protected native field + `Dispose` removed. Any external custom effect/filter must adapt (build-and-return instead of build-and-cache). *(The private effects package's custom effects will need the same adaptation — tracked separately.)*

## Bug found + fixed along the way

The first snapshot run caught a real one: `DisposeTask` cleared the cached native but not the cached **source** reference, so a paint reused after disposal (e.g. between two renders) with the *same* filter instance skipped the rebuild and assigned a null native — dropping the filter entirely on the next render. Fixed by clearing the source on dispose; pinned by `Filter_NativeIsRebuilt_WhenPaintIsReusedAfterDispose`.

## Tests

- Effect/filter unit tests adapted to the new surface (`Transitionate` tests unchanged); new rebuild-after-dispose regression (fails before the fix).
- Full CoreTests **840/840**; snapshot suite **175/175** (behavior-preserving — dash/blur/drop-shadow/floor all unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)