### PR TITLE
fix: hit testing and geo markers work with visuals built on Visual

### DIFF
--- a/docs/geomapchart/overview.md
+++ b/docs/geomapchart/overview.md
@@ -680,30 +680,34 @@ geoMap.DataPointerDown += (sender, points) =>
 
 ## Custom overlays at lat/lon (markers, callouts, etc.)
 
-The map's `VisualElements` collection accepts any `VisualElement` — the
-same primitives the cartesian charts use (`GeometryVisual`,
-`DrawnLabelVisual`, `LineVisual`, ...). Wrap one in a
-`GeoVisualElement(visual) { Longitude, Latitude }` to anchor it at a
-geographic coordinate; the wrapper re-projects on every measure so the
-overlay follows zoom, pan, and orthographic rotation.
+The map's `VisualElements` collection accepts any `Visual` — the same
+class the cartesian charts use for custom elements, described in the
+[visual elements article]({{ website_url }}/docs/{{ platform }}/{{ version }}/samples.general.visualElements).
+Wrap one in a `GeoVisualElement(visual) { Longitude, Latitude }` to anchor
+it at a geographic coordinate; the wrapper re-projects on every measure so
+the overlay follows zoom, pan, and orthographic rotation.
+
+The marker below is an ordinary `Visual` whose `DrawnElement` is a circle.
+Note that `Measure` is empty: `GeoVisualElement` writes the projected pixel
+onto the drawn element itself, so a visual that positions itself would
+overwrite the very coordinate it is anchored to.
+
+```csharp
+{{~ render "~/../samples/ViewModelsSamples/Maps/MarkersOnMap/CityMarkerVisual.cs" ~}}
+```
+
+Anchor one instance per coordinate and hand them to the map:
 
 {{~ if xaml ~}}
 <pre><code>// In your ViewModel:
 public IChartElement[] CityMarkers { get; } = [
-    Marker(longitude: -74.00, latitude:  40.71), // New York
-    Marker(longitude: 139.69, latitude:  35.69), // Tokyo
-    Marker(longitude:  -3.70, latitude:  40.42), // Madrid
+    CityMarker(longitude: -74.00, latitude:  40.71), // New York
+    CityMarker(longitude: 139.69, latitude:  35.69), // Tokyo
+    CityMarker(longitude:  -3.70, latitude:  40.42), // Madrid
 ];
 
