### PR TITLE
docs: the map title is a Visual, not a VisualElement

### DIFF
--- a/docs/geomapchart/overview.md
+++ b/docs/geomapchart/overview.md
@@ -248,7 +248,8 @@ a look at the [Paints article]({{ website_url }}/docs/{{ platform }}/{{ version 
 
 ## Title property
 
-A `Title` is a `VisualElement` rendered above the map. The same
+A `Title` is a `Visual` rendered above the map — the older
+`VisualElement` is still accepted, any other type throws. The same
 `DrawnLabelVisual` used by cartesian and pie charts works here — set
 `Text`, `TextSize` and `Padding`. The map shrinks vertically to make
 room for the title.


### PR DESCRIPTION
Follow-up to #2376, which moved the geomap docs' marker snippets onto `Visual` but left the `Title property` section describing the older type.

### The problem

> A `Title` is a `VisualElement` rendered above the map.

That names a type that is neither the one the next sentence recommends nor the one the property takes:

- `DrawnLabelVisual`, recommended two lines later, is a `Visual`.
- `IChartView.Title` is declared `IChartElement?`.

### The fix

Naming `IChartElement` would have been just as misleading in the other direction, because the runtime contract is narrower than the property type. `Chart.MeasureTitle` / `Chart.AddTitleToChart` take a `Visual`, still accept a `VisualElement` for compatibility, and throw `"The title must be a Visual or a VisualElement."` on anything else — so the article now says exactly that.

This is the only place in `docs/` that describes `Title`; the cartesian, pie and polar articles don't cover it.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)