### PR TITLE
fix: the chart title follows the theme

### DIFF
--- a/docs/geomapchart/overview.md
+++ b/docs/geomapchart/overview.md
@@ -250,15 +250,18 @@ a look at the [Paints article]({{ website_url }}/docs/{{ platform }}/{{ version 
 
 A `Title` is a `VisualElement` rendered above the map. The same
 `DrawnLabelVisual` used by cartesian and pie charts works here — set
-`Text`, `TextSize`, `Padding`, and the `Paint` that draws it. The map
-shrinks vertically to make room for the title.
+`Text`, `TextSize` and `Padding`. The map shrinks vertically to make
+room for the title.
+
+The theme paints the title, so it follows the light and dark modes on
+its own. Set the `Paint` property to pick the color yourself; a paint
+you set is never overwritten by the theme.
 
 {{~ if xaml ~}}
 <pre><code>&lt;lvc:GeoMap Series="{Binding Series}"&gt;
     &lt;lvc:GeoMap.Title&gt;&lt;!-- mark -->
         &lt;lvc:XamlDrawnLabelVisual
             Text="World population by country"
-            Paint="{lvc:SolidColorPaint Color='#303030'}"
             TextSize="20"
             Padding="{lvc:Padding '12'}"/&gt;
     &lt;/lvc:GeoMap.Title&gt;
@@ -274,8 +277,7 @@ shrinks vertically to make room for the title.
         {
             Text = "World population by country",
             TextSize = 20,
-            Padding = new Padding(12),
-            Paint = new SolidColorPaint(SKColors.Black)
+            Padding = new Padding(12)
         });
 }</code></pre>
 {{~ end ~}}
@@ -286,8 +288,7 @@ shrinks vertically to make room for the title.
     {
         Text = "World population by country",
         TextSize = 20,
-        Padding = new Padding(12),
-        Paint = new SolidColorPaint(SKColors.Black)
+        Padding = new Padding(12)
     });</code></pre>
 {{~ end ~}}
 

--- a/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
+++ b/generators/LiveChartsGenerators/XamlFriendlyObjectsGenerator.cs
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using LiveChartsGenerators.Definitions;
 using LiveChartsGenerators.Frameworks;
@@ -249,6 +251,16 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
         if (alsoMap is not null && alsoMapPath is not null)
             members[alsoMapPath] = GetLiveChartsMembers(alsoMap);
 
+        // The wrapped type wins over a mapped member of the same name. Both are hosted as
+        // bindable properties named after the member (the map path is not a prefix), so a
+        // wrapper property that shadows a mapped one would emit the same name twice and not
+        // compile. Shadowing is deliberate: it lets the wrapped type host a property that
+        // forwards to the mapped object while adding behavior the mapped object can not
+        // (e.g. DrawnLabelVisual.Paint forwards to LabelGeometry.Paint but records the write
+        // so a theme can tell a user-set paint from an unset one).
+        var wrappedTypeMembers = new HashSet<string>(
+            members[string.Empty].OfType<IPropertySymbol>().Select(static x => x.Name));
+
         foreach (var pair in members)
         {
             var bindableProperties = new List<IPropertySymbol>();
@@ -259,6 +271,9 @@ public class XamlFriendlyObjectsGenerator : IIncrementalGenerator
                 if (member is IPropertySymbol property)
                 {
                     if (property.DeclaredAccessibility == Accessibility.Protected || property.IsStatic)
+                        continue;
+
+                    if (pair.Key != string.Empty && wrappedTypeMembers.Contains(property.Name))
                         continue;
 
                     var notExplicit = property.ExplicitInterfaceImplementations.Length == 0;

--- a/samples/AvaloniaSample/Lines/Basic/View.axaml
+++ b/samples/AvaloniaSample/Lines/Basic/View.axaml
@@ -15,7 +15,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="25"
                 Padding="{lvc:Padding '15'}"/>
         </lvc:CartesianChart.Title>

--- a/samples/AvaloniaSample/Maps/World/View.axaml
+++ b/samples/AvaloniaSample/Maps/World/View.axaml
@@ -19,7 +19,6 @@
         <lvc:GeoMap.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="World population by country"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="20"
                 Padding="{lvc:Padding '12'}"/>
         </lvc:GeoMap.Title>

--- a/samples/AvaloniaSample/Pies/Basic/View.axaml
+++ b/samples/AvaloniaSample/Pies/Basic/View.axaml
@@ -21,7 +21,6 @@
         <lvc:PieChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#000'}"
                 TextSize="25"
                 Padding="{lvc:Padding '15'}"/>
         </lvc:PieChart.Title>

--- a/samples/AvaloniaSample/Polar/Basic/View.axaml
+++ b/samples/AvaloniaSample/Polar/Basic/View.axaml
@@ -16,7 +16,6 @@
         <lvc:PolarChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="25"
                 Padding="{lvc:Padding '15'}"/>
         </lvc:PolarChart.Title>

--- a/samples/AvaloniaSample/StepLines/Basic/View.axaml
+++ b/samples/AvaloniaSample/StepLines/Basic/View.axaml
@@ -14,7 +14,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="25"
                 Padding="{lvc:Padding '15'}"/>
         </lvc:CartesianChart.Title>

--- a/samples/BlazorSample/Pages/Lines/Basic/View.razor
+++ b/samples/BlazorSample/Pages/Lines/Basic/View.razor
@@ -30,7 +30,6 @@
         new LabelGeometry
         {
             Text = "My chart title",
-            Paint = new SolidColorPaint(SKColor.Parse("#303030")),
             TextSize = 25,
             Padding = new LiveChartsCore.Drawing.Padding(15)
         });

--- a/samples/BlazorSample/Pages/Pies/Basic/View.razor
+++ b/samples/BlazorSample/Pages/Pies/Basic/View.razor
@@ -27,7 +27,6 @@
                 Text = "My chart title",
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15),
-                Paint = new SolidColorPaint(SKColors.Black)
             });
     }
 