-static GeoVisualElement Marker(double longitude, double latitude) =>
-    new(new GeometryVisual&lt;CircleGeometry&gt;
-    {
-        Width = 14, Height = 14,
-        Fill = new SolidColorPaint(new SKColor(255, 87, 51)),
-        Stroke = new SolidColorPaint(SKColors.White) { StrokeThickness = 2 },
-        // Inner X/Y is the bbox top-left; center the dot on the point.
-        Translate = new LvcPoint(-7, -7),
-    })
+static GeoVisualElement CityMarker(double longitude, double latitude) =>
+    new(new CityMarkerVisual())
     {
         Longitude = longitude,
         Latitude = latitude,
@@ -721,19 +725,13 @@ static GeoVisualElement Marker(double longitude, double latitude) =>
 
 @code {
     private IChartElement[] markers = [
-        Marker(-74.00,  40.71),
-        Marker(139.69,  35.69),
-        Marker( -3.70,  40.42),
+        CityMarker(-74.00,  40.71),
+        CityMarker(139.69,  35.69),
+        CityMarker( -3.70,  40.42),
     ];
 
-    static GeoVisualElement Marker(double lon, double lat) =>
-        new(new GeometryVisual&lt;CircleGeometry&gt;
-        {
-            Width = 14, Height = 14,
-            Fill = new SolidColorPaint(new SKColor(255, 87, 51)),
-            Stroke = new SolidColorPaint(SKColors.White) { StrokeThickness = 2 },
-            Translate = new LvcPoint(-7, -7),
-        })
+    static GeoVisualElement CityMarker(double lon, double lat) =>
+        new(new CityMarkerVisual())
         {
             Longitude = lon,
             Latitude = lat,
@@ -744,19 +742,13 @@ static GeoVisualElement Marker(double longitude, double latitude) =>
 {{~ if winforms ~}}
 <pre><code>geoMap1.VisualElements = new IChartElement[]
 {
-    Marker(longitude: -74.00, latitude:  40.71),
-    Marker(longitude: 139.69, latitude:  35.69),
-    Marker(longitude:  -3.70, latitude:  40.42),
+    CityMarker(longitude: -74.00, latitude:  40.71),
+    CityMarker(longitude: 139.69, latitude:  35.69),
+    CityMarker(longitude:  -3.70, latitude:  40.42),
 };
 
-static GeoVisualElement Marker(double longitude, double latitude) =>
-    new(new GeometryVisual&lt;CircleGeometry&gt;
-    {
-        Width = 14, Height = 14,
-        Fill = new SolidColorPaint(new SKColor(255, 87, 51)),
-        Stroke = new SolidColorPaint(SKColors.White) { StrokeThickness = 2 },
-        Translate = new LvcPoint(-7, -7),
-    })
+static GeoVisualElement CityMarker(double longitude, double latitude) =>
+    new(new CityMarkerVisual())
     {
         Longitude = longitude,
         Latitude = latitude,

--- a/samples/ViewModelsSamples/Maps/MarkersOnMap/CityMarkerVisual.cs
+++ b/samples/ViewModelsSamples/Maps/MarkersOnMap/CityMarkerVisual.cs
@@ -1,4 +1,5 @@
 using LiveChartsCore;
+using LiveChartsCore.Drawing;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
 using LiveChartsCore.SkiaSharpView.Painting;
 using LiveChartsCore.VisualElements;
@@ -15,7 +16,10 @@ public class CityMarkerVisual : Visual
     //
     // The translate centers the circle on the projected point; without it the geometry's
     // top-left corner would sit on the coordinate.
-    protected override CircleGeometry DrawnElement { get; } = new()
+    //
+    // Declared as IDrawnElement rather than CircleGeometry: net462 does not support covariant
+    // returns, and Measure has no need for the derived type here.
+    protected override IDrawnElement DrawnElement { get; } = new CircleGeometry
     {
         Width = Size,
         Height = Size,

--- a/samples/ViewModelsSamples/Maps/MarkersOnMap/CityMarkerVisual.cs
+++ b/samples/ViewModelsSamples/Maps/MarkersOnMap/CityMarkerVisual.cs
@@ -1,0 +1,32 @@
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.VisualElements;
+using SkiaSharp;
+
+namespace ViewModelsSamples.Maps.MarkersOnMap;
+
+public class CityMarkerVisual : Visual
+{
+    private const float Size = 14f;
+
+    // GeoVisualElement writes the projected pixel onto this geometry, so do not set X or Y
+    // in Measure below or the marker would ignore the coordinate it is anchored to.
+    //
+    // The translate centers the circle on the projected point; without it the geometry's
+    // top-left corner would sit on the coordinate.
+    protected override CircleGeometry DrawnElement { get; } = new()
+    {
+        Width = Size,
+        Height = Size,
+        Fill = new SolidColorPaint(new SKColor(255, 87, 51)), // OrangeRed
+        Stroke = new SolidColorPaint(SKColors.White),
+        // A geometry that carries its own paints is drawn with the thickness set here, the one on
+        // the paint is ignored, so setting it there would silently draw a 1px hairline instead.
+        StrokeThickness = 2,
+        TranslateTransform = new(-Size / 2f, -Size / 2f),
+    };
+
+    protected override void Measure(Chart chart)
+    { }
+}

--- a/samples/ViewModelsSamples/Maps/MarkersOnMap/ViewModel.cs
+++ b/samples/ViewModelsSamples/Maps/MarkersOnMap/ViewModel.cs
@@ -1,12 +1,7 @@
-using LiveChartsCore.Drawing;
 using LiveChartsCore.Geo;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
-using LiveChartsCore.SkiaSharpView.Painting;
-using LiveChartsCore.SkiaSharpView.VisualElements;
-using LiveChartsCore.VisualElements;
-using SkiaSharp;
 
 namespace ViewModelsSamples.Maps.MarkersOnMap;
 
@@ -43,27 +38,13 @@ public class ViewModel
 
     public IChartElement[] VisualElements { get; }
 
-    private static GeoVisualElement CityMarker(double longitude, double latitude)
-    {
-        // GeoVisualElement wraps any VisualElement and re-projects its
-        // (Longitude, Latitude) to screen pixels each Measure pass. The
-        // inner visual then draws at that pixel — pan / zoom / orthographic
-        // rotation all follow automatically.
-        //
-        // The inner Translate centers the bbox on the projected point;
-        // without it the circle's top-left corner would sit on the coord.
-        const float size = 14f;
-        return new GeoVisualElement(new GeometryVisual<CircleGeometry>
-        {
-            Width = size,
-            Height = size,
-            Fill = new SolidColorPaint(new SKColor(255, 87, 51)), // OrangeRed
-            Stroke = new SolidColorPaint(SKColors.White) { StrokeThickness = 2 },
-            Translate = new LvcPoint(-size / 2f, -size / 2f),
-        })
+    private static GeoVisualElement CityMarker(double longitude, double latitude) =>
+        // GeoVisualElement wraps a visual and re-projects its (Longitude, Latitude)
+        // to screen pixels each Measure pass. The inner visual then draws at that
+        // pixel — pan / zoom / orthographic rotation all follow automatically.
+        new(new CityMarkerVisual())
         {
             Longitude = longitude,
             Latitude = latitude,
         };
-    }
 }

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -327,9 +327,25 @@ public abstract class Chart
     }
 
     /// <inheritdoc cref="IChartView.GetVisualsAt(LvcPointD)"/>
-    public IEnumerable<IChartElement> GetVisualsAt(LvcPointD point) =>
-        VisualElements.SelectMany(visual =>
-            ((VisualElement)visual).IsHitBy(this, new(point)));
+    public IEnumerable<IChartElement> GetVisualsAt(LvcPointD point)
+    {
+        var location = new LvcPoint(point);
+
+        // VisualElements is a collection of IChartElement, so it holds both visual families.
+        // Casting to VisualElement threw for anything built on Visual, which is every visual in
+        // the General/VisualElements samples. InvokePointerDown already hit tests through
+        // IInteractable, the interface both families implement for exactly this reason.
+        return VisualElements.SelectMany<IChartElement, IChartElement>(visual => visual switch
+        {
+            // A VisualElement can host children, so it runs its own, possibly nested, hit test.
+            VisualElement visualElement => visualElement.IsHitBy(this, location),
+
+            // A Visual draws a single element, its hit box is the whole of it.
+            Visual v => v.GetHitBox().Contains(location) ? [v] : [],
+
+            _ => []
+        });
+    }
 
     /// <summary>
     /// Loads the control resources.

--- a/src/LiveChartsCore/Geo/GeoVisualElement.cs
+++ b/src/LiveChartsCore/Geo/GeoVisualElement.cs
@@ -28,11 +28,11 @@ using LiveChartsCore.VisualElements;
 namespace LiveChartsCore.Geo;
 
 /// <summary>
-/// Wraps a <see cref="VisualElement"/> and positions it at a geographic
+/// Wraps a <see cref="VisualElements.Visual"/> (or the older
+/// <see cref="VisualElements.VisualElement"/>) and positions it at a geographic
 /// (longitude, latitude) on a <see cref="GeoMapChart"/>. Each measure pass
 /// re-projects the coordinate via the chart's current projector and writes
-/// the result onto the inner visual's <see cref="VisualElement.X"/> /
-/// <see cref="VisualElement.Y"/>, so the overlay follows zoom, pan, and
+/// the result onto the inner visual, so the overlay follows zoom, pan, and
 /// orthographic rotation. When the coordinate isn't visible (e.g. the back
 /// hemisphere on <see cref="MapProjection.Orthographic"/>), the inner
 /// visual is removed from the UI for the frame so it doesn't ghost at
@@ -45,13 +45,33 @@ public class GeoVisualElement : ChartElement
     /// inner visual.
     /// </summary>
     /// <param name="visual">The visual to position at (Longitude, Latitude).</param>
+    /// <remarks>
+    /// A <see cref="VisualElements.Visual"/> is positioned through its drawn element, so it must
+    /// not set its own location in <c>Measure</c> or it will overwrite the projected coordinate.
+    /// </remarks>
+    public GeoVisualElement(Visual visual)
+        : this((ChartElement?)visual)
+    { }
+
+    /// <summary>
+    /// Initializes a new <see cref="GeoVisualElement"/> wrapping the given
+    /// inner visual element.
+    /// </summary>
+    /// <param name="visual">The visual element to position at (Longitude, Latitude).</param>
     public GeoVisualElement(VisualElement visual)
+        : this((ChartElement?)visual)
+    { }
+
+    private GeoVisualElement(ChartElement? visual)
     {
         Visual = visual ?? throw new ArgumentNullException(nameof(visual));
     }
 
-    /// <summary>Gets the wrapped visual element.</summary>
-    public VisualElement Visual { get; }
+    /// <summary>
+    /// Gets the wrapped visual, a <see cref="VisualElements.Visual"/> or a
+    /// <see cref="VisualElements.VisualElement"/>, the constructors take no other type.
+    /// </summary>
+    public ChartElement Visual { get; }
 
     /// <summary>Gets or sets the longitude (in degrees) where the visual is anchored.</summary>
     public double Longitude { get; set => SetProperty(ref field, value); }
@@ -76,8 +96,7 @@ public class GeoVisualElement : ChartElement
             return;
         }
 
-        Visual.X = pixel.Value.X;
-        Visual.Y = pixel.Value.Y;
+        SetLocation(pixel.Value.X, pixel.Value.Y);
         Visual.Invalidate(chart);
 
         // Chart.AddVisual normally calls RemoveOldPaints after Invalidate to
@@ -86,6 +105,24 @@ public class GeoVisualElement : ChartElement
         // The wrapped visual goes through our Invalidate, not AddVisual, so
         // mirror that step explicitly.
         Visual.RemoveOldPaints(chart.View);
+    }
+
+    private void SetLocation(float x, float y)
+    {
+        switch (Visual)
+        {
+            case VisualElement visualElement:
+                visualElement.X = x;
+                visualElement.Y = y;
+                break;
+
+            // A Visual has no location of its own, it lives on the drawn element, the same place
+            // Chart.AddTitleToChart writes to position the title.
+            case Visual visual when visual.DrawnElement is not null:
+                visual.DrawnElement.X = x;
+                visual.DrawnElement.Y = y;
+                break;
+        }
     }
 
     /// <inheritdoc cref="ChartElement.RemoveFromUI(Chart)"/>

--- a/src/skiasharp/_Shared/SourceGenChart.shared.cs
+++ b/src/skiasharp/_Shared/SourceGenChart.shared.cs
@@ -119,9 +119,10 @@ public partial class SourceGenChart : IChartView
     }
 
     /// <inheritdoc cref="IChartView.GetVisualsAt(LvcPointD)"/>
