### PR TITLE
fix: range series auto-fit padding uses the full [low, high] span

### DIFF
--- a/src/LiveChartsCore/CoreRangeColumnSeries.cs
+++ b/src/LiveChartsCore/CoreRangeColumnSeries.cs
@@ -136,6 +136,14 @@ public abstract class CoreRangeColumnSeries<TModel, TVisual, TLabel, TErrorGeome
         b.PrimaryBounds.AppendValue(b.TertiaryBounds);
         b.VisiblePrimaryBounds.AppendValue(b.VisibleTertiaryBounds);
 
+        // base.GetBounds derived the value-axis data padding from the High track alone
+        // (the tick of PrimaryBounds before the Low/tertiary merge above), so the auto-fit
+        // margin reflected only the High sub-range. Recompute it over the full [low, high]
+        // span so the padding uses the same tick the gridlines resolve for that range.
+        var tp = primaryAxis.GetTick(chart.ControlSize, b.VisiblePrimaryBounds).Value * DataPadding.Y;
+        b.PrimaryBounds.PaddingMax = tp;
+        b.PrimaryBounds.PaddingMin = tp;
+
         return sb;
     }
 

--- a/src/LiveChartsCore/CoreRangeLineSeries.cs
+++ b/src/LiveChartsCore/CoreRangeLineSeries.cs
@@ -508,6 +508,14 @@ public abstract class CoreRangeLineSeries<TModel, TVisual, TLabel, TStrokePathGe
         var b = sb.Bounds;
         b.PrimaryBounds.AppendValue(b.TertiaryBounds);
         b.VisiblePrimaryBounds.AppendValue(b.VisibleTertiaryBounds);
+
+        // base.GetBounds derived the value-axis data padding from the High track alone
+        // (the tick of PrimaryBounds before the Low/tertiary merge above), so the auto-fit
+        // margin reflected only the High sub-range. Recompute it over the full [low, high]
+        // span so the padding uses the same tick the gridlines resolve for that range.
+        var tp = primaryAxis.GetTick(chart.ControlSize, b.VisiblePrimaryBounds).Value * DataPadding.Y;
+        b.PrimaryBounds.PaddingMax = tp;
+        b.PrimaryBounds.PaddingMin = tp;
         return sb;
     }
 

--- a/src/LiveChartsCore/CoreRangeRowSeries.cs
+++ b/src/LiveChartsCore/CoreRangeRowSeries.cs
@@ -129,6 +129,14 @@ public abstract class CoreRangeRowSeries<TModel, TVisual, TLabel, TErrorGeometry
         b.SecondaryBounds.AppendValue(b.TertiaryBounds);
         b.VisibleSecondaryBounds.AppendValue(b.VisibleTertiaryBounds);
 
+        // base.GetBounds derived the value-axis data padding from the High track alone
+        // (the tick of SecondaryBounds before the Low/tertiary merge above), so the auto-fit
+        // margin reflected only the High sub-range. Recompute it over the full [low, high]
+        // span so the padding uses the same tick the gridlines resolve for that range.
+        var ts = secondaryAxis.GetTick(chart.ControlSize, b.VisibleSecondaryBounds).Value * DataPadding.X;
+        b.SecondaryBounds.PaddingMax = ts;
+        b.SecondaryBounds.PaddingMin = ts;
+
         return sb;
     }
 

--- a/tests/CoreTests/SeriesTests/RangeSeriesAutoBoundsTests.cs
+++ b/tests/CoreTests/SeriesTests/RangeSeriesAutoBoundsTests.cs
@@ -220,6 +220,57 @@ public class RangeSeriesAutoBoundsTests
             $"value-axis auto-max differs ({lowIsOuter.max} vs {highIsOuter.max}) for the same [0, 99] span.");
     }
 