--- a/samples/BlazorSample/Pages/Polar/Basic/View.razor
+++ b/samples/BlazorSample/Pages/Polar/Basic/View.razor
@@ -60,7 +60,6 @@
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/BlazorSample/Pages/StepLines/Basic/View.razor
+++ b/samples/BlazorSample/Pages/StepLines/Basic/View.razor
@@ -34,7 +34,6 @@
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/ConsoleSample/ConsoleSample/Program.cs
+++ b/samples/ConsoleSample/ConsoleSample/Program.cs
@@ -20,7 +20,6 @@ var cartesianChart = new SKCartesianChart
             Text = "Hello LiveCharts",
             TextSize = 30,
             Padding = new Padding(15),
-            Paint = new SolidColorPaint(0xff303030)
         }),
     LegendPosition = LiveChartsCore.Measure.LegendPosition.Right,
     Background = SKColors.White

--- a/samples/EtoFormsSample/Lines/Basic/View.cs
+++ b/samples/EtoFormsSample/Lines/Basic/View.cs
@@ -36,7 +36,6 @@ public class View : Panel
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/EtoFormsSample/Pies/Basic/View.cs
+++ b/samples/EtoFormsSample/Pies/Basic/View.cs
@@ -21,7 +21,6 @@ public class View : Panel
                 new LabelGeometry
                 {
                     Text = "My chart title",
-                    Paint = new SolidColorPaint(SKColors.Black),
                     TextSize = 25,
                     Padding = new LiveChartsCore.Drawing.Padding(15)
                 })

--- a/samples/EtoFormsSample/Polar/Basic/View.cs
+++ b/samples/EtoFormsSample/Polar/Basic/View.cs
@@ -52,7 +52,6 @@ public class View : Panel
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/EtoFormsSample/StepLines/Basic/View.cs
+++ b/samples/EtoFormsSample/StepLines/Basic/View.cs
@@ -29,7 +29,6 @@ public class View : Panel
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/MauiSample/Lines/Basic/View.xaml
+++ b/samples/MauiSample/Lines/Basic/View.xaml
@@ -16,7 +16,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:CartesianChart.Title>

--- a/samples/MauiSample/Pies/Basic/View.xaml
+++ b/samples/MauiSample/Pies/Basic/View.xaml
@@ -24,7 +24,6 @@
         <lvc:PieChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#000'}"
                 TextSize="25"
                 Padding="15"/>
         </lvc:PieChart.Title>