+    // Delegate to the core instead of repeating the hit test, which is how this copy came to
+    // still cast every element to VisualElement after the core learned to handle both families.
     public IEnumerable<IChartElement> GetVisualsAt(LvcPointD point) =>
-        CoreChart.VisualElements.SelectMany(visual =>
-            ((VisualElement)visual).IsHitBy(CoreChart, new(point)));
+        CoreChart.GetVisualsAt(point);
 
     private void OnCoreMeasuring(IChartView chart) =>
         Measuring?.Invoke(this);

--- a/tests/CoreTests/ChartTests/GeoVisualElementTests.cs
+++ b/tests/CoreTests/ChartTests/GeoVisualElementTests.cs
@@ -1,0 +1,136 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Geo;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using LiveChartsCore.VisualElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.ChartTests;
+
+// GeoVisualElement took a VisualElement only, so a marker had to be built on the older, partly
+// obsolete family: the markers sample used GeometryVisual, which is [Obsolete]. It positions the
+// inner visual by writing its location, and a Visual has none of its own -- its location lives on
+// the drawn element -- which is why the newer family did not fit.
+[TestClass]
+public class GeoVisualElementTests
+{
+    private const double Longitude = -74.00;
+    private const double Latitude = 40.71;
+    private const float Size = 14f;
+
+    private class MarkerVisual : Visual
+    {
+        public CircleGeometry Circle { get; } = new()
+        {
+            Width = Size,
+            Height = Size,
+            Fill = new SolidColorPaint(SKColors.Red)
+        };
+
+        protected internal override IDrawnElement? DrawnElement => Circle;
+
+        protected override void Measure(Chart chart)
+        { }
+    }
+
+    private static SKGeoMap BuildMap(params IChartElement[] visuals) =>
+        new()
+        {
+            Width = 800,
+            Height = 600,
+            MapProjection = MapProjection.Mercator,
+            Series = [new HeatLandSeries { Lands = [new() { Name = "usa", Value = 15 }] }],
+            VisualElements = visuals
+        };
+
+    [TestMethod]
+    public void VisualIsProjectedToTheSamePixelAsAVisualElement()
+    {
+        // Parity is the whole contract: the new branch must place a Visual exactly where the old
+        // branch places a VisualElement for the same coordinate.
+        var visual = new MarkerVisual();
+        var visualElement = new GeometryVisual<CircleGeometry>
+        {
+            Width = Size,
+            Height = Size,
+            Fill = new SolidColorPaint(SKColors.Red),
+            LocationUnit = MeasureUnit.Pixels,
+            SizeUnit = MeasureUnit.Pixels
+        };
+
+        var map = BuildMap(
+            new GeoVisualElement(visual) { Longitude = Longitude, Latitude = Latitude },
+            new GeoVisualElement(visualElement) { Longitude = Longitude, Latitude = Latitude });
+
+        _ = map.GetImage();
+
+        Assert.AreEqual(
+            (float)visualElement.X, visual.Circle.X,
+            "A Visual must be projected to the same X as a VisualElement.");
+        Assert.AreEqual(
+            (float)visualElement.Y, visual.Circle.Y,
+            "A Visual must be projected to the same Y as a VisualElement.");
+    }
+
+    [TestMethod]
+    public void VisualIsMovedFromItsOrigin()
+    {
+        // Guards the parity test above: if neither family were positioned, both would sit at 0
+        // and the assert would still pass.
+        var visual = new MarkerVisual();
+
+        var map = BuildMap(
+            new GeoVisualElement(visual) { Longitude = Longitude, Latitude = Latitude });
+
+        _ = map.GetImage();
+
+        Assert.AreNotEqual(0f, visual.Circle.X, "The visual must be projected, not left at its origin.");
+        Assert.AreNotEqual(0f, visual.Circle.Y, "The visual must be projected, not left at its origin.");
+    }
+
+    [TestMethod]
+    public void DifferentCoordinatesLandOnDifferentPixels()
+    {
+        var newYork = new MarkerVisual();
+        var tokyo = new MarkerVisual();
+
+        var map = BuildMap(
+            new GeoVisualElement(newYork) { Longitude = Longitude, Latitude = Latitude },
+            new GeoVisualElement(tokyo) { Longitude = 139.69, Latitude = 35.69 });
+
+        _ = map.GetImage();
+
+        Assert.AreNotEqual(
+            newYork.Circle.X, tokyo.Circle.X,
+            "Each coordinate must be projected on its own.");
+    }
+}

