### PR TITLE
refactor: VisualElement is obsolete, Visual replaces it

### DIFF
--- a/docs/samples/general/visualElements/template.md
+++ b/docs/samples/general/visualElements/template.md
@@ -156,11 +156,11 @@ Uses a grid system to place `IDrawnElement` objects.
 
 ### Z-ordering with series
 
-By default, every series whose `ZIndex` is unset draws its fill at `SeriesId + 0.1`, while a `Visual` (or
-`VisualElement`) draws at `0`. That means decorations land **behind** the data they annotate, which is
+By default, every series whose `ZIndex` is unset draws its fill at `SeriesId + 0.1`, while a `Visual`
+draws at `0`. That means decorations land **behind** the data they annotate, which is
 rarely what you want for glyphs, callouts or markers.
 
-To bring a visual to the front, set `Visual.ZIndex` (or `VisualElement.ZIndex`) to a value above
+To bring a visual to the front, set `Visual.ZIndex` to a value above
 the series stack. A safe ceiling is `1000` (above stacked series and below the crosshair layer):
 
 ```csharp

--- a/src/LiveChartsCore/Chart.cs
+++ b/src/LiveChartsCore/Chart.cs
@@ -335,6 +335,8 @@ public abstract class Chart
         // Casting to VisualElement threw for anything built on Visual, which is every visual in
         // the General/VisualElements samples. InvokePointerDown already hit tests through
         // IInteractable, the interface both families implement for exactly this reason.
+        // CS0618: VisualElement is obsolete and still supported, that is the point of this branch.
+#pragma warning disable CS0618
         return VisualElements.SelectMany<IChartElement, IChartElement>(visual => visual switch
         {
             // A VisualElement can host children, so it runs its own, possibly nested, hit test.
@@ -345,6 +347,7 @@ public abstract class Chart
 
             _ => []
         });
+#pragma warning restore CS0618
     }
 
     /// <summary>
@@ -909,8 +912,11 @@ public abstract class Chart
         }
 
         // VisualElement is an older type for the title, this is kept for compatibility.
+        // CS0618: it is obsolete and still supported, that is what this branch is for.
+#pragma warning disable CS0618
         if (View.Title?.ChartElementSource is VisualElement ve)
             return ve.Measure(this);
+#pragma warning restore CS0618
 
         throw new Exception("The title must be a Visual or a VisualElement.");
     }
@@ -937,6 +943,8 @@ public abstract class Chart
         }
 
         // VisualElement is an older type for the title, this is kept for compatibility.
+        // CS0618: it is obsolete and still supported, that is what this branch is for.
+#pragma warning disable CS0618
         if (View.Title?.ChartElementSource is VisualElement ve)
         {
             var titleSize = ve.Measure(this);
@@ -946,6 +954,7 @@ public abstract class Chart
             AddVisual(((IChartElement)ve).ChartElementSource);
             return;
         }
+#pragma warning restore CS0618
 
         throw new Exception("The title must be a Visual or a VisualElement.");
     }

--- a/src/LiveChartsCore/Geo/GeoVisualElement.cs
+++ b/src/LiveChartsCore/Geo/GeoVisualElement.cs
@@ -58,6 +58,7 @@ public class GeoVisualElement : ChartElement
     /// inner visual element.
     /// </summary>
     /// <param name="visual">The visual element to position at (Longitude, Latitude).</param>
+    [Obsolete($"Replaced by the {nameof(Visual)} overload.")]
     public GeoVisualElement(VisualElement visual)
         : this((ChartElement?)visual)
     { }
@@ -109,6 +110,8 @@ public class GeoVisualElement : ChartElement
 
     private void SetLocation(float x, float y)
     {
+        // CS0618: VisualElement is obsolete and still supported, that is what this branch is for.
+#pragma warning disable CS0618
         switch (Visual)
         {
             case VisualElement visualElement:
@@ -123,6 +126,7 @@ public class GeoVisualElement : ChartElement
                 visual.DrawnElement.Y = y;
                 break;
         }
+#pragma warning restore CS0618
     }
 
     /// <inheritdoc cref="ChartElement.RemoveFromUI(Chart)"/>

--- a/src/LiveChartsCore/Kernel/Extensions.cs
+++ b/src/LiveChartsCore/Kernel/Extensions.cs
@@ -374,6 +374,7 @@ public static class Extensions
     /// <param name="visual">The visual.</param>
     /// <param name="animation">The animation.</param>
     /// <param name="properties">The properties.</param>
+    [Obsolete($"Replaced by {nameof(Visual)}, which animates itself, see its Easing and AnimationSpeed.")]
     public static void Animate(this VisualElement visual, Animation animation, params PropertyDefinition[]? properties)
     {
         foreach (var animatable in visual.GetDrawnGeometries())

--- a/src/LiveChartsCore/VisualElements/BaseGeometryVisual.cs
+++ b/src/LiveChartsCore/VisualElements/BaseGeometryVisual.cs
@@ -30,6 +30,7 @@ namespace LiveChartsCore.VisualElements;
 /// Defines a visual element that has stroke and fill, it can also be scaled in
 /// <see cref="MeasureUnit.Pixels"/> or <see cref="MeasureUnit.ChartValues"/>.
 /// </summary>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public abstract class BaseGeometryVisual : VisualElement
 {
     /// <summary>

--- a/src/LiveChartsCore/VisualElements/BaseLabelVisual.cs
+++ b/src/LiveChartsCore/VisualElements/BaseLabelVisual.cs
@@ -32,6 +32,7 @@ namespace LiveChartsCore.VisualElements;
 /// <summary>
 /// Defines a label visual element.
 /// </summary>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public abstract class BaseLabelVisual : VisualElement
 {
     internal Paint? _paint;
@@ -94,6 +95,7 @@ public abstract class BaseLabelVisual : VisualElement
 /// Defines a label visual element.
 /// </summary>
 /// <typeparam name="TLabelGeometry">The type of the label.</typeparam>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public abstract class BaseLabelVisual<TLabelGeometry> : BaseLabelVisual
     where TLabelGeometry : BaseLabelGeometry, new()
 {

--- a/src/LiveChartsCore/VisualElements/GeometryVisual.cs
+++ b/src/LiveChartsCore/VisualElements/GeometryVisual.cs
@@ -34,6 +34,7 @@ namespace LiveChartsCore.VisualElements;
 /// </summary>
 /// <typeparam name="TGeometry">The type of the geometry.</typeparam>
 /// <typeparam name="TLabelGeometry">The type of the label.</typeparam>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public class GeometryVisual<TGeometry, TLabelGeometry> : BaseGeometryVisual
     where TGeometry : BoundedDrawnGeometry, new()
     where TLabelGeometry : BaseLabelGeometry, new()

--- a/src/LiveChartsCore/VisualElements/LineVisual.cs
+++ b/src/LiveChartsCore/VisualElements/LineVisual.cs
@@ -33,6 +33,7 @@ namespace LiveChartsCore.VisualElements;
 /// Defines a visual element in a chart that draws a sized geometry in the user interface.
 /// </summary>
 /// <typeparam name="TGeometry">The type of the geometry.</typeparam>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public class LineVisual<TGeometry> : BaseGeometryVisual
     where TGeometry : BaseLineGeometry, new()
 {

--- a/src/LiveChartsCore/VisualElements/VisualElement.cs
+++ b/src/LiveChartsCore/VisualElements/VisualElement.cs
@@ -35,6 +35,7 @@ namespace LiveChartsCore.VisualElements;
 /// <summary>
 /// Defines the base visual element class, inheriting from this class makes it easy to implement a visual element.
 /// </summary>
+[Obsolete($"Replaced by {nameof(Visual)}.")]
 public abstract class VisualElement : ChartElement, INotifyPropertyChanged, IInternalInteractable
 {
     internal double _x;

--- a/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharp/ThemesExtensions.cs
@@ -349,11 +349,15 @@ public static class ThemesExtensions
                             sankey.DataLabelsPaint =
                                 new SolidColorPaint(theme.IsDark ? new(245, 245, 245) : new(45, 45, 45));
                     })
+                    // CS0618: BaseLabelVisual is obsolete and still themed, a LabelVisual that is
+                    // already out there has to keep following the theme.
+#pragma warning disable CS0618
                     .HasRuleFor<BaseLabelVisual>(label =>
                     {
                         label.Paint =
                             new SolidColorPaint(theme.IsDark ? new(200, 200, 200) : new(30, 30, 30));
                     })
+#pragma warning restore CS0618
                     .HasRuleFor<DrawnLabelVisual>(label =>
                     {
                         label.Paint =


### PR DESCRIPTION
> _Note: this description was drafted by Claude Code on Beto's behalf._

**Stacked on #2378** — review that one first; this branch targets it, not master.

`1abd04dc2` said it plainly: *"Visual elements will be obsolete, instead they are replaced by the Visual class, both classes implement IInteractable as a temporal solution for the migration."* The attribute never landed. So for a year the library has shipped two ways to build a visual with nothing telling anyone which to reach for — while the samples quietly used the newer one and the docs described the older.

This marks it. `[Obsolete($"Replaced by {nameof(Visual)}.")]`.

It is only possible now because **#2378 moved the gauge visuals off `VisualElement`** — they were the last two the library itself needed. Marked on master, the attribute would have warned about LiveCharts' own code.

## What is marked

Directly:

- `VisualElement`

And everything reachable only through it, which would otherwise just relay the warning:

- `BaseGeometryVisual`, `GeometryVisual<TGeometry, TLabelGeometry>`, `LineVisual`, `BaseLabelVisual`
- `Extensions.Animate(this VisualElement, ...)` — a `Visual` animates itself, see its `Easing` / `AnimationSpeed`
- `GeoVisualElement`'s `VisualElement` overload — the `Visual` overload replaces it

Already obsolete, untouched: `LabelVisual`, `SVGVisual`, `GeometryVisual<TGeometry>`, `VariableGeometryVisual`, `StackPanel`, `RelativePanel`, `TableLayout<T>`.

## What is not marked, and why

The old family **keeps working**. Three places support it deliberately, and they now say so with a scoped `#pragma` and a reason rather than being warned at:

| Where | Why it stays |
|---|---|
| `Chart.GetVisualsAt` | hit tests both families (#2376) |
| `Chart.MeasureTitle` / `AddTitleToChart` | a `VisualElement` title is still accepted |
| `ThemesExtensions` `HasRuleFor<BaseLabelVisual>` | a `LabelVisual` already out there must keep following the theme |

## Verification

- 844 CoreTests, 172 SnapshotTests.
- `net462` builds. Core, SkiaSharpView, WPF, Avalonia, WinForms, `ViewModelsSamples` and `CoreTests` all build with **zero CS0618** — every remaining use of the old family is either obsolete itself or an intentional, annotated exception.

## Worth deciding separately

`VisualElement` is public API in stable 2.0.0, so this is a visible deprecation for anyone with a custom visual element. Their code keeps compiling and working; they get a warning pointing at `Visual`. Given `Visual` has no `X`/`Y`/`ScalesXAt` (you position yourself in `Measure` via `ScaleDataToPixels`), a migration note in the docs would soften the landing — happy to draft one if you want it in this PR rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