--- a/samples/MauiSample/Polar/Basic/View.xaml
+++ b/samples/MauiSample/Polar/Basic/View.xaml
@@ -17,7 +17,6 @@
         <lvc:PolarChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:PolarChart.Title>

--- a/samples/MauiSample/StepLines/Basic/View.xaml
+++ b/samples/MauiSample/StepLines/Basic/View.xaml
@@ -15,7 +15,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:CartesianChart.Title>

--- a/samples/WPFSample/Lines/Basic/View.xaml
+++ b/samples/WPFSample/Lines/Basic/View.xaml
@@ -15,7 +15,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:CartesianChart.Title>

--- a/samples/WPFSample/Pies/Basic/View.xaml
+++ b/samples/WPFSample/Pies/Basic/View.xaml
@@ -19,7 +19,6 @@
         <lvc:PieChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#000"
                 TextSize="25"
                 Padding="15"/>
         </lvc:PieChart.Title>

--- a/samples/WPFSample/Polar/Basic/View.xaml
+++ b/samples/WPFSample/Polar/Basic/View.xaml
@@ -14,7 +14,6 @@
         <lvc:PolarChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:PolarChart.Title>

--- a/samples/WPFSample/StepLines/Basic/View.xaml
+++ b/samples/WPFSample/StepLines/Basic/View.xaml
@@ -13,7 +13,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="#303030"
                 TextSize="25"
                 Padding="15"/>
         </lvc:CartesianChart.Title>

--- a/samples/WinFormsSample/Lines/Basic/View.cs
+++ b/samples/WinFormsSample/Lines/Basic/View.cs
@@ -39,7 +39,6 @@ public partial class View : UserControl
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/WinFormsSample/Pies/Basic/View.cs
+++ b/samples/WinFormsSample/Pies/Basic/View.cs
@@ -24,7 +24,6 @@ public partial class View : UserControl
                 new LabelGeometry
                 {
                     Text = "My chart title",
-                    Paint = new SolidColorPaint(SKColors.Black),
                     TextSize = 25,
                     Padding = new LiveChartsCore.Drawing.Padding(15)
                 }),

--- a/samples/WinFormsSample/Polar/Basic/View.cs
+++ b/samples/WinFormsSample/Polar/Basic/View.cs
@@ -55,7 +55,6 @@ public partial class View : UserControl
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/WinFormsSample/StepLines/Basic/View.cs
+++ b/samples/WinFormsSample/StepLines/Basic/View.cs
@@ -32,7 +32,6 @@ public partial class View : UserControl
             new LabelGeometry
             {
                 Text = "My chart title",
-                Paint = new SolidColorPaint(SKColor.Parse("#303030")),
                 TextSize = 25,
                 Padding = new LiveChartsCore.Drawing.Padding(15)
             });

--- a/samples/WinUISample/WinUISample/Samples/Lines/Basic/View.xaml
+++ b/samples/WinUISample/WinUISample/Samples/Lines/Basic/View.xaml
@@ -17,7 +17,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="{lvc:Float Value='25'}"
                 Padding="{lvc:Padding Value='15'}"/>
         </lvc:CartesianChart.Title>

--- a/samples/WinUISample/WinUISample/Samples/Pies/Basic/View.xaml
+++ b/samples/WinUISample/WinUISample/Samples/Pies/Basic/View.xaml
@@ -23,7 +23,6 @@
         <lvc:PieChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#000'}"
                 TextSize="{lvc:Float Value='25'}"
                 Padding="{lvc:Padding Value='15'}"/>
         </lvc:PieChart.Title>

--- a/samples/WinUISample/WinUISample/Samples/Polar/Basic/View.xaml
+++ b/samples/WinUISample/WinUISample/Samples/Polar/Basic/View.xaml
@@ -17,7 +17,6 @@
         <lvc:PolarChart.Title>
             <lvc:XamlDrawnLabelVisual
             Text="My chart title"
-            Paint="{lvc:SolidColorPaint Color='#303030'}"
             TextSize="{lvc:Float Value='25'}"
             Padding="{lvc:Padding Value='15'}"/>
         </lvc:PolarChart.Title>