--- a/tests/CoreTests/OtherTests/GetVisualsAtTests.cs
+++ b/tests/CoreTests/OtherTests/GetVisualsAtTests.cs
@@ -1,0 +1,155 @@
+// The MIT License(MIT)
+//
+// Copyright(c) 2021 Alberto Rodriguez Orozco & LiveCharts Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Linq;
+using LiveChartsCore;
+using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel;
+using LiveChartsCore.Measure;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Drawing.Geometries;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.SKCharts;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using LiveChartsCore.VisualElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SkiaSharp;
+
+namespace CoreTests.OtherTests;
+
+// The library builds custom visuals two ways: the older VisualElement and the newer Visual, and
+// IChartView.VisualElements takes IChartElement, so it holds either. GetVisualsAt cast every
+// element to VisualElement and threw an InvalidCastException on anything built on Visual, which
+// is every visual in the General/VisualElements samples.
+[TestClass]
+public class GetVisualsAtTests
+{
+    private const int X = 100;
+    private const int Y = 100;
+    private const int Size = 40;
+
+    // Sits at (100, 100) and spans 40x40, so (110, 110) hits and (10, 10) misses.
+    private class TestVisual : Visual
+    {
+        private readonly RectangleGeometry _rectangle = new()
+        {
+            X = X,
+            Y = Y,
+            Width = Size,
+            Height = Size,
+            Fill = new SolidColorPaint(SKColors.Red)
+        };
+
+        protected internal override IDrawnElement? DrawnElement => _rectangle;
+
+        protected override void Measure(Chart chart)
+        { }
+    }
+
+    private static SKCartesianChart BuildChart(params IChartElement[] visuals) =>
+        new()
+        {
+            Width = 300,
+            Height = 300,
+            Series = [new LineSeries<double> { Values = [1, 2, 3] }],
+            VisualElements = visuals
+        };
+
+    [TestMethod]
+    public void VisualIsHit()
+    {
+        var visual = new TestVisual();
+        var chart = BuildChart(visual);
+
+        _ = chart.GetImage();
+
+        var hit = chart.GetVisualsAt(new LvcPointD(X + Size * 0.5, Y + Size * 0.5)).ToArray();
+
+        Assert.AreEqual(1, hit.Length, "The visual must be hit inside its bounds.");
+        Assert.AreSame(visual, hit[0]);
+    }
+
+    [TestMethod]
+    public void VisualIsNotHitOutsideItsBounds()
+    {
+        var chart = BuildChart(new TestVisual());
+
+        _ = chart.GetImage();
+
+        var hit = chart.GetVisualsAt(new LvcPointD(X - Size, Y - Size)).ToArray();
+
+        Assert.AreEqual(0, hit.Length, "The visual must not be hit outside its bounds.");
+    }
+
+    [TestMethod]
+    public void VisualElementIsStillHit()
+    {
+        // The older family must keep working, it runs its own IsHitBy.
+        var visualElement = new GeometryVisual<RectangleGeometry>
+        {
+            X = X,
+            Y = Y,
+            Width = Size,
+            Height = Size,
+            Fill = new SolidColorPaint(SKColors.Red),
+            LocationUnit = MeasureUnit.Pixels,
+            SizeUnit = MeasureUnit.Pixels
+        };
+
+        var chart = BuildChart(visualElement);
+
+        _ = chart.GetImage();
+
+        var hit = chart.GetVisualsAt(new LvcPointD(X + Size * 0.5, Y + Size * 0.5)).ToArray();
+
+        Assert.AreEqual(1, hit.Length, "A VisualElement must still be hit.");
+        Assert.AreSame(visualElement, hit[0]);
+    }
+
+    [TestMethod]
+    public void BothFamiliesCoexistInTheSameCollection()
+    {
+        // The real regression: one Visual in the collection threw before any element was tested,
+        // so a chart mixing both families could not be hit tested at all.
+        var visual = new TestVisual();
+        var visualElement = new GeometryVisual<RectangleGeometry>
+        {
+            X = X,
+            Y = Y,
+            Width = Size,
+            Height = Size,
+            Fill = new SolidColorPaint(SKColors.Blue),
+            LocationUnit = MeasureUnit.Pixels,
+            SizeUnit = MeasureUnit.Pixels
+        };
+
+        var chart = BuildChart(visualElement, visual);
+
+        _ = chart.GetImage();
+
+        var hit = chart.GetVisualsAt(new LvcPointD(X + Size * 0.5, Y + Size * 0.5)).ToArray();
+
+        Assert.AreEqual(2, hit.Length, "Both families must be hit when they overlap.");
+        CollectionAssert.Contains(hit, visual);
+        CollectionAssert.Contains(hit, visualElement);
+    }
+}