+    [TestMethod]
+    public void RangeRowSeries_AutoPadding_UsesFullSpanTick()
+    {
+        // Horizontal variant: for RangeRow the value axis is X (secondary), and the same
+        // quirk lived there — base.GetBounds resolved the secondary padding tick from the
+        // High track before the Low endpoint was merged. Two rows with the SAME full [0, 99]
+        // value span but a different High sub-range must resolve the SAME value-axis padding.
+        //
+        // Unlike the vertical variants this asserts at the GetBounds level (the series'
+        // SecondaryBounds padding) rather than the fitted axis: a horizontal auto value axis
+        // re-resolves its own tick from the category (Y) axis, which happens to round both
+        // sub-ranges to the same nice number and would mask the difference the fix targets.
+        var lowIsOuter = RowValuePadding([new(0, 0), new(0, 99)]);   // Low=0 const, High in [0, 99]
+        var highIsOuter = RowValuePadding([new(0, 50), new(49, 99)]); // Low in [0, 49], High in [50, 99]
+
+        Assert.AreEqual(lowIsOuter, highIsOuter, 1e-9,
+            $"value-axis padding differs ({lowIsOuter} vs {highIsOuter}) for the same [0, 99] span; " +
+            "the padding tick must reflect the full span, not the High sub-range.");
+    }
+
+    // Measures a RangeRow series and returns the value-axis (X = secondary) data padding
+    // the series reports — the quantity the full-span-tick fix corrects.
+    private static double RowValuePadding(RangeValue[] values)
+    {
+        var series = new RangeRowSeries<RangeValue> { Values = values };
+        var chart = new SKCartesianChart
+        {
+            Width = 1000,
+            Height = 500,
+            Series = [series],
+            XAxes = [new Axis()],
+            YAxes = [new Axis()],
+        };
+        var core = (CartesianChartEngine)chart.CoreChart;
+        CoreMotionCanvas.DebugElapsedMilliseconds = 0;
+        core.IsLoaded = true;
+        core._isFirstDraw = true;
+        core.Measure();
+        try
+        {
+            // HorizontalBar swaps the axes: the value axis is the primary (X) argument, and
+            // its bounds land in SecondaryBounds — where the padding recompute applies.
+            var sb = series.GetBounds(core, core.YAxes[0], core.XAxes[0]);
+            return sb.Bounds.SecondaryBounds.PaddingMax;
+        }
+        finally
+        {
+            CoreMotionCanvas.DebugElapsedMilliseconds = -1;
+        }
+    }
+
     // Fits a vertical range series and returns the padded value-axis (Y) bounds.
     private static (double min, double max) FitValueBounds(ISeries series)
     {

--- a/tests/CoreTests/SeriesTests/RangeSeriesAutoBoundsTests.cs
+++ b/tests/CoreTests/SeriesTests/RangeSeriesAutoBoundsTests.cs
@@ -176,6 +176,67 @@ public class RangeSeriesAutoBoundsTests
     }
 
     [TestMethod]