--- a/samples/WinUISample/WinUISample/Samples/StepLines/Basic/View.xaml
+++ b/samples/WinUISample/WinUISample/Samples/StepLines/Basic/View.xaml
@@ -16,7 +16,6 @@
         <lvc:CartesianChart.Title>
             <lvc:XamlDrawnLabelVisual
                 Text="My chart title"
-                Paint="{lvc:SolidColorPaint Color='#303030'}"
                 TextSize="{lvc:Float Value='25'}"
                 Padding="{lvc:Padding Value='15'}"/>
         </lvc:CartesianChart.Title>

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -885,6 +885,11 @@ public abstract class Chart
         // more flexibility compared with VisualElement.
         if (View.Title?.ChartElementSource is Visual v)
         {
+            // Measure is where a visual applies the theme to itself, and it would otherwise not
+            // run until AddTitleToChart -> AddVisual -> Invalidate, a full layout pass later.
+            // GetHitBox below already needs the themed paint: a label with no paint can not be
+            // measured, so the title has to be given the chance to theme itself first.
+            v.InvokeMeasure(this);
             return v.GetHitBox().Size;
         }
 
@@ -905,6 +910,11 @@ public abstract class Chart
         // more flexibility compared with VisualElement.
         if (View.Title?.ChartElementSource is Visual v && v.DrawnElement is not null)
         {
+            // Not every path measured the title first (PolarChartEngine skips MeasureTitle when
+            // it fits to bounds), and GetHitBox below needs the themed paint. Measure applies the
+            // theme only once per theme, so measuring twice costs nothing when it did run.
+            v.InvokeMeasure(this);
+
             var size = v.GetHitBox().Size;
             v.DrawnElement.X = ControlSize.Width * 0.5f - size.Width * 0.5f;
             v.DrawnElement.Y = 0;

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -885,11 +885,10 @@ public abstract class Chart
         // more flexibility compared with VisualElement.
         if (View.Title?.ChartElementSource is Visual v)
         {
-            // Measure is where a visual applies the theme to itself, and it would otherwise not
-            // run until AddTitleToChart -> AddVisual -> Invalidate, a full layout pass later.
-            // GetHitBox below already needs the themed paint: a label with no paint can not be
-            // measured, so the title has to be given the chance to theme itself first.
-            v.InvokeMeasure(this);
+            // The title is themed on invalidation, which does not happen until AddTitleToChart,
+            // a full layout pass later. GetHitBox below already needs the themed paint: a label
+            // with no paint can not be measured, so theme it now.
+            v.ApplyTheme(this);
             return v.GetHitBox().Size;
         }
 
@@ -911,9 +910,8 @@ public abstract class Chart
         if (View.Title?.ChartElementSource is Visual v && v.DrawnElement is not null)
         {
             // Not every path measured the title first (PolarChartEngine skips MeasureTitle when
-            // it fits to bounds), and GetHitBox below needs the themed paint. Measure applies the
-            // theme only once per theme, so measuring twice costs nothing when it did run.
-            v.InvokeMeasure(this);
+            // it fits to bounds), and GetHitBox below needs the themed paint.
+            v.ApplyTheme(this);
 
             var size = v.GetHitBox().Size;
             v.DrawnElement.X = ControlSize.Width * 0.5f - size.Width * 0.5f;

--- a/src/LiveChartsCore/VisualElements/Visual.cs
+++ b/src/LiveChartsCore/VisualElements/Visual.cs
@@ -25,6 +25,7 @@ using LiveChartsCore.Drawing;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.Kernel.Events;
 using LiveChartsCore.Painting;
+using LiveChartsCore.Themes;
 
 namespace LiveChartsCore.VisualElements;
 
@@ -105,4 +106,26 @@ public abstract class Visual : ChartElement, IInternalInteractable
     /// </summary>
     /// <param name="chart"></param>
     protected abstract void Measure(Chart chart);
+
+    // The chart measures the title before it invalidates it (Chart.MeasureTitle), and by then
+    // the title must already be themed. Measure stays protected so that overriding it does not
+    // depend on whether the assembly has InternalsVisibleTo access to the core.
+    internal void InvokeMeasure(Chart chart) => Measure(chart);
+
+    /// <summary>
+    /// Applies the theme to the visual, a style only sets the properties that the user has not set.
+    /// </summary>
+    /// <typeparam name="T">The type of the visual.</typeparam>
+    /// <param name="theme">The theme.</param>
+    protected virtual void ApplyTheme<T>(Theme theme)
+        where T : Visual
+    {
+        _isInternalSet = true;
+        if (_theme != theme.ThemeId)
+        {
+            theme.ApplyStyleTo<T>(this);
+            _theme = theme.ThemeId;
+        }
+        _isInternalSet = false;
+    }
 }

--- a/src/LiveChartsCore/VisualElements/Visual.cs
+++ b/src/LiveChartsCore/VisualElements/Visual.cs
@@ -68,6 +68,7 @@ public abstract class Visual : ChartElement, IInternalInteractable
         if (DrawnElement is null)
             throw new Exception($"{nameof(DrawnElement)} can not be null.");
 
+        ApplyTheme(chart);
         Measure(chart);
 
         if (_drawnTask is null || _drawnTask.IsEmpty)
@@ -107,23 +108,26 @@ public abstract class Visual : ChartElement, IInternalInteractable
     /// <param name="chart"></param>
     protected abstract void Measure(Chart chart);
 
-    // The chart measures the title before it invalidates it (Chart.MeasureTitle), and by then
-    // the title must already be themed. Measure stays protected so that overriding it does not
-    // depend on whether the assembly has InternalsVisibleTo access to the core.
-    internal void InvokeMeasure(Chart chart) => Measure(chart);
-
     /// <summary>
-    /// Applies the theme to the visual, a style only sets the properties that the user has not set.
+    /// Applies the theme style to this visual, override it to be styled by the theme, normally
+    /// as <c>theme.ApplyStyleTo&lt;MyVisual&gt;(this)</c>. A style only sets the properties that
+    /// the user has not set, the arbitration is handled by the caller.
     /// </summary>
-    /// <typeparam name="T">The type of the visual.</typeparam>
     /// <param name="theme">The theme.</param>
-    protected virtual void ApplyTheme<T>(Theme theme)
-        where T : Visual
+    protected virtual void ApplyStyle(Theme theme) { }
+
+    // Called on every invalidation, and by the chart before it reads the title's size: the title
+    // is measured a full layout pass before it is invalidated, and a label with no paint can not
+    // be measured, so the theme has to have run by then. Applying the style is guarded by the
+    // theme id, so calling this more than once per theme costs nothing.
+    internal void ApplyTheme(Chart chart)
     {
+        var theme = chart.GetTheme();
+
         _isInternalSet = true;
         if (_theme != theme.ThemeId)
         {
-            theme.ApplyStyleTo<T>(this);
+            ApplyStyle(theme);
             _theme = theme.ThemeId;
         }
         _isInternalSet = false;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
@@ -29,6 +29,7 @@ using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.SkiaSharpView.Painting.ImageFilters;
 using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.SkiaSharpView.VisualElements;
 using LiveChartsCore.Themes;
 using LiveChartsCore.VisualElements;
 using LiveChartsCore.VisualStates;
@@ -349,6 +350,11 @@ public static class ThemesExtensions
                                 new SolidColorPaint(theme.IsDark ? new(245, 245, 245) : new(45, 45, 45));
                     })
                     .HasRuleFor<BaseLabelVisual>(label =>
+                    {
+                        label.Paint =
+                            new SolidColorPaint(theme.IsDark ? new(200, 200, 200) : new(30, 30, 30));
+                    })
+                    .HasRuleFor<DrawnLabelVisual>(label =>
                     {
                         label.Paint =
                             new SolidColorPaint(theme.IsDark ? new(200, 200, 200) : new(30, 30, 30));

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
@@ -23,6 +23,7 @@
 using LiveChartsCore.Drawing;
 using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.Themes;
 using LiveChartsCore.VisualElements;
 
 namespace LiveChartsCore.SkiaSharpView.VisualElements;
@@ -84,17 +85,26 @@ public class DrawnLabelVisual : Visual
     public Paint? Paint
     {
         get => _paint;
-        set => SetPaintProperty(ref _paint, value, PaintStyle.Text);
+        set
+        {
+            SetPaintProperty(ref _paint, value, PaintStyle.Text);
+
+            // Forward right away instead of on measure: the geometry paint is what the label is
+            // drawn and measured with, and the chart measures the title before it invalidates it.
+            _drawnElement.Paint = _paint;
+        }
     }
 
     /// <inheritdoc cref="Visual.DrawnElement"/>
     protected internal override IDrawnElement? DrawnElement => _drawnElement;
 
+    /// <inheritdoc cref="Visual.ApplyStyle(Theme)"/>
+    protected override void ApplyStyle(Theme theme) =>
+        theme.ApplyStyleTo<DrawnLabelVisual>(this);
+
     /// <inheritdoc cref="Visual.Measure(Chart)"/>
     protected override void Measure(Chart chart)
     {
-        ApplyTheme<DrawnLabelVisual>(chart.GetTheme());
 
-        _drawnElement.Paint = _paint;
     }
 }

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/VisualElements/DrawnLabelVisual.cs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 using LiveChartsCore.Drawing;
+using LiveChartsCore.Painting;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 using LiveChartsCore.VisualElements;
 
@@ -36,6 +37,7 @@ public class DrawnLabelVisual : Visual
         HorizontalAlign = Align.Start,
         VerticalAlign = Align.Start
     };