### PR DESCRIPTION
> _Note: this description was drafted by Claude Code on Beto's behalf._

Two gaps left by the `VisualElement` → `Visual` migration. Independent of #2375.

## 1. `GetVisualsAt` threw on any `Visual`

`IChartView.VisualElements` is an `IEnumerable<IChartElement>`, so it holds either family — but `GetVisualsAt` cast every element to `VisualElement`:

```
System.InvalidCastException: Unable to cast object of type 'RectangleVisual'
to type 'LiveChartsCore.VisualElements.VisualElement'.
```

Every visual in the `General/VisualElements` samples is built on `Visual`, so hit-testing them crashed, and a single `Visual` in the collection took the whole call down with it. There was no test coverage on `GetVisualsAt` at all.

It's an oversight rather than a design problem: `InvokePointerDown` right below it already hit tests through `IInteractable`, the interface both families implement for exactly this reason. Each family is now tested the way it is built — a `VisualElement` runs its own `IsHitBy` (it can host children and report them), a `Visual` reports its hit box. The platform copy now delegates to the core instead of repeating the hit test, which is how it came to still hold the old cast.

## 2. `GeoVisualElement` only took a `VisualElement`

So a map marker had to be built on the older family, and the markers sample duly used `GeometryVisual` — which is `[Obsolete("Replaced by Visual.")]`. The deprecated path was the only supported one, and it was the repo's only forced obsolete usage.