+    public void RangeColumnSeries_AutoPadding_UsesFullSpanTick()
+    {
+        // Two series with the SAME full [low, high] span (0..99) but a different High
+        // sub-range must auto-fit the value axis identically — the data padding is a
+        // function of the whole span, not just the High track. Pre-fix the padding tick
+        // came from the High track alone (base.GetBounds runs before Low is merged), so
+        // series B (High in [50, 99]) got a finer tick and a tighter margin than series A
+        // (High in [0, 99]) despite covering the same range.
+        var lowIsOuter = FitValueBounds(new RangeColumnSeries<RangeValue>
+        {
+            Values = [new(0, 0), new(0, 99)],   // Low=0 const, High in [0, 99] → full [0, 99]
+        });
+        var highIsOuter = FitValueBounds(new RangeColumnSeries<RangeValue>
+        {
+            Values = [new(0, 50), new(49, 99)], // Low in [0, 49], High in [50, 99] → full [0, 99]
+        });
+
+        Assert.AreEqual(lowIsOuter.min, highIsOuter.min, 1e-9,
+            $"value-axis auto-min differs ({lowIsOuter.min} vs {highIsOuter.min}) for the same [0, 99] span; " +
+            "the padding tick must reflect the full span, not the High sub-range.");
+        Assert.AreEqual(lowIsOuter.max, highIsOuter.max, 1e-9,
+            $"value-axis auto-max differs ({lowIsOuter.max} vs {highIsOuter.max}) for the same [0, 99] span.");
+    }
+
+    [TestMethod]
+    public void RangeLineSeries_AutoPadding_UsesFullSpanTick()
+    {
+        // Same contract as the column variant — RangeLine folds the Low endpoint into the
+        // value axis the same way, so its padding tick must also reflect the full span.
+        var lowIsOuter = FitValueBounds(new RangeLineSeries<RangeValue>
+        {
+            Values = [new(0, 0), new(0, 99)],
+        });
+        var highIsOuter = FitValueBounds(new RangeLineSeries<RangeValue>
+        {
+            Values = [new(0, 50), new(49, 99)],
+        });
+
+        Assert.AreEqual(lowIsOuter.min, highIsOuter.min, 1e-9,
+            $"value-axis auto-min differs ({lowIsOuter.min} vs {highIsOuter.min}) for the same [0, 99] span.");
+        Assert.AreEqual(lowIsOuter.max, highIsOuter.max, 1e-9,
+            $"value-axis auto-max differs ({lowIsOuter.max} vs {highIsOuter.max}) for the same [0, 99] span.");
+    }
+
+    // Fits a vertical range series and returns the padded value-axis (Y) bounds.
+    private static (double min, double max) FitValueBounds(ISeries series)
+    {
+        var yAxis = new Axis();
+        var chart = new SKCartesianChart
+        {
+            Width = 1000,
+            Height = 500,
+            Series = [series],
+            XAxes = [new Axis()],
+            YAxes = [yAxis],
+        };
+        using var _ = chart.GetImage();
+        return (yAxis.VisibleDataBounds.Min, yAxis.VisibleDataBounds.Max);
+    }
+
+    [TestMethod]
     public void RangeRowSeries_DateTimeAxis_AutoMinReachesEarliestStart()
     {
         // The actual Gantt repro: project starts Jun 1, first task spans


### PR DESCRIPTION
## Problem

The range series (`RangeColumnSeries`, `RangeLineSeries`, `RangeRowSeries`) seed the value-axis bounds from `PrimaryValue` (High) alone in `base.GetBounds`, then merge the Low endpoint (`TertiaryBounds`) so the auto axis covers the whole band:

```csharp
var sb = base.GetBounds(chart, secondaryAxis, primaryAxis);
...
b.PrimaryBounds.AppendValue(b.TertiaryBounds);           // extend to full [low, high]
b.VisiblePrimaryBounds.AppendValue(b.VisibleTertiaryBounds);
```

But `base.GetBounds` resolves the data-padding tick (`tick × DataPadding`) from the **High track alone**, *before* the Low endpoint is merged in. So the auto-fit margin reflects only the High sub-range — not the full band. Two series covering the **same** `[low, high]` span get **different** padding depending on how the span splits between the Low and High tracks. It is also inconsistent with every non-range series, which resolve the padding from their full value extent.

### Example

Both series below cover the identical value span `[0, 99]`:

| Series | Low track | High track | Padding tick (before) |
|---|---|---|---|
| A | `0` | `[0, 99]` | tick of `[0, 99]` |
| B | `[0, 49]` | `[50, 99]` | tick of `[50, 99]` ← wrong |

Series B ends up with a tighter auto-fit margin than A despite covering the same range.

## Fix

Recompute the value-axis padding over the merged full span, so the padding uses the same tick the gridlines resolve for that range. Applied symmetrically to the vertical variants (primary axis) and the horizontal variant (secondary axis).

## Notes

- Only the **auto-fit** path is affected — charts with an explicit `MinLimit`/`MaxLimit` are unchanged (padding is not consulted there), so no snapshot output changes.
- The existing `RangeSeriesAutoBoundsTests` (which pin the "Low endpoint is not clipped" contract) still pass — the change only widens the margin, never narrows the covered range.

## Tests

- New `RangeColumnSeries_AutoPadding_UsesFullSpanTick` / `RangeLineSeries_AutoPadding_UsesFullSpanTick`: two series with the same full span but a different High sub-range must auto-fit the value axis identically. Verified by revert (both fail without the fix).
- Full `CoreTests` suite (842) green; `RangeSeriesTests` snapshots (5) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)