+    private Paint? _paint;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DrawnLabelVisual"/> class.
@@ -55,17 +57,35 @@ public class DrawnLabelVisual : Visual
         labelGeometry.HorizontalAlign = Align.Start;
         labelGeometry.VerticalAlign = Align.Start;
         _drawnElement = labelGeometry;
+
+        // A paint that came in on the geometry is an explicit choice, but it was not made
+        // through the Paint property, so route it through now: otherwise the theme reads it
+        // as unset and Measure overwrites it with the themed paint.
+        if (labelGeometry.Paint is not null) Paint = labelGeometry.Paint;
     }
 
     /// <summary>
     /// Gets the underlying <see cref="LabelGeometry"/>. Use this to read or
     /// mutate label properties such as
     /// <see cref="BaseLabelGeometry.Text"/>,
-    /// <see cref="BaseLabelGeometry.TextSize"/>,
-    /// <see cref="BaseLabelGeometry.Paint"/> or
+    /// <see cref="BaseLabelGeometry.TextSize"/> or
     /// <see cref="BaseLabelGeometry.Padding"/> after construction.
     /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="Paint"/> over <see cref="BaseLabelGeometry.Paint"/>: a paint set here
+    /// is invisible to the theme, which then can not tell it apart from an unset paint and
+    /// overwrites it.
+    /// </remarks>
     public LabelGeometry Label => _drawnElement;
