### PR TITLE
refactor(axis): give the scaler provider the chart it is scaling for

### DIFF
--- a/src/LiveChartsCore/CartesianChartEngine.cs
+++ b/src/LiveChartsCore/CartesianChartEngine.cs
@@ -134,8 +134,8 @@ public class CartesianChartEngine(
         var xAxis = XAxes[xAxisIndex];
         var yAxis = YAxes[yAxisIndex];
 
-        var xScaler = xAxis.GetScaler(DrawMarginLocation, DrawMarginSize);
-        var yScaler = yAxis.GetScaler(DrawMarginLocation, DrawMarginSize);
+        var xScaler = xAxis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
+        var yScaler = yAxis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
         return [xScaler.ToChartValues(point.X), yScaler.ToChartValues(point.Y)];
     }
@@ -768,7 +768,7 @@ public class CartesianChartEngine(
             // apply padding
             if (axis.MinLimit is null)
             {
-                var s = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+                var s = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
                 // correction by geometry size
                 var p = Math.Abs(s.ToChartValues(axis.DataBounds.RequestedGeometrySize) - s.ToChartValues(0));
                 if (axis.DataBounds.PaddingMin > p) p = axis.DataBounds.PaddingMin;
@@ -791,7 +791,7 @@ public class CartesianChartEngine(
             // apply padding
             if (axis.MaxLimit is null)
             {
-                var s = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+                var s = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
                 // correction by geometry size
                 var p = Math.Abs(s.ToChartValues(axis.DataBounds.RequestedGeometrySize) - s.ToChartValues(0));
                 if (axis.DataBounds.PaddingMax > p) p = axis.DataBounds.PaddingMax;
@@ -874,8 +874,8 @@ public class CartesianChartEngine(
     /// <inheritdoc cref="ICartesianChartView.ScalePixelsToData(LvcPointD, int, int)"/>
     public LvcPointD ScalePixelsToData(LvcPointD point, int xAxisIndex = 0, int yAxisIndex = 0)
     {
-        var xScaler = XAxes[xAxisIndex].GetScaler(DrawMarginLocation, DrawMarginSize);
-        var yScaler = YAxes[yAxisIndex].GetScaler(DrawMarginLocation, DrawMarginSize);
+        var xScaler = XAxes[xAxisIndex].GetScaler(this, DrawMarginLocation, DrawMarginSize);
+        var yScaler = YAxes[yAxisIndex].GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
         return new LvcPointD { X = xScaler.ToChartValues(point.X), Y = yScaler.ToChartValues(point.Y) };
     }
@@ -883,8 +883,8 @@ public class CartesianChartEngine(
     /// <inheritdoc cref="ICartesianChartView.ScaleDataToPixels(LvcPointD, int, int)"/>
     public LvcPointD ScaleDataToPixels(LvcPointD point, int xAxisIndex = 0, int yAxisIndex = 0)
     {
-        var xScaler = XAxes[xAxisIndex].GetScaler(DrawMarginLocation, DrawMarginSize);
-        var yScaler = YAxes[yAxisIndex].GetScaler(DrawMarginLocation, DrawMarginSize);
+        var xScaler = XAxes[xAxisIndex].GetScaler(this, DrawMarginLocation, DrawMarginSize);
+        var yScaler = YAxes[yAxisIndex].GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
         return new LvcPointD { X = xScaler.ToPixels(point.X), Y = yScaler.ToPixels(point.Y) };
     }
@@ -1044,7 +1044,7 @@ public class CartesianChartEngine(
 
         void Fit(ICartesianAxis axis)
         {
-            var scale = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+            var scale = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
             var geometryOffset = GetGeometryOffset(axis, scale);
 
@@ -1090,7 +1090,7 @@ public class CartesianChartEngine(
         var speed = _zoomingSpeed < 0.1 ? 0.1 : (_zoomingSpeed > 0.95 ? 0.95 : _zoomingSpeed);
         speed = 1 - speed;
         var m = direction == ZoomDirection.ZoomIn ? speed : 1 / speed;
-        var scale = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+        var scale = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
         var limits = axis.GetLimits();
 
@@ -1190,7 +1190,7 @@ public class CartesianChartEngine(
     {
         if (_sectionZoomingStart is null) return;
 
-        var scaler = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+        var scaler = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
 
         var value = axis.Orientation == AxisOrientation.X
             ? _sectionZoomingStart.Value.X
@@ -1236,7 +1236,7 @@ public class CartesianChartEngine(
 
     private void PanAxis(ICartesianAxis axis, ZoomAndPanMode flags, float delta, bool thresholded)
     {
-        var scale = axis.GetScaler(DrawMarginLocation, DrawMarginSize);
+        var scale = axis.GetScaler(this, DrawMarginLocation, DrawMarginSize);
         var fits = !flags.HasFlag(ZoomAndPanMode.NoFit);
 
         var deltapixels = scale.ToChartValues(0) - scale.ToChartValues(delta);

--- a/src/LiveChartsCore/CartesianSeries.cs
+++ b/src/LiveChartsCore/CartesianSeries.cs
@@ -249,10 +249,10 @@ public abstract class CartesianSeries<TModel, TVisual, TLabel>(
 
         var secondaryScale = secondaryAxis is null
             ? new Scaler()
-            : secondaryAxis.GetScaler(core.DrawMarginLocation, core.DrawMarginSize);
+            : secondaryAxis.GetScaler(core, core.DrawMarginLocation, core.DrawMarginSize);
         var primaryScale = primaryAxis is null
             ? new Scaler()
-            : primaryAxis.GetScaler(core.DrawMarginLocation, core.DrawMarginSize);
+            : primaryAxis.GetScaler(core, core.DrawMarginLocation, core.DrawMarginSize);
 
         var deleted = new List<ChartPoint>();
         foreach (var point in everFetched)

--- a/src/LiveChartsCore/CoreAxis.cs
+++ b/src/LiveChartsCore/CoreAxis.cs
@@ -1139,12 +1139,12 @@ public abstract class CoreAxis<TTextGeometry, TLineGeometry>
     /// <inheritdoc cref="ICartesianAxis.ScalerProvider"/>
     public IScalerProvider? ScalerProvider { get; set => SetProperty(ref field, value); }
 
-    /// <inheritdoc cref="ICartesianAxis.GetScaler(LvcPoint, LvcSize, Bounds?)"/>
-    public virtual Scaler GetScaler(LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds = null) =>
+    /// <inheritdoc cref="ICartesianAxis.GetScaler(Chart, LvcPoint, LvcSize, Bounds?)"/>
+    public virtual Scaler GetScaler(Chart chart, LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds = null) =>
         // an explicit ScalerProvider wins; otherwise a Renderer that also knows how to scale
         // (implements IScalerProvider) supplies the coordinate strategy; otherwise the default linear scaler.
         (ScalerProvider ?? Renderer as IScalerProvider) is { } provider
-            ? provider.GetScaler(this, drawMarginLocation, drawMarginSize, bounds)
+            ? provider.GetScaler(this, chart, drawMarginLocation, drawMarginSize, bounds)
             : new(drawMarginLocation, drawMarginSize, this, bounds);
 
     /// <summary>

--- a/src/LiveChartsCore/CoreScatterSeries.cs
+++ b/src/LiveChartsCore/CoreScatterSeries.cs
@@ -132,8 +132,8 @@ public abstract class CoreScatterSeries<TModel, TVisual, TLabel, TErrorGeometry>
 
         var drawLocation = chart.DrawMarginLocation;
         var drawMarginSize = chart.DrawMarginSize;
-        var xScale = secondaryAxis.GetScaler(drawLocation, drawMarginSize);
-        var yScale = primaryAxis.GetScaler(drawLocation, drawMarginSize);
+        var xScale = secondaryAxis.GetScaler(chart, drawLocation, drawMarginSize);
+        var yScale = primaryAxis.GetScaler(chart, drawLocation, drawMarginSize);
 
         var weightStackIndex = StackGroup ?? ((ISeries)this).SeriesId;
         var weightBounds = chart.SeriesContext.GetWeightBounds(weightStackIndex);

--- a/src/LiveChartsCore/CoreSection.cs
+++ b/src/LiveChartsCore/CoreSection.cs
@@ -207,8 +207,8 @@ public abstract class CoreSection<TSizedGeometry, TLabelGeometry> : CoreSection
         var primaryAxis = cartesianChart.GetYAxis(ScalesYAt);
         var secondaryAxis = cartesianChart.GetXAxis(ScalesXAt);
 
-        var secondaryScale = secondaryAxis.GetScaler(drawLocation, drawMarginSize);
-        var primaryScale = primaryAxis.GetScaler(drawLocation, drawMarginSize);
+        var secondaryScale = secondaryAxis.GetScaler(chart, drawLocation, drawMarginSize);
+        var primaryScale = primaryAxis.GetScaler(chart, drawLocation, drawMarginSize);
 
         var xi = Xi is null ? drawLocation.X : secondaryScale.ToPixels(Xi.Value);
         var xj = Xj is null ? drawLocation.X + drawMarginSize.Width : secondaryScale.ToPixels(Xj.Value);

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -542,7 +542,7 @@ public static class Extensions
     /// <param name="chart"></param>
     /// <returns></returns>
     public static Scaler GetNextScaler(this ICartesianAxis axis, CartesianChartEngine chart) =>
-        axis.GetScaler(chart.DrawMarginLocation, chart.DrawMarginSize);
+        axis.GetScaler(chart, chart.DrawMarginLocation, chart.DrawMarginSize);
 
     /// <summary>
     /// Gets a scaler that is built based on the dimensions of the chart at a given time, the scaler is built based on the
@@ -560,6 +560,7 @@ public static class Extensions
         // if necessary, implement motion properties to track the DrawMarginLocation and DrawMarginSize.
 
         return axis.GetScaler(
+            chart,
             chart.DrawMarginLocation,
             chart.DrawMarginSize,
             new Bounds

--- a/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/ICartesianAxis.cs
@@ -256,11 +256,12 @@ public interface ICartesianAxis : IPlane, INotifyPropertyChanged
     /// derived axis to provide a custom (for example, non-linear) coordinate mapping; every scaler the
     /// engine builds for this axis — target, animated, zoom/pan and section scalers — flows through here.
     /// </summary>
+    /// <param name="chart">The chart the scaler is built for; an axis can be shared by several charts.</param>
     /// <param name="drawMarginLocation">The draw margin location.</param>
     /// <param name="drawMarginSize">The draw margin size.</param>
     /// <param name="bounds">Optional bounds to scale against; when null the axis' own limits are used.</param>
     /// <returns>The scaler.</returns>
-    Scaler GetScaler(LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds = null);
+    Scaler GetScaler(Chart chart, LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds = null);
 
     /// <summary>
     /// Gets or sets a renderer that fully owns this axis' measure and draw. When null (the default)

--- a/src/LiveChartsCore/Kernel/Sketches/IScalerProvider.cs
+++ b/src/LiveChartsCore/Kernel/Sketches/IScalerProvider.cs
@@ -37,8 +37,10 @@ public interface IScalerProvider
     /// Builds a scaler for <paramref name="axis"/>.
     /// </summary>
     /// <param name="axis">The axis to scale.</param>
+    /// <param name="chart">The chart the axis belongs to. An axis can be shared by several charts, so the
+    /// scaler is built per chart and a provider that keeps per-chart state must key it on this.</param>
     /// <param name="drawMarginLocation">The draw margin location.</param>
     /// <param name="drawMarginSize">The draw margin size.</param>
     /// <param name="bounds">Optional bounds to scale against; when null the axis' own limits are used.</param>
-    Scaler GetScaler(ICartesianAxis axis, LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds);
+    Scaler GetScaler(ICartesianAxis axis, Chart chart, LvcPoint drawMarginLocation, LvcSize drawMarginSize, Bounds? bounds);
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/LiveChartsSkiaSharp.cs
@@ -196,8 +196,8 @@ public static class LiveChartsSkiaSharp
 
                 var drawLocation = cartesianChart.Core.DrawMarginLocation;
                 var drawMarginSize = cartesianChart.Core.DrawMarginSize;
-                var secondaryScale = primaryAxis.GetScaler(drawLocation, drawMarginSize);
-                var primaryScale = secondaryAxis.GetScaler(drawLocation, drawMarginSize);
+                var secondaryScale = primaryAxis.GetScaler(cartesianChart.Core, drawLocation, drawMarginSize);
+                var primaryScale = secondaryAxis.GetScaler(cartesianChart.Core, drawLocation, drawMarginSize);
 
                 var coordinate = target.Coordinate;
 
@@ -212,8 +212,8 @@ public static class LiveChartsSkiaSharp
                 var drawLocation = cartesianChart.Core.DrawMarginLocation;
                 var drawMarginSize = cartesianChart.Core.DrawMarginSize;
 
-                var secondaryScale = secondaryAxis.GetScaler(drawLocation, drawMarginSize);
-                var primaryScale = primaryAxis.GetScaler(drawLocation, drawMarginSize);
+                var secondaryScale = secondaryAxis.GetScaler(cartesianChart.Core, drawLocation, drawMarginSize);
+                var primaryScale = primaryAxis.GetScaler(cartesianChart.Core, drawLocation, drawMarginSize);
 
                 var coordinate = target.Coordinate;
 

--- a/tests/CoreTests/ChartTests/AxisRendererTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRendererTests.cs
@@ -176,11 +176,13 @@ public class AxisRendererTests
     {
         public int Calls;
         public Bounds? LastBounds;
+        public Chart? LastChart;
 
         public Scaler GetScaler(ICartesianAxis axis, Chart chart, LvcPoint location, LvcSize size, Bounds? bounds)
         {
             Calls++;
             LastBounds = bounds;
+            LastChart = chart;
             // deliberately squash the plot to half its size so the mapping is provably different from the
             // default scaler — if a call site ignored us and used `new Scaler(...)`, the pixel a data value
             // maps to would not match this provider's own scaler.
@@ -238,6 +240,30 @@ public class AxisRendererTests
         _ = xAxis.GetScaler(engine, new LvcPoint(0, 0), new LvcSize(100, 100), bounds);
 
         Assert.AreSame(bounds, provider.LastBounds, "the optional Bounds argument must be forwarded to the provider untouched");
+    }
+
+    // An axis can be shared across charts, so the provider is told which chart it is scaling for. A provider
+    // that keys per-chart state on it, or that needs the chart to reach the canvas, depends on this being the
+    // measuring chart and not, say, the axis' first chart.
+    [TestMethod]
+    public void Custom_scaler_provider_receives_the_measuring_chart()
+    {
+        var provider = new SpyScalerProvider();
+
+        var chart = new SKCartesianChart
+        {
+            Width = 400,
+            Height = 300,
+            Series = [new LineSeries<double> { Values = [1, 2, 3] }],
+            XAxes = [new Axis { ScalerProvider = provider }],
+            YAxes = [new Axis()],
+        };
+
+        _ = chart.GetImage();
+
+        Assert.AreSame(
+            chart.CoreChart, provider.LastChart,
+            "the chart that measured the axis must be the chart handed to the scaler provider");
     }
 
     // A non-linear (here: logarithmic) X scaler: ToPixels is affine in a WINDOW-INDEPENDENT transform

--- a/tests/CoreTests/ChartTests/AxisRendererTests.cs
+++ b/tests/CoreTests/ChartTests/AxisRendererTests.cs
@@ -177,7 +177,7 @@ public class AxisRendererTests
         public int Calls;
         public Bounds? LastBounds;
 
-        public Scaler GetScaler(ICartesianAxis axis, LvcPoint location, LvcSize size, Bounds? bounds)
+        public Scaler GetScaler(ICartesianAxis axis, Chart chart, LvcPoint location, LvcSize size, Bounds? bounds)
         {
             Calls++;
             LastBounds = bounds;
@@ -211,7 +211,7 @@ public class AxisRendererTests
         var engine = (CartesianChartEngine)chart.CoreChart;
 
         // the public data<->pixel path must map through the provider's scaler, not a default `new Scaler(...)`.
-        var expected = provider.GetScaler(xAxis, engine.DrawMarginLocation, engine.DrawMarginSize, null).ToPixels(2d);
+        var expected = provider.GetScaler(xAxis, engine, engine.DrawMarginLocation, engine.DrawMarginSize, null).ToPixels(2d);
         var actual = engine.ScaleDataToPixels(new LvcPointD(2d, 0d)).X;
         Assert.AreEqual(expected, actual, 1e-4, "ScaleDataToPixels must map through the custom provider");
     }
@@ -233,8 +233,9 @@ public class AxisRendererTests
 
         _ = chart.GetImage(); // establishes the axis orientation so a scaler can be built
 
+        var engine = (CartesianChartEngine)chart.CoreChart;
         var bounds = new Bounds();
-        _ = xAxis.GetScaler(new LvcPoint(0, 0), new LvcSize(100, 100), bounds);
+        _ = xAxis.GetScaler(engine, new LvcPoint(0, 0), new LvcSize(100, 100), bounds);
 
         Assert.AreSame(bounds, provider.LastBounds, "the optional Bounds argument must be forwarded to the provider untouched");
     }
@@ -268,7 +269,7 @@ public class AxisRendererTests
 
     private sealed class LogScalerProvider : IScalerProvider
     {
-        public Scaler GetScaler(ICartesianAxis axis, LvcPoint location, LvcSize size, Bounds? bounds) =>
+        public Scaler GetScaler(ICartesianAxis axis, Chart chart, LvcPoint location, LvcSize size, Bounds? bounds) =>
             new LogScaler(location, size, axis, bounds);
     }
 
@@ -287,7 +288,7 @@ public class AxisRendererTests
         };
         _ = chart.GetImage();
 
-        Assert.IsTrue(((ICartesianAxis)axis).GetScaler(new LvcPoint(0, 0), new LvcSize(100, 100)).IsLinear);
+        Assert.IsTrue(((ICartesianAxis)axis).GetScaler(chart.CoreChart, new LvcPoint(0, 0), new LvcSize(100, 100)).IsLinear);
     }
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to #2369, which introduced `IAxisRenderer` and `IScalerProvider` as the two halves of the pluggable-axis seam.

The two are meant to be symmetric — one owns the axis' drawing, the other its coordinate mapping — but only one of them gets the chart:

```csharp
LvcSize Measure(ICartesianAxis axis, Chart chart);   // IAxisRenderer
void    Draw   (ICartesianAxis axis, Chart chart);   // IAxisRenderer

Scaler  GetScaler(ICartesianAxis axis, LvcPoint loc, LvcSize size, Bounds? bounds);  // IScalerProvider — no chart
```

A scaler provider therefore had no way to reach chart-level state. And it cannot simply read the chart off the axis: an axis can be shared by several charts (`SharedWith`), so "the chart" is not a property of the axis — it has to arrive with the call.

## What changed

`Chart` is threaded through `ICartesianAxis.GetScaler` into `IScalerProvider.GetScaler`. Every call site already had the chart in scope, so the change is mechanical.

Both signatures are new in #2369 and appear in **no released version** — `ICartesianAxis.GetScaler` has zero occurrences in the `2.0.0` tag — so this widens the seam before anyone can depend on it.

## Verification

- `CoreTests` 828/828 (827 existing + 1 new)
- `SnapshotTests` 170/170, no pixel change — this is a signature change, the scaler resolution is untouched
- Core, SkiaSharpView, Avalonia and WPF all build clean

The new test asserts the chart handed to the provider is the chart that measured the axis. It is revert-verified: forwarding `null!` from `CoreAxis.GetScaler` fails that test and only that test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)