It positions the inner visual by writing its location, and a `Visual` has none of its own — its location lives on the drawn element, which is why the newer family did not fit. It now writes to whichever place the inner visual keeps its location, the same way `Chart.AddTitleToChart` already positions a `Visual` title.

The `Visual` property widens from `VisualElement` to `ChartElement` to hold either family; the constructors still take only the two, so nothing else can get in. **This is safe to change**: `GeoVisualElement` has only ever shipped in `2.1.0-dev-798`, never in stable 2.0.0.

## Worth knowing: `Paint.StrokeThickness` is ignored in the `Visual` model

Rebuilding the marker on `Visual` moved 633 pixels, and the cause is a trap for anyone doing the same migration. `SkiaPaint.cs:238`:

```csharp
paint.StrokeWidth = StrokeThickness;                    // the paint's own (2)
...
if (drawnElement is not null)
    paint.StrokeWidth = drawnElement.StrokeThickness;   // the geometry's wins — default 1
```

A geometry-owned paint is always drawn with the element passed, so the geometry's `StrokeThickness` overrides the paint's unconditionally. `Stroke = new SolidColorPaint(c) { StrokeThickness = 2 }` is correct in the `VisualElement` model, still compiles in the `Visual` model, and silently draws a 1px hairline. Moving it onto the geometry fixed it.

Not addressed here — it may well be deliberate ("the element dictates its stroke width") and changing it could ripple into the render-override paths. Flagging it for a decision: make the override conditional, `[Obsolete]` the paint's `StrokeThickness`, or document it.

## Verification

- Every fix fails its own tests when reverted: the old cast brings back the `InvalidCastException` in 3 of 4, and dropping the `Visual` branch of the geo projection fails all 3 geo tests.
- The geo parity test asserts a `Visual` lands on the same pixel a `VisualElement` lands on for the same coordinate. Confirmed at the pixel level too: `MapsTests.MarkersOnMap` still matched its **unchanged** baseline with the marker rebuilt on `Visual`.
- 835 CoreTests and 170 SnapshotTests pass.
- `MapsTests.MarkersOnMap` deliberately keeps using `GeometryVisual` — it is the only coverage of the `VisualElement` path on a geo map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