+
+    /// <summary>
+    /// Gets or sets the paint used to draw the label, when null the theme sets it.
+    /// </summary>
+    public Paint? Paint
+    {
+        get => _paint;
+        set => SetPaintProperty(ref _paint, value, PaintStyle.Text);
+    }
 
     /// <inheritdoc cref="Visual.DrawnElement"/>
     protected internal override IDrawnElement? DrawnElement => _drawnElement;
@@ -73,6 +93,8 @@ public class DrawnLabelVisual : Visual
     /// <inheritdoc cref="Visual.Measure(Chart)"/>
     protected override void Measure(Chart chart)
     {
+        ApplyTheme<DrawnLabelVisual>(chart.GetTheme());
 
+        _drawnElement.Paint = _paint;
     }
 }

--- a/tests/CoreTests/OtherTests/DrawnLabelVisualThemeTests.cs
+++ b/tests/CoreTests/OtherTests/DrawnLabelVisualThemeTests.cs
@@ -1,0 +1,253 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore;
+using LiveChartsCore.Painting;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using LiveChartsCore.Themes;
+using LiveChartsCore.VisualElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+// Covers the chart title following the theme.
+//
+// DrawnLabelVisual derives from Visual, which had no theme pass at all: ApplyTheme only
+// existed on VisualElement and was only ever reached from BaseLabelVisual (the obsolete
+// label family). So a title never got a paint from the theme, and since a label can not be
+// measured without one, every sample had to hardcode a color that then ignored dark mode.
+[TestClass]
+public class DrawnLabelVisualThemeTests
+{
+    private static readonly SKColor s_lightPaint = new(30, 30, 30);
+    private static readonly SKColor s_darkPaint = new(200, 200, 200);
+
+    private static SKCartesianChart BuildChart(DrawnLabelVisual title) =>
+        new()
+        {
+            Width = 300,
+            Height = 300,
+            Title = title,
+            Series = [new LineSeries<double> { Values = [1, 2, 3] }]
+        };
+
+    private static DrawnLabelVisual BuildTitle() =>
+        new(new LabelGeometry { Text = "My chart title", TextSize = 25 });
+
+    private static SKColor ColorOf(Paint? paint) =>
+        ((SolidColorPaint)paint!).Color;
+
+    private static void UseTheme(LvcThemeKind kind) =>
+        LiveCharts.Configure(s => s.AddDefaultTheme(requestedTheme: kind));
+
+    private static void ResetTheme() =>
+        LiveCharts.Configure(s => s.AddDefaultTheme());
+
+    [TestMethod]
+    public void TitleWithNoPaintIsThemed()
+    {
+        // Before the fix this threw "A paint is required to measure a label": MeasureTitle
+        // reads the title's size before anything could have given it a paint.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = BuildTitle();
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                s_lightPaint, ColorOf(title.Paint),
+                "A title with no paint must take the paint from the theme.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void ThemedTitlePaintReachesTheGeometry()
+    {
+        // The theme sets DrawnLabelVisual.Paint, but the label is drawn from the geometry's
+        // own paint, so Measure must forward it or the title renders as nothing.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = BuildTitle();
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                s_lightPaint, ColorOf(title.Label.Paint),
+                "The themed paint must be forwarded to the label geometry.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void UserSetTitlePaintWinsOverTheme()
+    {
+        // The whole reason DrawnLabelVisual.Paint exists: a paint set through the property is
+        // recorded in _userSets, so CanSetProperty blocks the theme. Writing straight to
+        // Label.Paint can not be seen, which is why the theme would overwrite it.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var userPaint = new SolidColorPaint(SKColors.Red);
+            var title = BuildTitle();
+            title.Paint = userPaint;
+
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                SKColors.Red, ColorOf(title.Paint),
+                "A user-set paint must survive the theme.");
+            Assert.AreEqual(
+                SKColors.Red, ColorOf(title.Label.Paint),
+                "A user-set paint must reach the geometry.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void PaintOnTheCtorGeometryWinsOverTheme()
+    {
+        // The code-only samples build the title as DrawnLabelVisual(new LabelGeometry { Paint }).
+        // That write never went through the Paint property, so the ctor has to route it.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = new DrawnLabelVisual(
+                new LabelGeometry
+                {
+                    Text = "My chart title",
+                    TextSize = 25,
+                    Paint = new SolidColorPaint(SKColors.Red)
+                });
+
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                SKColors.Red, ColorOf(title.Label.Paint),
+                "A paint handed to the ctor on the geometry must survive the theme.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void UnsetTitlePaintFollowsAThemeChange()
+    {
+        // The point of theming the title: switching light <-> dark must repaint it. A rule that
+        // only filled in a null paint would pass the first-load test and fail this one.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = BuildTitle();
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(s_lightPaint, ColorOf(title.Paint));
+
+            UseTheme(LvcThemeKind.Dark);
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                s_darkPaint, ColorOf(title.Paint),
+                "An unset title paint must follow a theme change.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void UserSetTitlePaintSurvivesAThemeChange()
+    {
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = BuildTitle();
+            title.Paint = new SolidColorPaint(SKColors.Red);
+            _ = BuildChart(title).GetImage();
+
+            UseTheme(LvcThemeKind.Dark);
+            _ = BuildChart(title).GetImage();
+
+            Assert.AreEqual(
+                SKColors.Red, ColorOf(title.Paint),
+                "A user-set paint must survive a theme change too.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+
+    [TestMethod]
+    public void TitleIsThemedWhenThePolarChartFitsToBounds()
+    {
+        // PolarChartEngine skips MeasureTitle when it fits to bounds, so AddTitleToChart is the
+        // first thing to touch the title on that path and has to measure it too.
+        try
+        {
+            UseTheme(LvcThemeKind.Light);
+
+            var title = BuildTitle();
+            var chart = new SKPolarChart
+            {
+                Width = 300,
+                Height = 300,
+                Title = title,
+                FitToBounds = true,
+                Series = [new PolarLineSeries<double> { Values = [1, 2, 3] }]
+            };
+
+            _ = chart.GetImage();
+
+            Assert.AreEqual(
+                s_lightPaint, ColorOf(title.Paint),
+                "The title must be themed on the fit-to-bounds polar path.");
+        }
+        finally
+        {
+            ResetTheme();
+        }
+    }
+}


### PR DESCRIPTION
> _Note: this description was drafted by Claude Code on Beto's behalf._

## The problem

The chart title never followed the theme, and it could not: `DrawnLabelVisual` derives from `Visual`, which had no theme pass at all. `ApplyTheme` only existed on `VisualElement`, and it was only ever reached from `BaseLabelVisual` — the obsolete label family. The default theme's only label rule targets `BaseLabelVisual` too.

Since a label cannot be measured without a paint, this was not a "title is the wrong color" bug. Removing the color from a sample did not fall back to a default, it threw:

```
System.Exception: A paint is required to measure a label, please set the Paint property with the paint that is drawing the label.
```

That is why every sample on every platform hardcoded `#303030` — and so rendered a dark title in dark mode.

## The fix

**`Visual` can apply a theme to itself.** `ApplyTheme<T>` mirrors the one on `VisualElement`.

**The chart measures the title before reading its size.** `Measure` is where a visual themes itself, but `MeasureTitle` reads `GetHitBox()` a full layout pass before `Invalidate` calls `Measure`, and by then the paint has to exist. `AddTitleToChart` measures too, because `PolarChartEngine` skips `MeasureTitle` entirely when it fits to bounds. Measuring twice is free — `ApplyTheme` runs once per theme.

**`DrawnLabelVisual` hosts `Paint`.** This is the part worth reviewing. The paint lives on `LabelGeometry`, a plain auto-property that records nothing, so a rule writing `Label.Paint` could not tell a user-set paint from an unset one and would overwrite it. Filling in only a null paint fails the other way: the title keeps the old color across a theme switch. Hosting `Paint` on the visual puts the write through `SetPaintProperty`, so `_userSets` records it and `CanSetProperty` arbitrates — exactly as series and axes already do. The ctor routes a paint that arrives on the geometry through the same property, since the code-only samples build titles that way.

`Label.Paint` still works as an escape hatch, but it is invisible to the theme; the XML docs say so.

## Notes for the reviewer

**The generator commit is enabling work, not a fix.** Nothing collides on `master`. `XamlClass` hosts wrapped-type and `Map`-type members under the same names (the `MapPath` is not a prefix), and `Paint` is the first name to exist on both sides — deliberately, so the write can be recorded. Without the change the generator emits `PaintProperty` twice (`CS0102`). The wrapped type now wins, which generalizes to any future shadowing wrapper property. **The XAML surface is unchanged**: `Paint="#303030"` still binds, it just routes through the arbitration property now.

**`Measure` stays `protected`.** Widening it to `protected internal` compiles in `LiveChartsCore.SkiaSharpView` (it has `InternalsVisibleTo`) but breaks `CoreTests` with `CS0507`: an override must drop the internal part in assemblies without IVT and keep it in assemblies with it. That would break existing subclasses on one side or the other, so the chart calls an internal `InvokeMeasure` instead.

## Verification

- Every fix fails its own test in isolation, checked by reverting each one: dropping the theme rule or the `MeasureTitle` call brings back "A paint is required to measure a label"; dropping the `AddTitleToChart` call fails only the fit-to-bounds polar case; dropping the ctor routing fails only the paint-on-the-ctor-geometry case.
- 835 CoreTests and 170 SnapshotTests pass. Snapshots do not render titles, so no baselines moved.
- The Console sample renders a themed title with no hardcoded color.
- All XAML platforms regenerate and compile (WPF, Avalonia, MAUI, WinUI, Blazor, WinForms, Eto).

## Not included

`docs/samples/**/result.png` still show the old `#303030` title (now `#1E1E1E`). A barely visible shift, and regenerating churns binaries — happy to do it if you want them exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
